### PR TITLE
Fix SuperHeavy Hover and SuperHeavy Displacement MotiveType Vehicles

### DIFF
--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -6616,7 +6616,6 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         }
 
         CurVee.GetArmor().SetMaxArmor(CurVee.GetArmorableLocationCount());
-        
         // fix the walking and jumping MP spinners
         FixMPSpinner();
         FixJJSpinnerModel();
@@ -8740,6 +8739,10 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         }
 
         FixTonnageSpinner( CurVee.GetMinTonnage(), CurVee.GetMaxTonnage() );
+
+        // Update Tonnage and vehicle class
+        lblVeeLimits.setText(CurVee.GetMaxTonnage() + "t Max");
+
         BuildChassisSelector();
         BuildEngineSelector();
         BuildArmorSelector();

--- a/sswlib/src/main/java/states/stCVDisplacementSH.java
+++ b/sswlib/src/main/java/states/stCVDisplacementSH.java
@@ -59,7 +59,7 @@ public class stCVDisplacementSH implements ifCombatVehicle {
     }
 
     public String GetMotiveLookupName() {
-        return "Naval (Displacement)";
+        return "Displacement (Super Heavy)";
     }
 
     public boolean CanUseJumpMP() {

--- a/sswlib/src/main/java/states/stCVHoverSH.java
+++ b/sswlib/src/main/java/states/stCVHoverSH.java
@@ -59,7 +59,7 @@ public class stCVHoverSH implements ifCombatVehicle {
     }
 
     public String GetMotiveLookupName() {
-        return "Hovercraft";
+        return "Hovercraft (Super Heavy)";
     }
 
     public boolean CanUseJumpMP() {


### PR DESCRIPTION
Closes #26 by correcting the motivetype fields for SH hovercrafts and displacements. Also fixes a bug where the UI did not properly update when loading one of these vehicles.