### PR TITLE
Add DA Availability Code to GUI

### DIFF
--- a/ssw/src/main/java/ssw/gui/dlgPlaceableInfo.form
+++ b/ssw/src/main/java/ssw/gui/dlgPlaceableInfo.form
@@ -360,6 +360,26 @@
             </Constraint>
           </Constraints>
         </Component>
+        <Component class="javax.swing.JLabel" name="jLabel17">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Availability (DA)"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="0" gridY="5" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="2" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JLabel" name="lblClanACDA">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="X"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="1" gridY="5" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="2" insetsBottom="0" insetsRight="6" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
       </SubComponents>
     </Container>
     <Container class="javax.swing.JPanel" name="pnlInnerSphere">
@@ -508,6 +528,26 @@
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
               <GridBagConstraints gridX="0" gridY="0" gridWidth="4" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel15">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Availability (DA)"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="0" gridY="5" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="2" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JLabel" name="lblISACDA">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="X"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="1" gridY="5" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="2" insetsBottom="0" insetsRight="6" anchor="17" weightX="0.0" weightY="0.0"/>
             </Constraint>
           </Constraints>
         </Component>

--- a/ssw/src/main/java/ssw/gui/dlgPlaceableInfo.java
+++ b/ssw/src/main/java/ssw/gui/dlgPlaceableInfo.java
@@ -71,6 +71,7 @@ public class dlgPlaceableInfo extends javax.swing.JDialog {
         lblISACSL.setText( "" + AC.GetISSLCode() );
         lblISACSW.setText( "" + AC.GetISSWCode() );
         lblISACCI.setText( "" + AC.GetISCICode() );
+        lblISACDA.setText( "" + AC.GetISDACode() );
         lblISIntro.setText( AC.GetISIntroDate() + " (" + AC.GetISIntroFaction() + ")" );
         if( AC.WentExtinctIS() ) {
             lblISExtinct.setText( "" + AC.GetISExtinctDate() );
@@ -92,6 +93,7 @@ public class dlgPlaceableInfo extends javax.swing.JDialog {
         lblClanACSL.setText( "" + AC.GetCLSLCode() );
         lblClanACSW.setText( "" + AC.GetCLSWCode() );
         lblClanACCI.setText( "" + AC.GetCLCICode() );
+        lblClanACDA.setText( "" + AC.GetCLDACode() );
         lblClanIntro.setText( AC.GetCLIntroDate() + " (" + AC.GetCLIntroFaction() + ")" );
         if( AC.WentExtinctCL() ) {
             lblClanExtinct.setText( "" + AC.GetCLExtinctDate() );
@@ -157,6 +159,8 @@ public class dlgPlaceableInfo extends javax.swing.JDialog {
         lblClanReIntro = new javax.swing.JLabel();
         lblClanExtinct = new javax.swing.JLabel();
         lblClanIntro = new javax.swing.JLabel();
+        jLabel17 = new javax.swing.JLabel();
+        lblClanACDA = new javax.swing.JLabel();
         pnlInnerSphere = new javax.swing.JPanel();
         jLabel18 = new javax.swing.JLabel();
         lblISACSL = new javax.swing.JLabel();
@@ -172,6 +176,8 @@ public class dlgPlaceableInfo extends javax.swing.JDialog {
         lblISReIntro = new javax.swing.JLabel();
         lblISExtraInfo = new javax.swing.JLabel();
         jLabel16 = new javax.swing.JLabel();
+        jLabel15 = new javax.swing.JLabel();
+        lblISACDA = new javax.swing.JLabel();
         jSeparator4 = new javax.swing.JSeparator();
         jLabel5 = new javax.swing.JLabel();
         lblBookRef = new javax.swing.JLabel();
@@ -439,6 +445,22 @@ public class dlgPlaceableInfo extends javax.swing.JDialog {
         gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 0);
         pnlClan.add(lblClanIntro, gridBagConstraints);
 
+        jLabel17.setText("Availability (DA)");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 5;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 0, 0, 2);
+        pnlClan.add(jLabel17, gridBagConstraints);
+
+        lblClanACDA.setText("X");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 5;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 6);
+        pnlClan.add(lblClanACDA, gridBagConstraints);
+
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 10;
@@ -563,6 +585,22 @@ public class dlgPlaceableInfo extends javax.swing.JDialog {
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         pnlInnerSphere.add(jLabel16, gridBagConstraints);
 
+        jLabel15.setText("Availability (DA)");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 5;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 0, 0, 2);
+        pnlInnerSphere.add(jLabel15, gridBagConstraints);
+
+        lblISACDA.setText("X");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 5;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 6);
+        pnlInnerSphere.add(lblISACDA, gridBagConstraints);
+
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 8;
@@ -611,7 +649,9 @@ private void btnCloseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRS
     private javax.swing.JLabel jLabel12;
     private javax.swing.JLabel jLabel13;
     private javax.swing.JLabel jLabel14;
+    private javax.swing.JLabel jLabel15;
     private javax.swing.JLabel jLabel16;
+    private javax.swing.JLabel jLabel17;
     private javax.swing.JLabel jLabel18;
     private javax.swing.JLabel jLabel19;
     private javax.swing.JLabel jLabel2;
@@ -633,6 +673,7 @@ private void btnCloseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRS
     private javax.swing.JLabel lblBV;
     private javax.swing.JLabel lblBookRef;
     private javax.swing.JLabel lblClanACCI;
+    private javax.swing.JLabel lblClanACDA;
     private javax.swing.JLabel lblClanACSL;
     private javax.swing.JLabel lblClanACSW;
     private javax.swing.JLabel lblClanExtinct;
@@ -641,6 +682,7 @@ private void btnCloseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRS
     private javax.swing.JLabel lblClanReIntro;
     private javax.swing.JLabel lblCost;
     private javax.swing.JLabel lblISACCI;
+    private javax.swing.JLabel lblISACDA;
     private javax.swing.JLabel lblISACSL;
     private javax.swing.JLabel lblISACSW;
     private javax.swing.JLabel lblISExtinct;

--- a/ssw/src/main/java/ssw/gui/dlgWeaponInfo.form
+++ b/ssw/src/main/java/ssw/gui/dlgWeaponInfo.form
@@ -486,6 +486,26 @@
             </Constraint>
           </Constraints>
         </Component>
+        <Component class="javax.swing.JLabel" name="jLabel11">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Availability (DA)"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="0" gridY="6" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="2" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JLabel" name="lblClanAVDA">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="X"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="1" gridY="6" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="2" insetsBottom="0" insetsRight="4" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
       </SubComponents>
     </Container>
     <Component class="javax.swing.JSeparator" name="jSeparator3">
@@ -668,6 +688,26 @@
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
               <GridBagConstraints gridX="1" gridY="2" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="2" insetsBottom="0" insetsRight="4" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel10">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Availability (DA)"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="0" gridY="6" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JLabel" name="lblISAVDA">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="X"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="1" gridY="6" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="2" insetsBottom="0" insetsRight="4" anchor="17" weightX="0.0" weightY="0.0"/>
             </Constraint>
           </Constraints>
         </Component>

--- a/ssw/src/main/java/ssw/gui/dlgWeaponInfo.java
+++ b/ssw/src/main/java/ssw/gui/dlgWeaponInfo.java
@@ -199,6 +199,7 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
         lblISAVSL.setText( "" + AC.GetISSLCode() );
         lblISAVSW.setText( "" + AC.GetISSWCode() );
         lblISAVCI.setText( "" + AC.GetISCICode() );
+        lblISAVDA.setText( "" + AC.GetISDACode() );
         lblISIntro.setText( AC.GetISIntroDate() + " (" + AC.GetISIntroFaction() + ")" );
         if( AC.WentExtinctIS() ) {
             lblISExtinct.setText( "" + AC.GetISExtinctDate() );
@@ -222,6 +223,7 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
         lblClanAVSL.setText( "" + AC.GetCLSLCode() );
         lblClanAVSW.setText( "" + AC.GetCLSWCode() );
         lblClanAVCI.setText( "" + AC.GetCLCICode() );
+        lblClanAVDA.setText( "" + AC.GetCLDACode() );
         lblClanIntro.setText( AC.GetCLIntroDate() + " (" + AC.GetCLIntroFaction() + ")" );
         if( AC.WentExtinctCL() ) {
             lblClanExtinct.setText( "" + AC.GetCLExtinctDate() );
@@ -309,6 +311,8 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
         lblClanExtraInfo = new javax.swing.JLabel();
         jLabel18 = new javax.swing.JLabel();
         lblClanTechRating = new javax.swing.JLabel();
+        jLabel11 = new javax.swing.JLabel();
+        lblClanAVDA = new javax.swing.JLabel();
         jSeparator3 = new javax.swing.JSeparator();
         pnlISAvailability = new javax.swing.JPanel();
         jLabel4 = new javax.swing.JLabel();
@@ -327,6 +331,8 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
         lblISExtinct = new javax.swing.JLabel();
         jLabel20 = new javax.swing.JLabel();
         lblISTechRating = new javax.swing.JLabel();
+        jLabel10 = new javax.swing.JLabel();
+        lblISAVDA = new javax.swing.JLabel();
         jSeparator4 = new javax.swing.JSeparator();
         lblToHit = new javax.swing.JLabel();
         jLabel21 = new javax.swing.JLabel();
@@ -695,6 +701,22 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
         gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 4);
         pnlClanAvailability.add(lblClanTechRating, gridBagConstraints);
 
+        jLabel11.setText("Availability (DA)");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 0, 0, 2);
+        pnlClanAvailability.add(jLabel11, gridBagConstraints);
+
+        lblClanAVDA.setText("X");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 4);
+        pnlClanAvailability.add(lblClanAVDA, gridBagConstraints);
+
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 13;
@@ -841,6 +863,21 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
         gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 4);
         pnlISAvailability.add(lblISTechRating, gridBagConstraints);
 
+        jLabel10.setText("Availability (DA)");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        pnlISAvailability.add(jLabel10, gridBagConstraints);
+
+        lblISAVDA.setText("X");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 4);
+        pnlISAvailability.add(lblISAVDA, gridBagConstraints);
+
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 11;
@@ -942,6 +979,8 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton btnClose;
     private javax.swing.JLabel jLabel1;
