### PR TITLE
Allow primitive industrialmechs to use all IS armor

### DIFF
--- a/sswlib/src/main/java/states/stArmorCM.java
+++ b/sswlib/src/main/java/states/stArmorCM.java
@@ -47,6 +47,7 @@ public class stArmorCM implements ifArmor, ifState {
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetPIMAllowed( true );
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED );
+        AC.SetPBMAllowed(true);
     }
 
     public String ActualName() {

--- a/sswlib/src/main/java/states/stArmorHA.java
+++ b/sswlib/src/main/java/states/stArmorHA.java
@@ -47,6 +47,7 @@ public class stArmorHA implements ifArmor, ifState {
         AC.SetCLDates( 3057, 3061, true, 3061, 0, 0, false, false );
         AC.SetCLFactions( "CGB", "CGB", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
+        AC.SetPBMAllowed(true);
     }
 
     public String ActualName() {

--- a/sswlib/src/main/java/states/stArmorHD.java
+++ b/sswlib/src/main/java/states/stArmorHD.java
@@ -46,6 +46,7 @@ public class stArmorHD implements ifArmor, ifState {
         AC.SetCLDates( 0, 0, false, 3126, 0, 0, false, false );
         AC.SetCLFactions( "", "", "--", "" );
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
+        AC.SetPBMAllowed(true);
     }
 
     public String ActualName() {

--- a/sswlib/src/main/java/states/stArmorIN.java
+++ b/sswlib/src/main/java/states/stArmorIN.java
@@ -46,6 +46,7 @@ public class stArmorIN implements ifArmor, ifState {
         AC.SetCLDates( 0, 0, false, 2439, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );
+        AC.SetPBMAllowed(true);
     }
 
     public String ActualName() {

--- a/sswlib/src/main/java/states/stArmorISAB.java
+++ b/sswlib/src/main/java/states/stArmorISAB.java
@@ -46,6 +46,7 @@ public class stArmorISAB implements ifArmor, ifState {
         AC.SetCLDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );*/
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED );
+        AC.SetPBMAllowed(true);
     }
 
     public String ActualName() {

--- a/sswlib/src/main/java/states/stArmorISBR.java
+++ b/sswlib/src/main/java/states/stArmorISBR.java
@@ -43,6 +43,7 @@ public class stArmorISBR implements ifArmor, ifState {
         AC.SetISDates( 0, 0, false, 3131, 0, 0, false, false );
         AC.SetISFactions( "", "", "DC", "" );
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED );
+        AC.SetPBMAllowed(true);
     }
 
     public String ActualName() {

--- a/sswlib/src/main/java/states/stArmorISFF.java
+++ b/sswlib/src/main/java/states/stArmorISFF.java
@@ -43,6 +43,7 @@ public class stArmorISFF implements ifArmor, ifState {
         AC.SetISDates( 0, 0, false, 2571, 2810, 3040, true, true );
         AC.SetISFactions( "", "", "TH", "DC" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );
+        AC.SetPBMAllowed(true);
     }
 
     public String ActualName() {

--- a/sswlib/src/main/java/states/stArmorISHF.java
+++ b/sswlib/src/main/java/states/stArmorISHF.java
@@ -39,6 +39,7 @@ public class stArmorISHF implements ifArmor, ifState {
         AC.SetISDates( 0, 0, false, 3069, 0, 0, false, false );
         AC.SetISFactions( "", "", "LA", "" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );
+        AC.SetPBMAllowed(true);
     }
 
     public String ActualName() {

--- a/sswlib/src/main/java/states/stArmorISIR.java
+++ b/sswlib/src/main/java/states/stArmorISIR.java
@@ -46,6 +46,7 @@ public class stArmorISIR implements ifArmor, ifState {
         AC.SetCLDates( 0, 0, false, 3126, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );*/
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
+        AC.SetPBMAllowed(true);
     }
 
     public String ActualName() {

--- a/sswlib/src/main/java/states/stArmorISLF.java
+++ b/sswlib/src/main/java/states/stArmorISLF.java
@@ -43,6 +43,7 @@ public class stArmorISLF implements ifArmor, ifState {
         AC.SetISDates( 0, 0, false, 3067, 0, 0, false, false );
         AC.SetISFactions( "", "", "FW", "" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );
+        AC.SetPBMAllowed(true);
     }
 
     public String ActualName() {

--- a/sswlib/src/main/java/states/stArmorISLR.java
+++ b/sswlib/src/main/java/states/stArmorISLR.java
@@ -43,6 +43,7 @@ public class stArmorISLR implements ifArmor, ifState {
         AC.SetISDates( 3055, 3058, true, 3058, 0, 0, false, false );
         AC.SetISFactions( "FC", "LA", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );
+        AC.SetPBMAllowed(true);
     }
 
     public String ActualName() {

--- a/sswlib/src/main/java/states/stArmorISRE.java
+++ b/sswlib/src/main/java/states/stArmorISRE.java
@@ -43,6 +43,7 @@ public class stArmorISRE implements ifArmor, ifState {
         AC.SetISDates( 3058, 3063, true, 3063, 0, 0, false, false );
         AC.SetISFactions( "DC", "DC", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );
+        AC.SetPBMAllowed(true);
     }
 
     public String ActualName() {

--- a/sswlib/src/main/java/states/stArmorISST.java
+++ b/sswlib/src/main/java/states/stArmorISST.java
@@ -44,6 +44,7 @@ public class stArmorISST implements ifArmor, ifState {
         AC.SetISFactions( "", "", "CC", "" );
         AC.SetSuperHeavyCompatible(false);
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );
+        AC.SetPBMAllowed(true);
     }
 
     public String ActualName() {

--- a/sswlib/src/main/java/states/stArmorISVST.java
+++ b/sswlib/src/main/java/states/stArmorISVST.java
@@ -39,6 +39,7 @@ public class stArmorISVST implements ifArmor, ifState {
         AC.SetISDates( 0, 0, false, 3067, 0, 0, false, false );
         AC.SetISFactions( "", "", "CC", "" );
         AC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );
+        AC.SetPBMAllowed(true);
     }
 
     public String ActualName() {

--- a/sswlib/src/main/java/states/stArmorMS.java
+++ b/sswlib/src/main/java/states/stArmorMS.java
@@ -46,6 +46,7 @@ public class stArmorMS implements ifArmor, ifState {
         AC.SetCLDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );
+        AC.SetPBMAllowed(true);
     }
 
     public String ActualName() {

--- a/sswlib/src/main/java/states/stArmorPatchwork.java
+++ b/sswlib/src/main/java/states/stArmorPatchwork.java
@@ -46,6 +46,7 @@ public class stArmorPatchwork implements ifArmor, ifState {
         AC.SetISDates( 0, 0, false, 2400, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );
+        AC.SetPBMAllowed(true);
     }
 
     public String ActualName() {


### PR DESCRIPTION
SSW erroneously restricted the armor type for primitive mechs to primitive armor only, while they should be able to equip all armor types. This PR adds `SetPBMAllowed(true)` to all armor types to allow primitive mechs to use them.