### PR TITLE
Fix issue with omnimech temporary loadout when loading mechs

### DIFF
--- a/sswlib/src/main/java/filehandlers/MechReader.java
+++ b/sswlib/src/main/java/filehandlers/MechReader.java
@@ -1689,9 +1689,12 @@ public class MechReader {
 
             // Remove the temporary loadout if we created one and set the mech
             // to the first loadout
-            if ( m.GetLoadout().GetName() == "SSW_TEMP_LOADOUT_001" ) {
-                m.RemoveLoadout( "SSW_TEMP_LOADOUT_001" );
-                m.SetCurLoadout( ((ifMechLoadout) m.GetLoadouts().get( 0 )).GetName() );
+            for (Object lo : m.GetLoadouts()) {
+                if (((ifMechLoadout)lo).GetName().equals("SSW_TEMP_LOADOUT_001")) {
+                    m.RemoveLoadout( "SSW_TEMP_LOADOUT_001" );
+                    m.SetCurLoadout( ((ifMechLoadout) m.GetLoadouts().get( 0 )).GetName() );
+                    break;
+                }
             }
         }
 

--- a/sswlib/src/main/java/filehandlers/MechWriter.java
+++ b/sswlib/src/main/java/filehandlers/MechWriter.java
@@ -393,7 +393,12 @@ public class MechWriter {
             String curLoadout = CurMech.GetLoadout().GetName();
             ArrayList v = CurMech.GetLoadouts();
             for( int i = 0; i < v.size(); i++ ) {
-                CurMech.SetCurLoadout( ((ifMechLoadout) v.get( i )).GetName() );
+                String loadoutName = ((ifMechLoadout)v.get( i )).GetName();
+                if (loadoutName.equals("SSW_TEMP_LOADOUT_001")) {
+                    // skip the temporary omnimech placeholder loadout
+                    continue;
+                }
+                CurMech.SetCurLoadout( loadoutName );
                 if( CurMech.GetBaseRulesLevel() != CurMech.GetLoadout().GetRulesLevel() ) {
                     FR.write( tab + "<loadout name=\"" + FileCommon.EncodeFluff( CurMech.GetLoadout().GetName() ) + "\" ruleslevel=\"" + CurMech.GetLoadout().GetRulesLevel() + "\" fcsa4=\"" + FileCommon.GetBoolean( CurMech.UsingArtemisIV() ) + "\" fcsa5=\"" + FileCommon.GetBoolean( CurMech.UsingArtemisV() ) + "\" fcsapollo=\"" + FileCommon.GetBoolean( CurMech.UsingApollo() ) + "\">" );
                 } else {

--- a/sswlib/src/main/java/filehandlers/MechWriter.java
+++ b/sswlib/src/main/java/filehandlers/MechWriter.java
@@ -394,10 +394,6 @@ public class MechWriter {
             ArrayList v = CurMech.GetLoadouts();
             for( int i = 0; i < v.size(); i++ ) {
                 String loadoutName = ((ifMechLoadout)v.get( i )).GetName();
-                if (loadoutName.equals("SSW_TEMP_LOADOUT_001")) {
-                    // skip the temporary omnimech placeholder loadout
-                    continue;
-                }
                 CurMech.SetCurLoadout( loadoutName );
                 if( CurMech.GetBaseRulesLevel() != CurMech.GetLoadout().GetRulesLevel() ) {
                     FR.write( tab + "<loadout name=\"" + FileCommon.EncodeFluff( CurMech.GetLoadout().GetName() ) + "\" ruleslevel=\"" + CurMech.GetLoadout().GetRulesLevel() + "\" fcsa4=\"" + FileCommon.GetBoolean( CurMech.UsingArtemisIV() ) + "\" fcsa5=\"" + FileCommon.GetBoolean( CurMech.UsingArtemisV() ) + "\" fcsapollo=\"" + FileCommon.GetBoolean( CurMech.UsingApollo() ) + "\">" );


### PR DESCRIPTION
This PR fixes a regression that was introduced in SSWLib where the temporary placeholder omnimech loadout was not removed after it was no longer needed. This created an issue where the temporary loadout was saved when exporting a mech, which caused errors when loading it again since the temporary loadouts conflicted each other.