+    private javax.swing.JLabel jLabel10;
+    private javax.swing.JLabel jLabel11;
     private javax.swing.JLabel jLabel12;
     private javax.swing.JLabel jLabel14;
     private javax.swing.JLabel jLabel15;
@@ -966,6 +1005,7 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
     private javax.swing.JLabel lblBV;
     private javax.swing.JLabel lblBookRef;
     private javax.swing.JLabel lblClanAVCI;
+    private javax.swing.JLabel lblClanAVDA;
     private javax.swing.JLabel lblClanAVSL;
     private javax.swing.JLabel lblClanAVSW;
     private javax.swing.JLabel lblClanExtinct;
@@ -979,6 +1019,7 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
     private javax.swing.JLabel lblFCSClass;
     private javax.swing.JLabel lblHeat;
     private javax.swing.JLabel lblISAVCI;
+    private javax.swing.JLabel lblISAVDA;
     private javax.swing.JLabel lblISAVSL;
     private javax.swing.JLabel lblISAVSW;
     private javax.swing.JLabel lblISExtinct;

--- a/ssw/src/main/java/ssw/gui/frmMain.form
+++ b/ssw/src/main/java/ssw/gui/frmMain.form
@@ -367,7 +367,7 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
-    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,2,60,0,0,3,67"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,2,75,0,0,3,67"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
@@ -5444,7 +5444,7 @@
                   </Properties>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                      <GridBagConstraints gridX="0" gridY="6" gridWidth="0" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="4" insetsLeft="0" insetsBottom="4" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+                      <GridBagConstraints gridX="0" gridY="7" gridWidth="0" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="4" insetsLeft="0" insetsBottom="4" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -5488,14 +5488,14 @@
                   </Properties>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                      <GridBagConstraints gridX="-1" gridY="-1" gridWidth="2" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="4" insetsRight="3" anchor="17" weightX="0.0" weightY="0.0"/>
