### PR TITLE
Fix crash related to super heavy biped internal structure

### DIFF
--- a/ssw/src/main/java/gui/frmMain.java
+++ b/ssw/src/main/java/gui/frmMain.java
@@ -699,7 +699,8 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         // to the selector list
         ifState[] check = CurMech.GetIntStruc().GetStates( CurMech.IsQuad() );
         for( int i = 0; i < check.length; i++ ) {
-            if( CommonTools.IsAllowed( check[i].GetAvailability(), CurMech ) ) {
+            // Need to check for null since GetStates() returns two null values if the mech isn't a super heavy biped
+            if( check[i] != null && CommonTools.IsAllowed( check[i].GetAvailability(), CurMech ) ) {
                 list.add( BuildLookupName( check[i] ) );
             }
         }


### PR DESCRIPTION
This PR should fix #27, which appears to be due to incomplete functionality in our copy of SSWLib that doesn't appear in the last official release. After calling `GetStates()`, we now check the value for null, since the last two elements will be null if the mech isn't a super heavy biped. This fixes the null pointer exception when loading the Snow Fox, although it'd be good to test other mechs as well.