### PR TITLE
Streak SRM: Fix errors where BV was sometimes not correctly adjusted

### DIFF
--- a/sswlib/src/main/java/components/RangedWeapon.java
+++ b/sswlib/src/main/java/components/RangedWeapon.java
@@ -543,7 +543,7 @@ public class RangedWeapon extends abPlaceable implements ifWeapon {
         if( Rotary ) { retval *= 6; }
         if( Ultra ) { retval *= 2; }
         if( OneShot ) { retval *= 0.25; }
-        if( Streak && this.ChatName.contains( "Streak SRM" ) ) { retval *= 0.5; }
+        if( Streak && this.ChatName.contains( "SRM" )) { retval *= 0.5; }
         if( retval < 0 ) { retval = 0; }
         return retval;
     }


### PR DESCRIPTION
Expands upon https://github.com/WEKarnesky/solarisskunkwerks/issues/13

The original patch f3819fe covered some streak SRM's, but others had slightly varied `ChatName`'s and thus were missed. `Streak` is already set to `true` for streak weapons, so `SRM` should be the only substring we need to check the name for.

This PR fixes https://github.com/Solaris-Skunk-Werks/solarisskunkwerks/pull/25#issuecomment-513366052.