+                      <GridBagConstraints gridX="0" gridY="8" gridWidth="2" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="4" insetsRight="3" anchor="17" weightX="0.0" weightY="0.0"/>
                     </Constraint>
                   </Constraints>
                 </Component>
                 <Component class="javax.swing.JLabel" name="lblInfoMountRestrict">
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                      <GridBagConstraints gridX="2" gridY="7" gridWidth="7" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="3" insetsBottom="4" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+                      <GridBagConstraints gridX="2" gridY="8" gridWidth="7" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="3" insetsBottom="4" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -5513,6 +5513,23 @@
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
                       <GridBagConstraints gridX="7" gridY="3" gridWidth="2" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="3" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+                    </Constraint>
+                  </Constraints>
+                </Component>
+                <Component class="javax.swing.JLabel" name="jLabel2">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" value="Availability (DA)"/>
+                  </Properties>
+                  <Constraints>
+                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                      <GridBagConstraints gridX="0" gridY="6" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+                    </Constraint>
+                  </Constraints>
+                </Component>
+                <Component class="javax.swing.JLabel" name="lblInfoAVDA">
+                  <Constraints>
+                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                      <GridBagConstraints gridX="1" gridY="6" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="3" insetsBottom="0" insetsRight="3" anchor="10" weightX="0.0" weightY="0.0"/>
                     </Constraint>
                   </Constraints>
                 </Component>

