### PR TITLE
Add LPS, void-sig, and null-sig to bv breakdown

### DIFF
--- a/sswlib/src/main/java/utilities/CostBVBreakdown.java
+++ b/sswlib/src/main/java/utilities/CostBVBreakdown.java
@@ -195,11 +195,25 @@ public class CostBVBreakdown {
         retval += NL + NL;
         retval += "Offensive BV Calculation Breakdown" + NL;
         retval += "________________________________________________________________________________" + NL;
+        retval += "Heat Efficiency (6 + " + CurMech.GetHeatSinks().TotalDissipation() + " - " + CurMech.GetBVMovementHeat();
+        double heatEfficiency = 6 + CurMech.GetHeatSinks().TotalDissipation() - CurMech.GetBVMovementHeat();
+        if (CurMech.HasChameleon()) {
+            retval += " - 6 (Chameleon LPS)";
+            heatEfficiency -= 6;
+        }
+        if (CurMech.HasNullSig()) {
+            retval += " - 10 (Null-Signature System)";
+            heatEfficiency -= 10;
+        }
+        if (CurMech.HasVoidSig()) {
+            retval += " - 10 (Void-Signature System)";
+            heatEfficiency -= 10;
+        }
         if( HasBonusFromCP() ) {
-            retval += "Heat Efficiency (6 + " + CurMech.GetHeatSinks().TotalDissipation() + " - " + CurMech.GetBVMovementHeat() + " + " + GetBonusFromCP() + ") = " + ( 6 + CurMech.GetHeatSinks().TotalDissipation() - CurMech.GetBVMovementHeat() + GetBonusFromCP() ) + NL;
-            retval += "    (Heat Efficiency calculation includes bonus from Coolant Pods)" + NL;
+            heatEfficiency += GetBonusFromCP();
+            retval +=  " + " + GetBonusFromCP() + " (Coolant Pods)) = " + heatEfficiency + NL;
         } else {
-            retval += "Heat Efficiency (6 + " + CurMech.GetHeatSinks().TotalDissipation() + " - " + CurMech.GetBVMovementHeat() + ") = "+ ( 6 + CurMech.GetHeatSinks().TotalDissipation() - CurMech.GetBVMovementHeat() ) + NL;
+            retval += ") = " + heatEfficiency + NL;
         }
         retval += String.format( "%1$-71s %2$,8.2f", "Adjusted Weapon BV Total WBV", CurMech.GetHeatAdjustedWeaponBV() ) + NL;
         retval += PrintHeatAdjustedWeaponBV();

--- a/sswlib/src/main/java/utilities/CostBVBreakdown.java
+++ b/sswlib/src/main/java/utilities/CostBVBreakdown.java
@@ -195,7 +195,7 @@ public class CostBVBreakdown {
         retval += NL + NL;
         retval += "Offensive BV Calculation Breakdown" + NL;
         retval += "________________________________________________________________________________" + NL;
-        retval += "Heat Efficiency (6 + " + CurMech.GetHeatSinks().TotalDissipation() + " - " + CurMech.GetBVMovementHeat();
+        retval += "Heat Efficiency (6 + " + CurMech.GetHeatSinks().TotalDissipation() + " (Dissipation) - " + CurMech.GetBVMovementHeat() + " (Movement Heat)";
         double heatEfficiency = 6 + CurMech.GetHeatSinks().TotalDissipation() - CurMech.GetBVMovementHeat();
         if (CurMech.HasChameleon()) {
             retval += " - 6 (Chameleon LPS)";


### PR DESCRIPTION
This PR updates the Cost BV Breakdown output to show the modifiers from Null Sigs, Void Sigs, and chameleon LPS, and to label them accordingly. Coolant pod output has also been slightly modified to make it clear exactly how much is being added, instead of a general note saying that the total includes it.

Example:

```
Offensive BV Calculation Breakdown
________________________________________________________________________________
Heat Efficiency (6 + 26 - 3 - 10 (Null-Signature System)) = 19.0
Adjusted Weapon BV Total WBV                                              297.00
    -> Magshot                                                             15.00
    -> Magshot                                                             15.00
    -> Streak SRM-6                                                        89.00
    -> Large X-Pulse Laser                                                178.00
```