--- a/ssw/src/main/java/ssw/gui/frmMain.java
+++ b/ssw/src/main/java/ssw/gui/frmMain.java
@@ -2855,6 +2855,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         lblInfoAVSL.setText( AC.GetISSLCode() + " / " + AC.GetCLSLCode() );
         lblInfoAVSW.setText( AC.GetISSWCode() + " / " + AC.GetCLSWCode() );
         lblInfoAVCI.setText( AC.GetISCICode() + " / " + AC.GetCLCICode() );
+        lblInfoAVDA.setText( AC.GetISDACode() + " / " + AC.GetCLDACode() );
         switch( AC.GetTechBase() ) {
             case AvailableCode.TECH_INNER_SPHERE:
                 lblInfoIntro.setText( AC.GetISIntroDate() + " (" + AC.GetISIntroFaction() + ")" );
@@ -4996,6 +4997,8 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         lblInfoMountRestrict = new javax.swing.JLabel();
         jLabel55 = new javax.swing.JLabel();
         lblInfoRulesLevel = new javax.swing.JLabel();
+        jLabel2 = new javax.swing.JLabel();
+        lblInfoAVDA = new javax.swing.JLabel();
         pnlCriticals = new javax.swing.JPanel();
         pnlHDCrits = new javax.swing.JPanel();
         chkHDTurret = new javax.swing.JCheckBox();
@@ -8267,7 +8270,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         jSeparator14.setBorder(javax.swing.BorderFactory.createEtchedBorder());
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 6;
+        gridBagConstraints.gridy = 7;
         gridBagConstraints.gridwidth = java.awt.GridBagConstraints.REMAINDER;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.insets = new java.awt.Insets(4, 0, 4, 0);
@@ -8307,13 +8310,15 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
 
         jLabel33.setText("Mounting Restrictions");
         gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 8;
         gridBagConstraints.gridwidth = 2;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 4, 3);
         pnlEquipInfo.add(jLabel33, gridBagConstraints);
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 2;
-        gridBagConstraints.gridy = 7;
+        gridBagConstraints.gridy = 8;
         gridBagConstraints.gridwidth = 7;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(0, 3, 4, 0);
@@ -8334,6 +8339,18 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(0, 3, 0, 0);
         pnlEquipInfo.add(lblInfoRulesLevel, gridBagConstraints);
+
+        jLabel2.setText("Availability (DA)");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        pnlEquipInfo.add(jLabel2, gridBagConstraints);
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.insets = new java.awt.Insets(0, 3, 0, 3);
+        pnlEquipInfo.add(lblInfoAVDA, gridBagConstraints);
 
         pnlEquipment.add(pnlEquipInfo, new org.netbeans.lib.awtextra.AbsoluteConstraints(17, 325, 710, -1));
 
@@ -15054,6 +15071,7 @@ private void setViewToolbar(boolean Visible)
     private javax.swing.JLabel jLabel17;
     private javax.swing.JLabel jLabel18;
     private javax.swing.JLabel jLabel19;
+    private javax.swing.JLabel jLabel2;
     private javax.swing.JLabel jLabel20;
     private javax.swing.JLabel jLabel21;
     private javax.swing.JLabel jLabel22;
@@ -15188,6 +15206,7 @@ private void setViewToolbar(boolean Visible)
     private javax.swing.JLabel lblHSNumber;
     private javax.swing.JLabel lblHeatSinkType;
     private javax.swing.JLabel lblInfoAVCI;
+    private javax.swing.JLabel lblInfoAVDA;
     private javax.swing.JLabel lblInfoAVSL;
     private javax.swing.JLabel lblInfoAVSW;
     private javax.swing.JLabel lblInfoAmmo;

--- a/sswlib/src/main/java/components/AvailableCode.java
+++ b/sswlib/src/main/java/components/AvailableCode.java
@@ -68,12 +68,12 @@ public class AvailableCode {
     private char IS_SL = 'X',
                  IS_SW = 'X',
                  IS_CI = 'X',
-                 IS_DA = 'A',
+                 IS_DA = 'X',
                  IS_TechRating = 'X',
                  CL_SL = 'X',
                  CL_SW = 'X',
                  CL_CI = 'X',
-                 CL_DA ='A',
+                 CL_DA ='X',
                  CL_TechRating = 'X';
     private int IS_RandDStartDate = 0,
                 IS_PrototypeDate = 0,
@@ -121,17 +121,17 @@ public class AvailableCode {
 /*
  *  Setters
  */
-    public void SetCodes( char istech, char isSL, char isSW, char isCI, char cltech, char clSL, char clSW, char clCI ) {
+    public void SetCodes( char istech, char isSL, char isSW, char isCI, char isDA, char cltech, char clSL, char clSW, char clCI, char clDA ) {
         IS_TechRating = istech;
         IS_SL = isSL;
         IS_SW = isSW;
         IS_CI = isCI;
-        //IS_DA = isDA;
+        IS_DA = isDA;
         CL_TechRating = istech;
         CL_SL = isSL;
         CL_SW = isSW;
         CL_CI = isCI;
-        //CL_DA = clDA;
+        CL_DA = clDA;
     }
 
     /**

--- a/sswlib/src/main/java/components/AvailableCode.java
+++ b/sswlib/src/main/java/components/AvailableCode.java
@@ -644,10 +644,10 @@ public class AvailableCode {
     public AvailableCode Clone() {
         AvailableCode retval = new AvailableCode( TechBase );
         retval.SetRulesLevels( RulesLevelBM, RulesLevelIM, RulesLevelCV, RulesLevelAF, RulesLevelCF );
-        retval.SetISCodes( IS_TechRating, IS_SL, IS_SW, IS_CI );
+        retval.SetISCodes( IS_TechRating, IS_SL, IS_SW, IS_CI, IS_DA );
         retval.SetISDates( IS_RandDStartDate, IS_PrototypeDate, IS_IsPrototype, IS_IntroDate, IS_ExtinctDate, IS_ReIntroDate, IS_WentExtinct, IS_ReIntroduced );
         retval.SetISFactions( IS_RandDFaction, IS_PrototypeFaction, IS_IntroFaction, IS_ReIntroFaction );
-        retval.SetCLCodes( CL_TechRating, CL_SL, CL_SW, CL_CI );
+        retval.SetCLCodes( CL_TechRating, CL_SL, CL_SW, CL_CI, CL_DA );
         retval.SetCLDates( CL_RandDStartDate, CL_PrototypeDate, CL_IsPrototype, CL_IntroDate, CL_ExtinctDate, CL_ReIntroDate, CL_WentExtinct, CL_ReIntroduced );
         retval.SetCLFactions( CL_RandDFaction, CL_PrototypeFaction, CL_IntroFaction, CL_ReIntroFaction );
         retval.SetPBMAllowed( PBMAllowed );

--- a/sswlib/src/main/java/components/CombatVehicle.java
+++ b/sswlib/src/main/java/components/CombatVehicle.java
@@ -34,7 +34,6 @@ import common.Constants;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Hashtable;
-import java.util.List;
 import java.util.prefs.Preferences;
 import states.*;
 import visitors.*;
@@ -117,25 +116,25 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
         1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.6, 1.6, 1.6, 1.6, 1.6, 1.6 };
 
     public CombatVehicle() {
-        OmniAvailable.SetCodes( 'E', 'X', 'E', 'E', 'E', 'X', 'E', 'E' );
+        OmniAvailable.SetCodes( 'E', 'X', 'E', 'E', 'D', 'E', 'X', 'E', 'E', 'D' );
         OmniAvailable.SetFactions( "", "", "", "", "", "", "", "" );
         OmniAvailable.SetISDates( 0, 0, false, 3010, 0, 0, false, false );
         OmniAvailable.SetCLDates( 0, 0, false, 2854, 0, 0, false, false );
         OmniAvailable.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
 
-        DualTurretAC.SetCodes( 'B', 'F', 'X', 'F', 'B', 'X', 'E', 'E' );
+        DualTurretAC.SetCodes( 'B', 'F', 'F', 'F', 'E', 'B', 'F', 'F', 'F', 'E' );
         DualTurretAC.SetFactions( "", "", "PS", "", "", "", "PS", "" );
         DualTurretAC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
         DualTurretAC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
         DualTurretAC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
 
-        ChinTurretAC.SetCodes( 'B', 'F', 'F', 'F', 'B', 'X', 'E', 'E' );
+        ChinTurretAC.SetCodes( 'B', 'F', 'F', 'F', 'E', 'B', 'F', 'F', 'F', 'E' );
         ChinTurretAC.SetFactions( "", "", "PS", "", "", "", "PS", "" );
         ChinTurretAC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
         ChinTurretAC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
         ChinTurretAC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
 
-        SponsoonAC.SetCodes( 'B', 'F', 'X', 'F', 'B', 'X', 'E', 'E' );
+        SponsoonAC.SetCodes( 'B', 'F', 'F', 'F', 'D', 'B', 'F', 'F', 'F', 'D' );
         SponsoonAC.SetFactions( "", "", "PS", "", "", "", "PS", "" );
         SponsoonAC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
         SponsoonAC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
@@ -2353,7 +2352,7 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
     public AvailableCode GetAvailability() {
         // returns the availability code for this mech based on all components
         AvailableCode Base = new AvailableCode( CurLoadout.GetTechBase() );
-        Base.SetCodes( 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A' );
+        Base.SetCodes( 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A' );
         Base.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
         Base.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
         Base.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
@@ -2389,7 +2388,7 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
         if( CurLoadout.GetEra() == AvailableCode.ERA_SUCCESSION ) {
             // cut out the Star League stuff.
             AvailableCode SW = new AvailableCode( Base.GetTechBase() );
-            SW.SetCodes( 'A', 'X', 'A', 'A', 'A', 'X', 'A', 'A' );
+            SW.SetCodes( 'A', 'X', 'A', 'A', 'A', 'A', 'X', 'A', 'A', 'A' );
             SW.SetISDates( 0, 0, false, 2801, 10000, 0, false, false );
             SW.SetCLDates( 0, 0, false, 2801, 10000, 0, false, false );
             SW.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
@@ -2398,7 +2397,7 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
         if( CurLoadout.GetEra() == AvailableCode.ERA_CLAN_INVASION ) {
             // cut out the Star League and Succession Wars stuff.
             AvailableCode CI = new AvailableCode( Base.GetTechBase() );
-            CI.SetCodes( 'A', 'X', 'X', 'A', 'A', 'X', 'X', 'A' );
+            CI.SetCodes( 'A', 'X', 'X', 'A', 'A', 'A', 'X', 'X', 'A', 'A' );
             CI.SetISDates( 0, 0, false, 3051, 10000, 0, false, false );
             CI.SetCLDates( 0, 0, false, 3051, 10000, 0, false, false );
             CI.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/components/Mech.java
+++ b/sswlib/src/main/java/components/Mech.java
@@ -4255,7 +4255,7 @@ public class Mech implements ifUnit, ifBattleforce {
     public AvailableCode GetAvailability() {
         // returns the availability code for this mech based on all components
         AvailableCode Base = new AvailableCode( CurLoadout.GetTechBase() );
-        Base.SetCodes( 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A' );
+        Base.SetCodes( 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A' );
         Base.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
         Base.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
         Base.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
@@ -4323,7 +4323,7 @@ public class Mech implements ifUnit, ifBattleforce {
         if( CurLoadout.GetEra() == AvailableCode.ERA_SUCCESSION ) {
             // cut out the Star League stuff.
             AvailableCode SW = new AvailableCode( Base.GetTechBase() );
-            SW.SetCodes( 'A', 'X', 'A', 'A', 'A', 'X', 'A', 'A' );
+            SW.SetCodes( 'A', 'X', 'A', 'A', 'A', 'A', 'X', 'A', 'A', 'A' );
             SW.SetISDates( 0, 0, false, 2801, 10000, 0, false, false );
             SW.SetCLDates( 0, 0, false, 2801, 10000, 0, false, false );
             SW.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
@@ -4332,7 +4332,7 @@ public class Mech implements ifUnit, ifBattleforce {
         if( CurLoadout.GetEra() == AvailableCode.ERA_CLAN_INVASION ) {
             // cut out the Star League and Succession Wars stuff.
             AvailableCode CI = new AvailableCode( Base.GetTechBase() );
-            CI.SetCodes( 'A', 'X', 'X', 'A', 'A', 'X', 'X', 'A' );
+            CI.SetCodes( 'A', 'X', 'X', 'A', 'A', 'A', 'X', 'X', 'A', 'A' );
             CI.SetISDates( 0, 0, false, 3051, 10000, 0, false, false );
             CI.SetCLDates( 0, 0, false, 3051, 10000, 0, false, false );
             CI.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );


### PR DESCRIPTION
This PR starts the process of implementing Dark Ages availability codes. IS and CL DA availability has been added to various places in the GUI such as equipment info and placeable equipment panes. The SetCodes methods have also been updated to account for both IS and CL availability codes. Currently, X is used if there is no DA data entered for the component.

Next steps are updating the 100 or so hardcoded availability codes in `sswlib/states` (in progress in the Google Docs spreadsheet), and ultimately refactoring that after the 0.7 release to use an external equipment database the way other equipment does.