### PR TITLE
Implement DA Availability Codes

### DIFF
--- a/saw/src/main/java/saw/gui/dlgPlaceableInfo.form
+++ b/saw/src/main/java/saw/gui/dlgPlaceableInfo.form
@@ -6,6 +6,7 @@
   </Properties>
   <SyntheticProperties>
     <SyntheticProperty name="formSizePolicy" type="int" value="1"/>
+    <SyntheticProperty name="generateCenter" type="boolean" value="false"/>
   </SyntheticProperties>
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
@@ -359,6 +360,26 @@
             </Constraint>
           </Constraints>
         </Component>
+        <Component class="javax.swing.JLabel" name="jLabel21">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Availability (DA)"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="0" gridY="5" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="2" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel22">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="X"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="1" gridY="5" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="2" insetsBottom="0" insetsRight="6" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
       </SubComponents>
     </Container>
     <Container class="javax.swing.JPanel" name="pnlInnerSphere">
@@ -507,6 +528,26 @@
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
               <GridBagConstraints gridX="0" gridY="0" gridWidth="4" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel15">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Availability (DA)"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="0" gridY="5" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="2" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel17">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="X"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="1" gridY="5" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="2" insetsBottom="0" insetsRight="6" anchor="17" weightX="0.0" weightY="0.0"/>
             </Constraint>
           </Constraints>
         </Component>

--- a/saw/src/main/java/saw/gui/dlgPlaceableInfo.form
+++ b/saw/src/main/java/saw/gui/dlgPlaceableInfo.form
@@ -370,7 +370,7 @@
             </Constraint>
           </Constraints>
         </Component>
-        <Component class="javax.swing.JLabel" name="jLabel22">
+        <Component class="javax.swing.JLabel" name="lblClanACDA">
           <Properties>
             <Property name="text" type="java.lang.String" value="X"/>
           </Properties>
@@ -541,7 +541,7 @@
             </Constraint>
           </Constraints>
         </Component>
-        <Component class="javax.swing.JLabel" name="jLabel17">
+        <Component class="javax.swing.JLabel" name="lblISACDA">
           <Properties>
             <Property name="text" type="java.lang.String" value="X"/>
           </Properties>

--- a/saw/src/main/java/saw/gui/dlgPlaceableInfo.java
+++ b/saw/src/main/java/saw/gui/dlgPlaceableInfo.java
@@ -157,6 +157,8 @@ public class dlgPlaceableInfo extends javax.swing.JDialog {
         lblClanReIntro = new javax.swing.JLabel();
         lblClanExtinct = new javax.swing.JLabel();
         lblClanIntro = new javax.swing.JLabel();
+        jLabel21 = new javax.swing.JLabel();
+        jLabel22 = new javax.swing.JLabel();
         pnlInnerSphere = new javax.swing.JPanel();
         jLabel18 = new javax.swing.JLabel();
         lblISACSL = new javax.swing.JLabel();
@@ -172,6 +174,8 @@ public class dlgPlaceableInfo extends javax.swing.JDialog {
         lblISReIntro = new javax.swing.JLabel();
         lblISExtraInfo = new javax.swing.JLabel();
         jLabel16 = new javax.swing.JLabel();
+        jLabel15 = new javax.swing.JLabel();
+        jLabel17 = new javax.swing.JLabel();
         jSeparator4 = new javax.swing.JSeparator();
         jLabel5 = new javax.swing.JLabel();
         lblBookRef = new javax.swing.JLabel();
@@ -439,6 +443,22 @@ public class dlgPlaceableInfo extends javax.swing.JDialog {
         gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 0);
         pnlClan.add(lblClanIntro, gridBagConstraints);
 
+        jLabel21.setText("Availability (DA)");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 5;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 0, 0, 2);
+        pnlClan.add(jLabel21, gridBagConstraints);
+
+        jLabel22.setText("X");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 5;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 6);
+        pnlClan.add(jLabel22, gridBagConstraints);
+
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 10;
@@ -563,6 +583,22 @@ public class dlgPlaceableInfo extends javax.swing.JDialog {
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         pnlInnerSphere.add(jLabel16, gridBagConstraints);
 
+        jLabel15.setText("Availability (DA)");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 5;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 0, 0, 2);
+        pnlInnerSphere.add(jLabel15, gridBagConstraints);
+
+        jLabel17.setText("X");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 5;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 6);
+        pnlInnerSphere.add(jLabel17, gridBagConstraints);
+
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 8;
@@ -611,11 +647,15 @@ private void btnCloseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRS
     private javax.swing.JLabel jLabel12;
     private javax.swing.JLabel jLabel13;
     private javax.swing.JLabel jLabel14;
+    private javax.swing.JLabel jLabel15;
     private javax.swing.JLabel jLabel16;
+    private javax.swing.JLabel jLabel17;
     private javax.swing.JLabel jLabel18;
     private javax.swing.JLabel jLabel19;
     private javax.swing.JLabel jLabel2;
     private javax.swing.JLabel jLabel20;
+    private javax.swing.JLabel jLabel21;
+    private javax.swing.JLabel jLabel22;
     private javax.swing.JLabel jLabel24;
     private javax.swing.JLabel jLabel25;
     private javax.swing.JLabel jLabel26;

--- a/saw/src/main/java/saw/gui/dlgPlaceableInfo.java
+++ b/saw/src/main/java/saw/gui/dlgPlaceableInfo.java
@@ -158,7 +158,7 @@ public class dlgPlaceableInfo extends javax.swing.JDialog {
         lblClanExtinct = new javax.swing.JLabel();
         lblClanIntro = new javax.swing.JLabel();
         jLabel21 = new javax.swing.JLabel();
-        jLabel22 = new javax.swing.JLabel();
+        lblClanACDA = new javax.swing.JLabel();
         pnlInnerSphere = new javax.swing.JPanel();
         jLabel18 = new javax.swing.JLabel();
         lblISACSL = new javax.swing.JLabel();
@@ -175,7 +175,7 @@ public class dlgPlaceableInfo extends javax.swing.JDialog {
         lblISExtraInfo = new javax.swing.JLabel();
         jLabel16 = new javax.swing.JLabel();
         jLabel15 = new javax.swing.JLabel();
-        jLabel17 = new javax.swing.JLabel();
+        lblISACDA = new javax.swing.JLabel();
         jSeparator4 = new javax.swing.JSeparator();
         jLabel5 = new javax.swing.JLabel();
         lblBookRef = new javax.swing.JLabel();
@@ -451,13 +451,13 @@ public class dlgPlaceableInfo extends javax.swing.JDialog {
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 0, 2);
         pnlClan.add(jLabel21, gridBagConstraints);
 
-        jLabel22.setText("X");
+        lblClanACDA.setText("X");
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 5;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 6);
-        pnlClan.add(jLabel22, gridBagConstraints);
+        pnlClan.add(lblClanACDA, gridBagConstraints);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -591,13 +591,13 @@ public class dlgPlaceableInfo extends javax.swing.JDialog {
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 0, 2);
         pnlInnerSphere.add(jLabel15, gridBagConstraints);
 
-        jLabel17.setText("X");
+        lblISACDA.setText("X");
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 5;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 6);
-        pnlInnerSphere.add(jLabel17, gridBagConstraints);
+        pnlInnerSphere.add(lblISACDA, gridBagConstraints);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -649,13 +649,11 @@ private void btnCloseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRS
     private javax.swing.JLabel jLabel14;
     private javax.swing.JLabel jLabel15;
     private javax.swing.JLabel jLabel16;
-    private javax.swing.JLabel jLabel17;
     private javax.swing.JLabel jLabel18;
     private javax.swing.JLabel jLabel19;
     private javax.swing.JLabel jLabel2;
     private javax.swing.JLabel jLabel20;
     private javax.swing.JLabel jLabel21;
-    private javax.swing.JLabel jLabel22;
     private javax.swing.JLabel jLabel24;
     private javax.swing.JLabel jLabel25;
     private javax.swing.JLabel jLabel26;
@@ -673,6 +671,7 @@ private void btnCloseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRS
     private javax.swing.JLabel lblBV;
     private javax.swing.JLabel lblBookRef;
     private javax.swing.JLabel lblClanACCI;
+    private javax.swing.JLabel lblClanACDA;
     private javax.swing.JLabel lblClanACSL;
     private javax.swing.JLabel lblClanACSW;
     private javax.swing.JLabel lblClanExtinct;
@@ -681,6 +680,7 @@ private void btnCloseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRS
     private javax.swing.JLabel lblClanReIntro;
     private javax.swing.JLabel lblCost;
     private javax.swing.JLabel lblISACCI;
+    private javax.swing.JLabel lblISACDA;
     private javax.swing.JLabel lblISACSL;
     private javax.swing.JLabel lblISACSW;
     private javax.swing.JLabel lblISExtinct;

--- a/saw/src/main/java/saw/gui/dlgWeaponInfo.form
+++ b/saw/src/main/java/saw/gui/dlgWeaponInfo.form
@@ -6,6 +6,7 @@
   </Properties>
   <SyntheticProperties>
     <SyntheticProperty name="formSizePolicy" type="int" value="1"/>
+    <SyntheticProperty name="generateCenter" type="boolean" value="false"/>
   </SyntheticProperties>
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
@@ -485,6 +486,26 @@
             </Constraint>
           </Constraints>
         </Component>
+        <Component class="javax.swing.JLabel" name="lblInfoAVDA">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Availability (DA)"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="0" gridY="6" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="2" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JLabel" name="lblClanAVDA">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="X"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="1" gridY="6" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="2" insetsBottom="0" insetsRight="4" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
       </SubComponents>
     </Container>
     <Component class="javax.swing.JSeparator" name="jSeparator3">
@@ -667,6 +688,26 @@
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
               <GridBagConstraints gridX="1" gridY="2" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="2" insetsBottom="0" insetsRight="4" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel10">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Availability (DA)"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="0" gridY="6" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="2" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JLabel" name="lblISAVDA">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="X"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="1" gridY="6" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="2" insetsBottom="0" insetsRight="4" anchor="17" weightX="0.0" weightY="0.0"/>
             </Constraint>
           </Constraints>
         </Component>

--- a/saw/src/main/java/saw/gui/dlgWeaponInfo.java
+++ b/saw/src/main/java/saw/gui/dlgWeaponInfo.java
@@ -199,6 +199,7 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
         lblISAVSL.setText( "" + AC.GetISSLCode() );
         lblISAVSW.setText( "" + AC.GetISSWCode() );
         lblISAVCI.setText( "" + AC.GetISCICode() );
+        lblISAVDA.setText( "" + AC.GetISDACode() );
         lblISIntro.setText( AC.GetISIntroDate() + " (" + AC.GetISIntroFaction() + ")" );
         if( AC.WentExtinctIS() ) {
             lblISExtinct.setText( "" + AC.GetISExtinctDate() );
@@ -222,6 +223,7 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
         lblClanAVSL.setText( "" + AC.GetCLSLCode() );
         lblClanAVSW.setText( "" + AC.GetCLSWCode() );
         lblClanAVCI.setText( "" + AC.GetCLCICode() );
+        lblClanAVDA.setText( "" + AC.GetCLDACode() );
         lblClanIntro.setText( AC.GetCLIntroDate() + " (" + AC.GetCLIntroFaction() + ")" );
         if( AC.WentExtinctCL() ) {
             lblClanExtinct.setText( "" + AC.GetCLExtinctDate() );

--- a/saw/src/main/java/saw/gui/dlgWeaponInfo.java
+++ b/saw/src/main/java/saw/gui/dlgWeaponInfo.java
@@ -309,6 +309,8 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
         lblClanExtraInfo = new javax.swing.JLabel();
         jLabel18 = new javax.swing.JLabel();
         lblClanTechRating = new javax.swing.JLabel();
+        lblInfoAVDA = new javax.swing.JLabel();
+        lblClanAVDA = new javax.swing.JLabel();
         jSeparator3 = new javax.swing.JSeparator();
         pnlISAvailability = new javax.swing.JPanel();
         jLabel4 = new javax.swing.JLabel();
@@ -327,6 +329,8 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
         lblISExtinct = new javax.swing.JLabel();
         jLabel20 = new javax.swing.JLabel();
         lblISTechRating = new javax.swing.JLabel();
+        jLabel10 = new javax.swing.JLabel();
+        lblISAVDA = new javax.swing.JLabel();
         jSeparator4 = new javax.swing.JSeparator();
         lblToHit = new javax.swing.JLabel();
         jLabel21 = new javax.swing.JLabel();
@@ -695,6 +699,22 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
         gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 4);
         pnlClanAvailability.add(lblClanTechRating, gridBagConstraints);
 
+        lblInfoAVDA.setText("Availability (DA)");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 0, 0, 2);
+        pnlClanAvailability.add(lblInfoAVDA, gridBagConstraints);
+
+        lblClanAVDA.setText("X");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 4);
+        pnlClanAvailability.add(lblClanAVDA, gridBagConstraints);
+
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 13;
@@ -841,6 +861,22 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
         gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 4);
         pnlISAvailability.add(lblISTechRating, gridBagConstraints);
 
+        jLabel10.setText("Availability (DA)");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 0, 0, 2);
+        pnlISAvailability.add(jLabel10, gridBagConstraints);
+
+        lblISAVDA.setText("X");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 2, 0, 4);
+        pnlISAvailability.add(lblISAVDA, gridBagConstraints);
+
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 11;
@@ -942,6 +978,7 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton btnClose;
     private javax.swing.JLabel jLabel1;
+    private javax.swing.JLabel jLabel10;
     private javax.swing.JLabel jLabel12;
     private javax.swing.JLabel jLabel14;
     private javax.swing.JLabel jLabel15;
@@ -966,6 +1003,7 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
     private javax.swing.JLabel lblBV;
     private javax.swing.JLabel lblBookRef;
     private javax.swing.JLabel lblClanAVCI;
+    private javax.swing.JLabel lblClanAVDA;
     private javax.swing.JLabel lblClanAVSL;
     private javax.swing.JLabel lblClanAVSW;
     private javax.swing.JLabel lblClanExtinct;
@@ -979,6 +1017,7 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
     private javax.swing.JLabel lblFCSClass;
     private javax.swing.JLabel lblHeat;
     private javax.swing.JLabel lblISAVCI;
+    private javax.swing.JLabel lblISAVDA;
     private javax.swing.JLabel lblISAVSL;
     private javax.swing.JLabel lblISAVSW;
     private javax.swing.JLabel lblISExtinct;
@@ -987,6 +1026,7 @@ public class dlgWeaponInfo extends javax.swing.JDialog {
     private javax.swing.JLabel lblISReIntro;
     private javax.swing.JLabel lblISTechRating;
     private javax.swing.JLabel lblInfoAVCI;
+    private javax.swing.JLabel lblInfoAVDA;
     private javax.swing.JLabel lblInfoAVSL;
     private javax.swing.JLabel lblInfoAVSW;
     private javax.swing.JLabel lblInfoAmmo;

--- a/saw/src/main/java/saw/gui/frmVee.form
+++ b/saw/src/main/java/saw/gui/frmVee.form
@@ -3644,7 +3644,7 @@
                           </Group>
                           <Group type="102" attributes="0">
                               <EmptySpace min="-2" pref="6" max="-2" attributes="0"/>
-                              <Component id="jScrollPane8" pref="244" max="32767" attributes="0"/>
+                              <Component id="jScrollPane8" max="32767" attributes="0"/>
                               <EmptySpace min="6" pref="6" max="6" attributes="0"/>
                           </Group>
                           <Group type="102" attributes="0">
@@ -4648,7 +4648,7 @@
                   </Properties>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                      <GridBagConstraints gridX="0" gridY="6" gridWidth="0" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="4" insetsLeft="0" insetsBottom="4" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+                      <GridBagConstraints gridX="0" gridY="7" gridWidth="0" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="4" insetsLeft="0" insetsBottom="4" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -4692,14 +4692,14 @@
                   </Properties>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                      <GridBagConstraints gridX="-1" gridY="-1" gridWidth="2" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="4" insetsRight="3" anchor="17" weightX="0.0" weightY="0.0"/>
+                      <GridBagConstraints gridX="0" gridY="8" gridWidth="2" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="4" insetsRight="3" anchor="17" weightX="0.0" weightY="0.0"/>
                     </Constraint>
                   </Constraints>
                 </Component>
                 <Component class="javax.swing.JLabel" name="lblInfoMountRestrict">
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                      <GridBagConstraints gridX="2" gridY="7" gridWidth="7" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="3" insetsBottom="4" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+                      <GridBagConstraints gridX="2" gridY="8" gridWidth="7" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="3" insetsBottom="4" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -4717,6 +4717,23 @@
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
                       <GridBagConstraints gridX="7" gridY="3" gridWidth="2" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="3" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+                    </Constraint>
+                  </Constraints>
+                </Component>
+                <Component class="javax.swing.JLabel" name="jLabel6">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" value="Availability (DA)"/>
+                  </Properties>
+                  <Constraints>
+                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                      <GridBagConstraints gridX="0" gridY="6" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="3" anchor="17" weightX="0.0" weightY="0.0"/>
+                    </Constraint>
+                  </Constraints>
+                </Component>
+                <Component class="javax.swing.JLabel" name="lblInfoAVDA">
+                  <Constraints>
+                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                      <GridBagConstraints gridX="1" gridY="6" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="3" insetsBottom="0" insetsRight="3" anchor="10" weightX="0.0" weightY="0.0"/>
                     </Constraint>
                   </Constraints>
                 </Component>

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -158,24 +158,30 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         setTitle( saw.Constants.AppDescription + " " + saw.Constants.Version );
 
         // added for easy checking
-        PPCCapAC.SetISCodes( 'E', 'X', 'X', 'E' );
-        PPCCapAC.SetISDates( 3057, 3060, true, 3060, 0, 0, false, false );
+        PPCCapAC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
+        PPCCapAC.SetISDates( 3057, 3060, true, 3081, 0, 0, false, false );
         PPCCapAC.SetISFactions( "DC", "DC", "", "" );
+        PPCCapAC.SetCLCodes( 'E', 'X', 'X', 'E', 'D' );
+        PPCCapAC.SetCLDates( 0, 0, false, 3101, 0, 0, false, false );
+        PPCCapAC.SetCLFactions( "", "", "PS", "" );
         PPCCapAC.SetPBMAllowed( true );
         PPCCapAC.SetPIMAllowed( true );
         PPCCapAC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
-        LIAC.SetISCodes( 'E', 'F', 'F', 'X' );
+        LIAC.SetISCodes( 'E', 'X', 'E', 'F', 'F' );
         LIAC.SetISDates( 0, 0, false, 2575, 2820, 0, true, false );
         LIAC.SetISFactions( "TH", "", "", "" );
-        LIAC.SetCLCodes( 'E', 'X', 'E', 'F' );
+        LIAC.SetCLCodes( 'E', 'X', 'E', 'F', 'F' );
         LIAC.SetCLDates( 0, 0, false, 2575, 0, 0, false, false );
         LIAC.SetCLFactions( "TH", "", "", "" );
         LIAC.SetPBMAllowed( true );
         LIAC.SetPIMAllowed( true );
         LIAC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
-        CaselessAmmoAC.SetISCodes( 'D', 'X', 'X', 'E' );
-        CaselessAmmoAC.SetISDates( 3055, 3056, true, 3056, 0, 0, false, false );
+        CaselessAmmoAC.SetISCodes( 'D', 'X', 'X', 'E', 'D' );
+        CaselessAmmoAC.SetISDates( 3055, 3056, true, 3079, 0, 0, false, false );
         CaselessAmmoAC.SetISFactions( "FC", "FC", "", "" );
+        CaselessAmmoAC.SetCLCodes( 'D', 'X', 'X', 'E', 'D' );
+        CaselessAmmoAC.SetCLDates( 3055, 3056, false, 3109, 0, 0, false, false );
+        CaselessAmmoAC.SetCLFactions( "TH", "", "CSR", "" );
         CaselessAmmoAC.SetPBMAllowed( true );
         CaselessAmmoAC.SetPIMAllowed( true );
         CaselessAmmoAC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -5677,6 +5677,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         lblInfoAVSL.setText( AC.GetISSLCode() + " / " + AC.GetCLSLCode() );
         lblInfoAVSW.setText( AC.GetISSWCode() + " / " + AC.GetCLSWCode() );
         lblInfoAVCI.setText( AC.GetISCICode() + " / " + AC.GetCLCICode() );
+        lblInfoAVDA.setText( AC.GetISDACode() + " / " + AC.GetCLDACode() );
         switch( AC.GetTechBase() ) {
             case AvailableCode.TECH_INNER_SPHERE:
                 lblInfoIntro.setText( AC.GetISIntroDate() + " (" + AC.GetISIntroFaction() + ")" );

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -1267,6 +1267,8 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         lblInfoMountRestrict = new javax.swing.JLabel();
         jLabel69 = new javax.swing.JLabel();
         lblInfoRulesLevel = new javax.swing.JLabel();
+        jLabel6 = new javax.swing.JLabel();
+        lblInfoAVDA = new javax.swing.JLabel();
         pnlControls = new javax.swing.JPanel();
         btnRemoveEquip = new javax.swing.JButton();
         btnClearEquip = new javax.swing.JButton();
@@ -1848,7 +1850,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             }
         });
 
-        spnTonnage.setModel(new javax.swing.SpinnerNumberModel(Integer.valueOf(10), Integer.valueOf(1), null, Integer.valueOf(1)));
+        spnTonnage.setModel(new javax.swing.SpinnerNumberModel(10, 1, null, 1));
         spnTonnage.setMinimumSize(new java.awt.Dimension(45, 20));
         spnTonnage.setPreferredSize(new java.awt.Dimension(45, 20));
         spnTonnage.addChangeListener(new javax.swing.event.ChangeListener() {
@@ -1862,10 +1864,10 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             }
         });
         spnTonnage.addInputMethodListener(new java.awt.event.InputMethodListener() {
-            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
-            }
             public void inputMethodTextChanged(java.awt.event.InputMethodEvent evt) {
                 spnTonnageInputMethodTextChanged(evt);
+            }
+            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
             }
         });
 
@@ -1896,7 +1898,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
 
         jLabel91.setText("Heat Sinks:");
 
-        spnHeatSinks.setModel(new javax.swing.SpinnerNumberModel(Integer.valueOf(10), Integer.valueOf(1), null, Integer.valueOf(1)));
+        spnHeatSinks.setModel(new javax.swing.SpinnerNumberModel(10, 1, null, 1));
         spnHeatSinks.setMinimumSize(new java.awt.Dimension(45, 20));
         spnHeatSinks.setNextFocusableComponent(spnCruiseMP);
         spnHeatSinks.setPreferredSize(new java.awt.Dimension(45, 20));
@@ -1911,10 +1913,10 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             }
         });
         spnHeatSinks.addInputMethodListener(new java.awt.event.InputMethodListener() {
-            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
-            }
             public void inputMethodTextChanged(java.awt.event.InputMethodEvent evt) {
                 spnHeatSinksInputMethodTextChanged(evt);
+            }
+            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
             }
         });
 
@@ -2015,7 +2017,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
 
         jLabel10.setText("Cruise MP:");
 
-        spnCruiseMP.setModel(new javax.swing.SpinnerNumberModel(Integer.valueOf(1), Integer.valueOf(0), null, Integer.valueOf(1)));
+        spnCruiseMP.setModel(new javax.swing.SpinnerNumberModel(1, 0, null, 1));
         spnCruiseMP.setMinimumSize(new java.awt.Dimension(45, 20));
         spnCruiseMP.setPreferredSize(new java.awt.Dimension(45, 20));
         spnCruiseMP.addChangeListener(new javax.swing.event.ChangeListener() {
@@ -2024,10 +2026,10 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             }
         });
         spnCruiseMP.addInputMethodListener(new java.awt.event.InputMethodListener() {
-            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
-            }
             public void inputMethodTextChanged(java.awt.event.InputMethodEvent evt) {
                 spnCruiseMPInputMethodTextChanged(evt);
+            }
+            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
             }
         });
 
@@ -3341,7 +3343,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
                 .addComponent(jSeparator5, javax.swing.GroupLayout.PREFERRED_SIZE, 106, javax.swing.GroupLayout.PREFERRED_SIZE))
             .addGroup(pnlBallisticLayout.createSequentialGroup()
                 .addGap(6, 6, 6)
-                .addComponent(jScrollPane8, javax.swing.GroupLayout.DEFAULT_SIZE, 244, Short.MAX_VALUE)
+                .addComponent(jScrollPane8, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addGap(6, 6, 6))
             .addGroup(pnlBallisticLayout.createSequentialGroup()
                 .addGap(106, 106, 106)
@@ -3977,7 +3979,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         jSeparator20.setBorder(javax.swing.BorderFactory.createEtchedBorder());
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 6;
+        gridBagConstraints.gridy = 7;
         gridBagConstraints.gridwidth = java.awt.GridBagConstraints.REMAINDER;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.insets = new java.awt.Insets(4, 0, 4, 0);
@@ -4017,13 +4019,15 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
 
         jLabel68.setText("Mounting Restrictions");
         gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 8;
         gridBagConstraints.gridwidth = 2;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 4, 3);
         pnlEquipInfo.add(jLabel68, gridBagConstraints);
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 2;
-        gridBagConstraints.gridy = 7;
+        gridBagConstraints.gridy = 8;
         gridBagConstraints.gridwidth = 7;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(0, 3, 4, 0);
@@ -4044,6 +4048,19 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(0, 3, 0, 0);
         pnlEquipInfo.add(lblInfoRulesLevel, gridBagConstraints);
+
+        jLabel6.setText("Availability (DA)");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 0, 0, 3);
+        pnlEquipInfo.add(jLabel6, gridBagConstraints);
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.insets = new java.awt.Insets(0, 3, 0, 3);
+        pnlEquipInfo.add(lblInfoAVDA, gridBagConstraints);
 
         pnlControls.setBorder(javax.swing.BorderFactory.createTitledBorder(javax.swing.BorderFactory.createEtchedBorder(), "Controls"));
         pnlControls.setLayout(new java.awt.GridBagLayout());
@@ -9835,6 +9852,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
     private javax.swing.JLabel jLabel57;
     private javax.swing.JLabel jLabel58;
     private javax.swing.JLabel jLabel59;
+    private javax.swing.JLabel jLabel6;
     private javax.swing.JLabel jLabel60;
     private javax.swing.JLabel jLabel61;
     private javax.swing.JLabel jLabel62;
@@ -9948,6 +9966,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
     private javax.swing.JLabel lblFreeHeatSinks;
     private javax.swing.JLabel lblFrontIntPts;
     private javax.swing.JLabel lblInfoAVCI;
+    private javax.swing.JLabel lblInfoAVDA;
     private javax.swing.JLabel lblInfoAVSL;
     private javax.swing.JLabel lblInfoAVSW;
     private javax.swing.JLabel lblInfoAmmo;

--- a/saw/src/main/java/saw/gui/frmVeeWide.form
+++ b/saw/src/main/java/saw/gui/frmVeeWide.form
@@ -730,7 +730,7 @@
                           <Component id="jPanel7" max="32767" attributes="1"/>
                           <Component id="jPanel8" max="32767" attributes="1"/>
                       </Group>
-                      <EmptySpace pref="13" max="32767" attributes="0"/>
+                      <EmptySpace max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -3875,7 +3875,7 @@
                   </Properties>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                      <GridBagConstraints gridX="0" gridY="6" gridWidth="0" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="4" insetsLeft="0" insetsBottom="4" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+                      <GridBagConstraints gridX="0" gridY="7" gridWidth="0" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="4" insetsLeft="0" insetsBottom="4" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -3919,14 +3919,14 @@
                   </Properties>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                      <GridBagConstraints gridX="-1" gridY="-1" gridWidth="2" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="4" insetsRight="3" anchor="17" weightX="0.0" weightY="0.0"/>
+                      <GridBagConstraints gridX="0" gridY="8" gridWidth="2" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="4" insetsRight="3" anchor="17" weightX="0.0" weightY="0.0"/>
                     </Constraint>
                   </Constraints>
                 </Component>
                 <Component class="javax.swing.JLabel" name="lblInfoMountRestrict">
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                      <GridBagConstraints gridX="2" gridY="7" gridWidth="7" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="3" insetsBottom="4" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+                      <GridBagConstraints gridX="2" gridY="8" gridWidth="7" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="3" insetsBottom="4" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -3944,6 +3944,23 @@
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
                       <GridBagConstraints gridX="7" gridY="3" gridWidth="2" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="3" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+                    </Constraint>
+                  </Constraints>
+                </Component>
+                <Component class="javax.swing.JLabel" name="jLabel6">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" value="Availability (DA)"/>
+                  </Properties>
+                  <Constraints>
+                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                      <GridBagConstraints gridX="0" gridY="6" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="3" anchor="17" weightX="0.0" weightY="0.0"/>
+                    </Constraint>
+                  </Constraints>
+                </Component>
+                <Component class="javax.swing.JLabel" name="lblInfoAVDA">
+                  <Constraints>
+                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                      <GridBagConstraints gridX="1" gridY="6" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="3" insetsBottom="0" insetsRight="3" anchor="10" weightX="0.0" weightY="0.0"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -4255,7 +4272,7 @@
                           </Group>
                           <Group type="102" attributes="0">
                               <EmptySpace min="-2" pref="6" max="-2" attributes="0"/>
-                              <Component id="jScrollPane8" pref="206" max="32767" attributes="0"/>
+                              <Component id="jScrollPane8" max="32767" attributes="0"/>
                               <EmptySpace min="6" pref="6" max="6" attributes="0"/>
                           </Group>
                           <Group type="102" attributes="0">

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -1212,6 +1212,8 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         lblInfoMountRestrict = new javax.swing.JLabel();
         jLabel69 = new javax.swing.JLabel();
         lblInfoRulesLevel = new javax.swing.JLabel();
+        jLabel6 = new javax.swing.JLabel();
+        lblInfoAVDA = new javax.swing.JLabel();
         pnlSpecials = new javax.swing.JPanel();
         jLabel37 = new javax.swing.JLabel();
         chkUseTC = new javax.swing.JCheckBox();
@@ -1838,7 +1840,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             }
         });
 
-        spnTonnage.setModel(new javax.swing.SpinnerNumberModel(Integer.valueOf(10), Integer.valueOf(1), null, Integer.valueOf(1)));
+        spnTonnage.setModel(new javax.swing.SpinnerNumberModel(10, 1, null, 1));
         spnTonnage.setMinimumSize(new java.awt.Dimension(45, 20));
         spnTonnage.setPreferredSize(new java.awt.Dimension(45, 20));
         spnTonnage.addChangeListener(new javax.swing.event.ChangeListener() {
@@ -1852,10 +1854,10 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             }
         });
         spnTonnage.addInputMethodListener(new java.awt.event.InputMethodListener() {
-            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
-            }
             public void inputMethodTextChanged(java.awt.event.InputMethodEvent evt) {
                 spnTonnageInputMethodTextChanged(evt);
+            }
+            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
             }
         });
 
@@ -1886,7 +1888,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
 
         jLabel91.setText("Heat Sinks:");
 
-        spnHeatSinks.setModel(new javax.swing.SpinnerNumberModel(Integer.valueOf(10), Integer.valueOf(1), null, Integer.valueOf(1)));
+        spnHeatSinks.setModel(new javax.swing.SpinnerNumberModel(10, 1, null, 1));
         spnHeatSinks.setMinimumSize(new java.awt.Dimension(45, 20));
         spnHeatSinks.setNextFocusableComponent(spnCruiseMP);
         spnHeatSinks.setPreferredSize(new java.awt.Dimension(45, 20));
@@ -1901,10 +1903,10 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             }
         });
         spnHeatSinks.addInputMethodListener(new java.awt.event.InputMethodListener() {
-            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
-            }
             public void inputMethodTextChanged(java.awt.event.InputMethodEvent evt) {
                 spnHeatSinksInputMethodTextChanged(evt);
+            }
+            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
             }
         });
 
@@ -2005,7 +2007,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
 
         jLabel10.setText("Cruise MP:");
 
-        spnCruiseMP.setModel(new javax.swing.SpinnerNumberModel(Integer.valueOf(1), Integer.valueOf(1), null, Integer.valueOf(1)));
+        spnCruiseMP.setModel(new javax.swing.SpinnerNumberModel(1, 1, null, 1));
         spnCruiseMP.setMinimumSize(new java.awt.Dimension(45, 20));
         spnCruiseMP.setPreferredSize(new java.awt.Dimension(45, 20));
         spnCruiseMP.addChangeListener(new javax.swing.event.ChangeListener() {
@@ -2014,10 +2016,10 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             }
         });
         spnCruiseMP.addInputMethodListener(new java.awt.event.InputMethodListener() {
-            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
-            }
             public void inputMethodTextChanged(java.awt.event.InputMethodEvent evt) {
                 spnCruiseMPInputMethodTextChanged(evt);
+            }
+            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
             }
         });
 
@@ -3224,7 +3226,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
                 .addGroup(pnlBasicSetupLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
                     .addComponent(jPanel7, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(jPanel8, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                .addContainerGap(13, Short.MAX_VALUE))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         pnlBasicSetupLayout.setVerticalGroup(
             pnlBasicSetupLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -3460,7 +3462,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         jSeparator20.setBorder(javax.swing.BorderFactory.createEtchedBorder());
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 6;
+        gridBagConstraints.gridy = 7;
         gridBagConstraints.gridwidth = java.awt.GridBagConstraints.REMAINDER;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.insets = new java.awt.Insets(4, 0, 4, 0);
@@ -3500,13 +3502,15 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
 
         jLabel68.setText("Mounting Restrictions");
         gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 8;
         gridBagConstraints.gridwidth = 2;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 4, 3);
         pnlEquipInfo.add(jLabel68, gridBagConstraints);
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 2;
-        gridBagConstraints.gridy = 7;
+        gridBagConstraints.gridy = 8;
         gridBagConstraints.gridwidth = 7;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(0, 3, 4, 0);
@@ -3527,6 +3531,19 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(0, 3, 0, 0);
         pnlEquipInfo.add(lblInfoRulesLevel, gridBagConstraints);
+
+        jLabel6.setText("Availability (DA)");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 0, 0, 3);
+        pnlEquipInfo.add(jLabel6, gridBagConstraints);
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.insets = new java.awt.Insets(0, 3, 0, 3);
+        pnlEquipInfo.add(lblInfoAVDA, gridBagConstraints);
 
         pnlSpecials.setBorder(javax.swing.BorderFactory.createTitledBorder(javax.swing.BorderFactory.createEtchedBorder(), "Specials"));
         pnlSpecials.setLayout(new java.awt.GridBagLayout());
@@ -3776,7 +3793,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
                 .addComponent(jSeparator5, javax.swing.GroupLayout.PREFERRED_SIZE, 106, javax.swing.GroupLayout.PREFERRED_SIZE))
             .addGroup(pnlBallisticLayout.createSequentialGroup()
                 .addGap(6, 6, 6)
-                .addComponent(jScrollPane8, javax.swing.GroupLayout.DEFAULT_SIZE, 206, Short.MAX_VALUE)
+                .addComponent(jScrollPane8, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addGap(6, 6, 6))
             .addGroup(pnlBallisticLayout.createSequentialGroup()
                 .addGap(106, 106, 106)
@@ -4097,7 +4114,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(pnlSelected, javax.swing.GroupLayout.PREFERRED_SIZE, 264, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(pnlEquipInfo, javax.swing.GroupLayout.DEFAULT_SIZE, 544, Short.MAX_VALUE)
+                .addComponent(pnlEquipInfo, javax.swing.GroupLayout.PREFERRED_SIZE, 544, Short.MAX_VALUE)
                 .addContainerGap())
         );
         pnlEquipmentLayout.setVerticalGroup(
@@ -5472,6 +5489,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         lblInfoAVSL.setText( AC.GetISSLCode() + " / " + AC.GetCLSLCode() );
         lblInfoAVSW.setText( AC.GetISSWCode() + " / " + AC.GetCLSWCode() );
         lblInfoAVCI.setText( AC.GetISCICode() + " / " + AC.GetCLCICode() );
+        lblInfoAVDA.setText( AC.GetISDACode() + " / " + AC.GetCLDACode() );
         switch( AC.GetTechBase() ) {
             case AvailableCode.TECH_INNER_SPHERE:
                 lblInfoIntro.setText( AC.GetISIntroDate() + " (" + AC.GetISIntroFaction() + ")" );
@@ -9847,6 +9865,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
     private javax.swing.JLabel jLabel57;
     private javax.swing.JLabel jLabel58;
     private javax.swing.JLabel jLabel59;
+    private javax.swing.JLabel jLabel6;
     private javax.swing.JLabel jLabel60;
     private javax.swing.JLabel jLabel61;
     private javax.swing.JLabel jLabel62;
@@ -9956,6 +9975,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
     private javax.swing.JLabel lblFreeHeatSinks;
     private javax.swing.JLabel lblFrontIntPts;
     private javax.swing.JLabel lblInfoAVCI;
+    private javax.swing.JLabel lblInfoAVDA;
     private javax.swing.JLabel lblInfoAVSL;
     private javax.swing.JLabel lblInfoAVSW;
     private javax.swing.JLabel lblInfoAmmo;

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -156,24 +156,30 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         setTitle( saw.Constants.AppDescription + " " + saw.Constants.Version );
 
         // added for easy checking
-        PPCCapAC.SetISCodes( 'E', 'X', 'X', 'E' );
-        PPCCapAC.SetISDates( 3057, 3060, true, 3060, 0, 0, false, false );
+        PPCCapAC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
+        PPCCapAC.SetISDates( 3057, 3060, true, 3081, 0, 0, false, false );
         PPCCapAC.SetISFactions( "DC", "DC", "", "" );
+        PPCCapAC.SetCLCodes( 'E', 'X', 'X', 'E', 'D' );
+        PPCCapAC.SetCLDates( 0, 0, false, 3101, 0, 0, false, false );
+        PPCCapAC.SetCLFactions( "", "", "PS", "" );
         PPCCapAC.SetPBMAllowed( true );
         PPCCapAC.SetPIMAllowed( true );
         PPCCapAC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
-        LIAC.SetISCodes( 'E', 'F', 'F', 'X' );
+        LIAC.SetISCodes( 'E', 'X', 'E', 'F', 'F' );
         LIAC.SetISDates( 0, 0, false, 2575, 2820, 0, true, false );
         LIAC.SetISFactions( "TH", "", "", "" );
-        LIAC.SetCLCodes( 'E', 'X', 'E', 'F' );
+        LIAC.SetCLCodes( 'E', 'X', 'E', 'F', 'F' );
         LIAC.SetCLDates( 0, 0, false, 2575, 0, 0, false, false );
         LIAC.SetCLFactions( "TH", "", "", "" );
         LIAC.SetPBMAllowed( true );
         LIAC.SetPIMAllowed( true );
         LIAC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
-        CaselessAmmoAC.SetISCodes( 'D', 'X', 'X', 'E' );
-        CaselessAmmoAC.SetISDates( 3055, 3056, true, 3056, 0, 0, false, false );
+        CaselessAmmoAC.SetISCodes( 'D', 'X', 'X', 'E', 'D' );
+        CaselessAmmoAC.SetISDates( 3055, 3056, true, 3079, 0, 0, false, false );
         CaselessAmmoAC.SetISFactions( "FC", "FC", "", "" );
+        CaselessAmmoAC.SetCLCodes( 'D', 'X', 'X', 'E', 'D' );
+        CaselessAmmoAC.SetCLDates( 3055, 3056, false, 3109, 0, 0, false, false );
+        CaselessAmmoAC.SetCLFactions( "TH", "", "CSR", "" );
         CaselessAmmoAC.SetPBMAllowed( true );
         CaselessAmmoAC.SetPIMAllowed( true );
         CaselessAmmoAC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/ssw/src/main/java/ssw/gui/frmMain.java
+++ b/ssw/src/main/java/ssw/gui/frmMain.java
@@ -175,24 +175,30 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         Mechrender = new MechLoadoutRenderer( this );
 
         // added for easy checking
-        PPCCapAC.SetISCodes( 'E', 'X', 'X', 'E' );
-        PPCCapAC.SetISDates( 3057, 3060, true, 3060, 0, 0, false, false );
+        PPCCapAC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
+        PPCCapAC.SetISDates( 3057, 3060, true, 3081, 0, 0, false, false );
         PPCCapAC.SetISFactions( "DC", "DC", "", "" );
+        PPCCapAC.SetCLCodes( 'E', 'X', 'X', 'E', 'D' );
+        PPCCapAC.SetCLDates( 0, 0, false, 3101, 0, 0, false, false );
+        PPCCapAC.SetCLFactions( "", "", "PS", "" );
         PPCCapAC.SetPBMAllowed( true );
         PPCCapAC.SetPIMAllowed( true );
         PPCCapAC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
-        LIAC.SetISCodes( 'E', 'F', 'F', 'X' );
+        LIAC.SetISCodes( 'E', 'X', 'E', 'F', 'F' );
         LIAC.SetISDates( 0, 0, false, 2575, 2820, 0, true, false );
         LIAC.SetISFactions( "TH", "", "", "" );
-        LIAC.SetCLCodes( 'E', 'X', 'E', 'F' );
+        LIAC.SetCLCodes( 'E', 'X', 'E', 'F', 'F' );
         LIAC.SetCLDates( 0, 0, false, 2575, 0, 0, false, false );
         LIAC.SetCLFactions( "TH", "", "", "" );
         LIAC.SetPBMAllowed( true );
         LIAC.SetPIMAllowed( true );
         LIAC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
-        CaselessAmmoAC.SetISCodes( 'D', 'X', 'X', 'E' );
-        CaselessAmmoAC.SetISDates( 3055, 3056, true, 3056, 0, 0, false, false );
+        CaselessAmmoAC.SetISCodes( 'D', 'X', 'X', 'E', 'D' );
+        CaselessAmmoAC.SetISDates( 3055, 3056, true, 3079, 0, 0, false, false );
         CaselessAmmoAC.SetISFactions( "FC", "FC", "", "" );
+        CaselessAmmoAC.SetCLCodes( 'D', 'X', 'X', 'E', 'D' );
+        CaselessAmmoAC.SetCLDates( 3055, 3056, false, 3109, 0, 0, false, false );
+        CaselessAmmoAC.SetCLFactions( "TH", "", "CSR", "" );
         CaselessAmmoAC.SetPBMAllowed( true );
         CaselessAmmoAC.SetPIMAllowed( true );
         CaselessAmmoAC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/ssw/src/main/java/ssw/gui/frmMainWide.java
+++ b/ssw/src/main/java/ssw/gui/frmMainWide.java
@@ -154,24 +154,30 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
         Mechrender = new MechLoadoutRenderer( this );
 
         // added for easy checking
-        PPCCapAC.SetISCodes( 'E', 'X', 'X', 'E' );
-        PPCCapAC.SetISDates( 3057, 3060, true, 3060, 0, 0, false, false );
+        PPCCapAC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
+        PPCCapAC.SetISDates( 3057, 3060, true, 3081, 0, 0, false, false );
         PPCCapAC.SetISFactions( "DC", "DC", "", "" );
+        PPCCapAC.SetCLCodes( 'E', 'X', 'X', 'E', 'D' );
+        PPCCapAC.SetCLDates( 0, 0, false, 3101, 0, 0, false, false );
+        PPCCapAC.SetCLFactions( "", "", "PS", "" );
         PPCCapAC.SetPBMAllowed( true );
         PPCCapAC.SetPIMAllowed( true );
         PPCCapAC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
-        LIAC.SetISCodes( 'E', 'F', 'F', 'X' );
+        LIAC.SetISCodes( 'E', 'X', 'E', 'F', 'F' );
         LIAC.SetISDates( 0, 0, false, 2575, 2820, 0, true, false );
         LIAC.SetISFactions( "TH", "", "", "" );
-        LIAC.SetCLCodes( 'E', 'X', 'E', 'F' );
+        LIAC.SetCLCodes( 'E', 'X', 'E', 'F', 'F' );
         LIAC.SetCLDates( 0, 0, false, 2575, 0, 0, false, false );
         LIAC.SetCLFactions( "TH", "", "", "" );
         LIAC.SetPBMAllowed( true );
         LIAC.SetPIMAllowed( true );
         LIAC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
-        CaselessAmmoAC.SetISCodes( 'D', 'X', 'X', 'E' );
-        CaselessAmmoAC.SetISDates( 3055, 3056, true, 3056, 0, 0, false, false );
+        CaselessAmmoAC.SetISCodes( 'D', 'X', 'X', 'E', 'D' );
+        CaselessAmmoAC.SetISDates( 3055, 3056, true, 3079, 0, 0, false, false );
         CaselessAmmoAC.SetISFactions( "FC", "FC", "", "" );
+        CaselessAmmoAC.SetCLCodes( 'D', 'X', 'X', 'E', 'D' );
+        CaselessAmmoAC.SetCLDates( 3055, 3056, false, 3109, 0, 0, false, false );
+        CaselessAmmoAC.SetCLFactions( "TH", "", "CSR", "" );
         CaselessAmmoAC.SetPBMAllowed( true );
         CaselessAmmoAC.SetPIMAllowed( true );
         CaselessAmmoAC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/common/EquipmentFactory.java
+++ b/sswlib/src/main/java/common/EquipmentFactory.java
@@ -544,9 +544,12 @@ public class EquipmentFactory {
         AvailableCode a;
 
         a = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
-        a.SetISCodes( 'E', 'X', 'X', 'F' );
+        a.SetISCodes( 'E', 'X', 'X', 'F', 'F' );
         a.SetISDates( 0, 0, false, 3068, 0, 0, false, false );
         a.SetISFactions( "--", "--", "FS", "--" );
+        a.SetCLCodes( 'E', 'X', 'X', 'F', 'F' );
+        a.SetCLDates( 0, 0, false, 3069, 0, 0, false, false );
+        a.SetCLFactions( "", "", "CSF", "" );
         a.SetPBMAllowed( true );
         a.SetPIMAllowed( true );
         a.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
@@ -597,7 +600,7 @@ public class EquipmentFactory {
         RangedWeapons.add(addMGA);
 
         a = new AvailableCode( AvailableCode.TECH_CLAN );
-        a.SetCLCodes( 'E', 'X', 'X', 'E' );
+        a.SetCLCodes( 'E', 'X', 'X', 'F', 'F' );
         a.SetCLDates( 0, 0, false, 3069, 0, 0, false, false );
         a.SetCLFactions( "--", "--", "CDS", "--" );
         a.SetPBMAllowed( true );

--- a/sswlib/src/main/java/components/AESSystem.java
+++ b/sswlib/src/main/java/components/AESSystem.java
@@ -35,11 +35,11 @@ public class AESSystem extends abPlaceable {
     private static MechModifier LegMod = new MechModifier( 0, 0, 0, 0, 0, -2, 0, 0.0, 0.0, 0.0, 0.0, false, false );
 
     public AESSystem( Mech m, boolean legs ) {
-        AC.SetISCodes( 'E', 'X', 'X', 'F' );
-        AC.SetISDates( 3067, 3070, true, 3070, 0, 0, false, false );
+        AC.SetISCodes( 'E', 'X', 'X', 'F', 'E' );
+        AC.SetISDates( 3067, 3070, true, 3109, 0, 0, false, false );
         AC.SetISFactions( "KH", "BC", "", "" );
-        AC.SetCLCodes( 'E', 'X', 'X', 'F' );
-        AC.SetCLDates( 3067, 3070, true, 3070, 0, 0, false, false );
+        AC.SetCLCodes( 'E', 'X', 'X', 'F', 'E' );
+        AC.SetCLDates( 3067, 3070, true, 3108, 0, 0, false, false );
         AC.SetCLFactions( "WD", "WD", "", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/components/ActuatorSet.java
+++ b/sswlib/src/main/java/components/ActuatorSet.java
@@ -65,11 +65,11 @@ public class ActuatorSet {
     private ifMechLoadout Owner;
 
     public ActuatorSet( ifMechLoadout l, Mech m ) {
-        AC.SetISCodes( 'C', 'C', 'C', 'C' );
-        AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
+        AC.SetISCodes( 'C', 'C', 'C', 'C', 'C' );
+        AC.SetISDates( 0, 0, false, 2350, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'C', 'X', 'C', 'C' );
-        AC.SetCLDates( 0, 0, false, 2300, 0, 0, false, false );
+        AC.SetCLCodes( 'C', 'X', 'C', 'C', 'C' );
+        AC.SetCLDates( 0, 0, false, 2350, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/components/ApolloFCS.java
+++ b/sswlib/src/main/java/components/ApolloFCS.java
@@ -33,7 +33,7 @@ public class ApolloFCS extends abPlaceable implements ifMissileGuidance {
     private RangedWeapon Owner;
 
     public ApolloFCS( RangedWeapon m ) {
-        AC.SetISCodes( 'D', 'X', 'X', 'E' );
+        AC.SetISCodes( 'D', 'X', 'X', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 3071, 0, 0, false, false );
         AC.SetISFactions( "", "", "DC", "" );
         AC.SetPBMAllowed( true );

--- a/sswlib/src/main/java/components/ArtemisIVFCS.java
+++ b/sswlib/src/main/java/components/ArtemisIVFCS.java
@@ -33,11 +33,11 @@ public class ArtemisIVFCS extends abPlaceable implements ifMissileGuidance {
     private RangedWeapon Owner;
 
     public ArtemisIVFCS( RangedWeapon m ) {
-        AC.SetISCodes( 'E', 'E', 'F', 'D' );
+        AC.SetISCodes( 'E', 'E', 'F', 'D', 'C' );
         AC.SetISDates( 0, 0, false, 2598, 2855, 3035, true, true );
         AC.SetISFactions( "", "", "TH", "FW" );
-        AC.SetCLCodes( 'E', 'X', 'D', 'C' );
-        AC.SetCLDates( 0, 0, false, 2598, 0, 0, false, false );
+        AC.SetCLCodes( 'F', 'X', 'F', 'D', 'C' );
+        AC.SetCLDates( 0, 0, false, 2818, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/components/ArtemisVFCS.java
+++ b/sswlib/src/main/java/components/ArtemisVFCS.java
@@ -33,8 +33,8 @@ public class ArtemisVFCS extends abPlaceable implements ifMissileGuidance {
     private RangedWeapon Owner;
 
     public ArtemisVFCS( RangedWeapon m ) {
-        AC.SetCLCodes( 'F', 'X', 'X', 'F' );
-        AC.SetCLDates( 3058, 3061, true, 3061, 0, 0, false, false );
+        AC.SetCLCodes( 'F', 'X', 'X', 'F', 'E' );
+        AC.SetCLDates( 3058, 3061, true, 3085, 0, 0, false, false );
         AC.SetCLFactions( "CGS", "CGS", "", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/components/BoobyTrap.java
+++ b/sswlib/src/main/java/components/BoobyTrap.java
@@ -38,8 +38,8 @@ public class BoobyTrap extends abPlaceable {
     public BoobyTrap( ifMechLoadout m ) {
         Owner = m;
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
-        AC.SetISCodes( 'B', 'D', 'F', 'D' );
-        AC.SetISDates( 3055, 3060, true, 3060, 0, 0, false, false );
+        AC.SetISCodes( 'B', 'D', 'F', 'D', 'D' );
+        AC.SetISDates( 3055, 3060, true, 3080, 0, 0, false, false );
         AC.SetISFactions( "CC", "TC", "WB", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/components/CASE.java
+++ b/sswlib/src/main/java/components/CASE.java
@@ -34,9 +34,12 @@ public class CASE extends abPlaceable {
     private boolean IsClan = false;
 
     public CASE() {
-        AC.SetISCodes( 'D', 'C', 'F', 'D' );
+        AC.SetISCodes( 'E', 'C', 'F', 'D', 'C' );
         AC.SetISDates( 0, 0, false, 2476, 2840, 3036, true, true );
         AC.SetISFactions( "", "", "TH", "DC" );
+        AC.SetCLCodes( 'F', 'X', 'F', 'D', 'C' );
+        AC.SetCLDates( 0, 0, false, 2825, 0, 0, false, false );
+        AC.SetCLFactions( "", "", "CCY", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/components/CASEII.java
+++ b/sswlib/src/main/java/components/CASEII.java
@@ -34,11 +34,11 @@ public class CASEII extends abPlaceable {
     private boolean Clan;
 
     public CASEII( boolean clan ) {
-        AC.SetISCodes( 'E', 'X', 'X', 'F' );
-        AC.SetISDates( 3057, 3064, true, 3064, 0, 0, false, false );
+        AC.SetISCodes( 'E', 'X', 'X', 'F', 'D' );
+        AC.SetISDates( 3057, 3064, true, 3082, 0, 0, false, false );
         AC.SetISFactions( "FW", "FW", "", "" );
-        AC.SetCLCodes( 'F', 'X', 'X', 'F' );
-        AC.SetCLDates( 3059, 3062, true, 3062, 0, 0, false, false );
+        AC.SetCLCodes( 'E', 'X', 'X', 'F', 'D' );
+        AC.SetCLDates( 3059, 3062, true, 3082, 0, 0, false, false );
         AC.SetCLFactions( "CCY", "CCY", "", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/components/CVPowerAmplifier.java
+++ b/sswlib/src/main/java/components/CVPowerAmplifier.java
@@ -36,12 +36,12 @@ public class CVPowerAmplifier {
     private AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public CVPowerAmplifier( ifLoadout l ) {
-        AC.SetISCodes( 'D', 'B', 'C', 'B' );
+        AC.SetISCodes( 'D', 'B', 'C', 'B', 'B' );
         AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
-        AC.SetISFactions( "", "", "PS", "" );
-        AC.SetCLCodes( 'D', 'X', 'C', 'B' );
+        AC.SetISFactions( "", "", "TA", "" );
+        AC.SetCLCodes( 'D', 'X', 'C', 'B', 'B' );
         AC.SetCLDates( 0, 0, false, 2300, 0, 0, false, false );
-        AC.SetCLFactions( "", "", "PS", "" );
+        AC.SetCLFactions( "", "", "TA", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );
         AC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/components/Cockpit.java
+++ b/sswlib/src/main/java/components/Cockpit.java
@@ -33,7 +33,7 @@ import states.*;
 public class Cockpit extends abPlaceable {
     private final ifCockpit StandardCockpit = new stCockpitStandard(),
                             InterfaceCockpit = new stCockpitInterface(),
-                            SmallCockpit = new stCockpitISSmall(),
+                            SmallCockpit = new stCockpitSmall(),
                             TorsoCockpit = new stCockpitTorsoMount(),
                             Primitive = new stCockpitISPrimitive(),
                             IndustrialCockpit = new stCockpitIndustrial(),

--- a/sswlib/src/main/java/components/CombatVehicle.java
+++ b/sswlib/src/main/java/components/CombatVehicle.java
@@ -141,7 +141,7 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
         SponsoonAC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
 
         AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
-        AC.SetISCodes( 'E', 'X', 'X', 'F' );
+        AC.SetISCodes( 'E', 'X', 'X', 'F', 'F' );
         AC.SetISDates( 3051, 3053, true, 3053, 0, 0, false, false );
         AC.SetISFactions( "FS", "FS", "", "" );
         AC.SetPBMAllowed( true );
@@ -153,12 +153,12 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
         BlueShield.SetChatName( "BluShld" );
 
         AC = new AvailableCode( AvailableCode.TECH_BOTH );
-        AC.SetISCodes( 'C', 'C', 'C', 'C' );
-        AC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
-        AC.SetISFactions( "", "", "PS", "" );
-        AC.SetCLCodes( 'C', 'X', 'C', 'C' );
-        AC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
-        AC.SetCLFactions( "", "", "PS", "" );
+        AC.SetISCodes( 'C', 'C', 'C', 'C', 'C' );
+        AC.SetISDates( 0, 0, false, 2350, 0, 0, false, false );
+        AC.SetISFactions( "", "", "TH", "" );
+        AC.SetCLCodes( 'C', 'X', 'C', 'C', 'C' );
+        AC.SetCLDates( 0, 0, false, 2350, 0, 0, false, false );
+        AC.SetCLFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );
         AC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/components/DroneOperatingSystem.java
+++ b/sswlib/src/main/java/components/DroneOperatingSystem.java
@@ -35,10 +35,10 @@ public class DroneOperatingSystem extends Equipment {
     public DroneOperatingSystem( Mech m ) {
         Owner = m;
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED );
-        AC.SetISCodes( 'C', 'E', 'F', 'F' );
+        AC.SetISCodes( 'C', 'E', 'F', 'F', 'E' );
         AC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetISFactions( "", "", "ES", "" );
-        AC.SetCLCodes( 'C', 'X', 'D', 'E' );
+        AC.SetCLCodes( 'C', 'X', 'F', 'F', 'E' );
         AC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetCLFactions( "", "", "ES", "" );
     }

--- a/sswlib/src/main/java/components/Dumper.java
+++ b/sswlib/src/main/java/components/Dumper.java
@@ -43,10 +43,10 @@ public class Dumper extends abPlaceable {
 
     public Dumper( ifMechLoadout l)
     {
-        AC.SetISCodes( 'A', 'A', 'A', 'A' );
+        AC.SetISCodes( 'A', 'A', 'A', 'A', 'A' );
         AC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetISFactions( "", "", "", "" );
-        AC.SetCLCodes( 'A', 'A', 'A', 'A' );
+        AC.SetCLCodes( 'A', 'X', 'A', 'A', 'A' );
         AC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetCLFactions( "", "", "", "" );
         AC.SetPBMAllowed( false );

--- a/sswlib/src/main/java/components/EmptyItem.java
+++ b/sswlib/src/main/java/components/EmptyItem.java
@@ -33,10 +33,10 @@ public class EmptyItem extends abPlaceable {
     private AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public EmptyItem() {
-        AC.SetISCodes( 'A', 'A', 'A', 'A' );
+        AC.SetISCodes( 'A', 'A', 'A', 'A', 'A' );
         AC.SetISDates( 0, 0, false, 1900, 0, 0, false, false );
         AC.SetISFactions( "", "", "", "" );
-        AC.SetCLCodes( 'A', 'A', 'A', 'A' );
+        AC.SetCLCodes( 'A', 'A', 'A', 'A', 'A' );
         AC.SetCLDates( 0, 0, false, 1900, 0, 0, false, false );
         AC.SetCLFactions( "", "", "", "" );
         AC.SetPBMAllowed( true );

--- a/sswlib/src/main/java/components/ExtendedFuelTank.java
+++ b/sswlib/src/main/java/components/ExtendedFuelTank.java
@@ -35,12 +35,12 @@ public class ExtendedFuelTank extends Equipment {
     public ExtendedFuelTank( ifUnit m ) {
         Owner = m;
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
-        AC.SetISCodes( 'C', 'C', 'D', 'C' );
-        AC.SetISDates( 0, 0, false, 1900, 0, 0, false, false );
-        AC.SetISFactions( "", "", "PS", "" );
-        AC.SetCLCodes( 'C', 'X', 'C', 'C' );
-        AC.SetCLDates( 0, 0, false, 1900, 0, 0, false, false );
-        AC.SetCLFactions( "", "", "PS", "" );
+        AC.SetISCodes( 'C', 'C', 'D', 'D', 'D' );
+        AC.SetISDates( 0, 0, false, 2350, 0, 0, false, false );
+        AC.SetISFactions( "", "", "TH", "" );
+        AC.SetCLCodes( 'C', 'X', 'D', 'D', 'D' );
+        AC.SetCLDates( 0, 0, false, 2350, 0, 0, false, false );
+        AC.SetCLFactions( "", "", "TH", "" );
         AC.SetPIMAllowed( true );
         AC.SetPBMAllowed( true );
     }

--- a/sswlib/src/main/java/components/Hitch.java
+++ b/sswlib/src/main/java/components/Hitch.java
@@ -8,10 +8,10 @@ public class Hitch extends abPlaceable {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public Hitch() {
-        AC.SetISCodes( 'B', 'B', 'B', 'B' );
+        AC.SetISCodes( 'B', 'B', 'B', 'B', 'B' );
         AC.SetISDates( 0, 0, false, 2000, 0, 0, false, false );
         AC.SetISFactions( "", "", "CMN", "" );
-        AC.SetCLCodes( 'B', 'B', 'B', 'B' );
+        AC.SetCLCodes( 'B', 'X', 'B', 'B', 'B' );
         AC.SetCLDates( 0, 0, false, 2000, 0, 0, false, false );
         AC.SetCLFactions( "", "", "CMN", "" );
         AC.SetPBMAllowed( true );

--- a/sswlib/src/main/java/components/LaserInsulator.java
+++ b/sswlib/src/main/java/components/LaserInsulator.java
@@ -33,10 +33,10 @@ public class LaserInsulator extends abPlaceable {
     private RangedWeapon Owner;
 
     public LaserInsulator( RangedWeapon w ) {
-        AC.SetISCodes( 'E', 'F', 'F', 'X' );
+        AC.SetISCodes( 'E', 'X', 'E', 'F', 'F' );
         AC.SetISDates( 0, 0, false, 2575, 2820, 0, true, false );
         AC.SetISFactions( "TH", "", "", "" );
-        AC.SetCLCodes( 'E', 'X', 'E', 'F' );
+        AC.SetCLCodes( 'E', 'X', 'E', 'F', 'F' );
         AC.SetCLDates( 0, 0, false, 2575, 0, 0, false, false );
         AC.SetCLFactions( "TH", "", "", "" );
         AC.SetPBMAllowed( true );

--- a/sswlib/src/main/java/components/Mech.java
+++ b/sswlib/src/main/java/components/Mech.java
@@ -157,18 +157,18 @@ public class Mech implements ifUnit, ifBattleforce {
         CurRAAES = RAAES;
 
         // finish off the OmniMech availability
-        OmniAvailable.SetISCodes( 'E', 'X', 'X', 'E' );
+        OmniAvailable.SetISCodes( 'E', 'X', 'E', 'E', 'D' );
         OmniAvailable.SetISDates( 0, 0, false, 3052, 0, 0, false, false );
         OmniAvailable.SetISFactions( "", "", "", "" );
-        OmniAvailable.SetCLCodes( 'E', 'X', 'E', 'E' );
-        OmniAvailable.SetCLDates( 0, 0, false, 2854, 0, 0, false, false );
+        OmniAvailable.SetCLCodes( 'E', 'X', 'E', 'E', 'D' );
+        OmniAvailable.SetCLDates( 0, 0, false, 2856, 0, 0, false, false );
         OmniAvailable.SetCLFactions( "", "", "", "" );
         OmniAvailable.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
 
         // load up some special equipment
         AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
-        AC.SetISCodes( 'E', 'E', 'X', 'X' );
-        AC.SetISDates( 0, 0, false, 2630, 2790, 0, true, false );
+        AC.SetISCodes( 'E', 'E', 'X', 'X', 'F' );
+        AC.SetISDates( 0, 0, false, 2630, 2790, 3099, true, true );
         AC.SetISFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );
@@ -180,8 +180,8 @@ public class Mech implements ifUnit, ifBattleforce {
         NullSig.SetChatName( "NullSig" );
 
         AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
-        AC.SetISCodes( 'E', 'F', 'X', 'X' );
-        AC.SetISDates( 0, 0, false, 2630, 2790, 0, true, false );
+        AC.SetISCodes( 'E', 'F', 'X', 'X', 'F' );
+        AC.SetISDates( 0, 0, false, 2630, 2790, 3099, true, true );
         AC.SetISFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );
@@ -193,7 +193,7 @@ public class Mech implements ifUnit, ifBattleforce {
         Chameleon.SetChatName( "CLPS" );
 
         AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
-        AC.SetISCodes( 'E', 'X', 'X', 'F' );
+        AC.SetISCodes( 'E', 'X', 'X', 'F', 'F' );
         AC.SetISDates( 3051, 3053, true, 3053, 0, 0, false, false );
         AC.SetISFactions( "FS", "FS", "", "" );
         AC.SetPBMAllowed( true );
@@ -205,8 +205,8 @@ public class Mech implements ifUnit, ifBattleforce {
         BlueShield.SetChatName( "BluShld" );
 
         AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
-        AC.SetISDates( 3060, 3070, true, 3070, 0, 0, false, false );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'F' );
+        AC.SetISDates( 3060, 3070, true, 3085, 0, 0, false, false );
         AC.SetISFactions( "WB", "WB", "", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );
@@ -218,11 +218,11 @@ public class Mech implements ifUnit, ifBattleforce {
         VoidSig.SetChatName( "VoidSig" );
 
         AC = new AvailableCode( AvailableCode.TECH_BOTH );
-        AC.SetISCodes( 'C', 'C', 'C', 'C' );
-        AC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
+        AC.SetISCodes( 'C', 'C', 'C', 'C', 'C' );
+        AC.SetISDates( 0, 0, false, 2350, 0, 0, false, false );
         AC.SetISFactions( "", "", "PS", "" );
-        AC.SetCLCodes( 'C', 'X', 'C', 'C' );
-        AC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
+        AC.SetCLCodes( 'C', 'X', 'C', 'C', 'C' );
+        AC.SetCLDates( 0, 0, false, 2350, 0, 0, false, false );
         AC.SetCLFactions( "", "", "PS", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );
@@ -233,10 +233,10 @@ public class Mech implements ifUnit, ifBattleforce {
         EnviroSealing.SetChatName( "EnvSlng" );
 
         AC = new AvailableCode( AvailableCode.TECH_BOTH );
-        AC.SetISCodes( 'B', 'D', 'E', 'F' );
+        AC.SetISCodes( 'B', 'D', 'E', 'F', 'E' );
         AC.SetISDates( 0, 0, false, 2445, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'B', 'X', 'D', 'F' );
+        AC.SetCLCodes( 'B', 'X', 'E', 'F', 'E' );
         AC.SetCLDates( 0, 0, false, 2445, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );
@@ -247,11 +247,11 @@ public class Mech implements ifUnit, ifBattleforce {
         EjectionSeat.SetCost( 25000.0 );
 
         AC = new AvailableCode( AvailableCode.TECH_BOTH );
-        AC.SetISCodes( 'C', 'D', 'E', 'E' );
-        AC.SetISDates( 0, 0, false, 2400, 0, 0, false, false );
+        AC.SetISCodes( 'C', 'D', 'E', 'E', 'D' );
+        AC.SetISDates( 0, 0, false, 2440, 0, 0, false, false );
         AC.SetISFactions( "", "", "DC", "" );
-        AC.SetCLCodes( 'C', 'X', 'D', 'E' );
-        AC.SetCLDates( 0, 0, false, 2400, 0, 0, false, false );
+        AC.SetCLCodes( 'C', 'X', 'D', 'E', 'D' );
+        AC.SetCLDates( 0, 0, false, 2440, 0, 0, false, false );
         AC.SetCLFactions( "", "", "DC", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );
@@ -259,10 +259,10 @@ public class Mech implements ifUnit, ifBattleforce {
         Tracks = new Tracks( this, AC );
 
         AC = new AvailableCode( AvailableCode.TECH_BOTH );
-        AC.SetISCodes( 'D', 'C', 'F', 'E' );
+        AC.SetISCodes( 'D', 'C', 'F', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 2631, 2850, 3030, true, true );
         AC.SetISFactions( "", "", "TH", "??" );
-        AC.SetCLCodes( 'D', 'X', 'B', 'B' );
+        AC.SetCLCodes( 'D', 'X', 'F', 'E', 'D' );
         AC.SetCLDates( 0, 0, false, 2631, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );
@@ -273,10 +273,10 @@ public class Mech implements ifUnit, ifBattleforce {
         CommandConsole.SetCost( 500000.0 );
         CommandConsole.SetArmoredTonnage(1.0);
 
-        FHESAC.SetISCodes( 'D', 'X', 'F', 'E' );
+        FHESAC.SetISCodes( 'D', 'X', 'X', 'E', 'D' );
         FHESAC.SetISDates( 0, 0, false, 3023, 0, 0, false, false );
         FHESAC.SetISFactions( "", "", "LC", "" );
-        FHESAC.SetCLCodes( 'D', 'X', 'X', 'E' );
+        FHESAC.SetCLCodes( 'D', 'X', 'X', 'E', 'D' );
         FHESAC.SetCLDates( 0, 0, false, 3052, 0, 0, false, false );
         FHESAC.SetCLFactions( "", "", "CWF", "" );
         FHESAC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/components/MechTurret.java
+++ b/sswlib/src/main/java/components/MechTurret.java
@@ -40,11 +40,11 @@ public class MechTurret extends abPlaceable implements ifTurret {
     public MechTurret( ifMechLoadout l ) {
         Owner = l;
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
-        AC.SetISCodes( 'C', 'F', 'X', 'F' );
-        AC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
+        AC.SetISCodes( 'C', 'F', 'X', 'F', 'E' );
+        AC.SetISDates( 0, 0, false, 3082, 0, 0, false, false );
         AC.SetISFactions( "", "", "PS", "" );
-        AC.SetCLCodes( 'C', 'X', 'E', 'E' );
-        AC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
+        AC.SetCLCodes( 'C', 'X', 'X', 'F', 'E' );
+        AC.SetCLDates( 0, 0, false, 3082, 0, 0, false, false );
         AC.SetCLFactions( "", "", "PS", "" );
     }
 

--- a/sswlib/src/main/java/components/MechanicalJumpBooster.java
+++ b/sswlib/src/main/java/components/MechanicalJumpBooster.java
@@ -38,8 +38,8 @@ public class MechanicalJumpBooster extends abPlaceable {
     public MechanicalJumpBooster( Mech m ) {
         Owner = m;
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
-        AC.SetISCodes( 'E', 'X', 'X', 'F' );
-        AC.SetISDates( 3055, 3060, true, 3060, 0, 0, false, false );
+        AC.SetISCodes( 'E', 'X', 'X', 'F', 'E' );
+        AC.SetISDates( 3055, 3060, true, 3083, 0, 0, false, false );
         AC.SetISFactions( "FS", "FS", "", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/components/ModularArmor.java
+++ b/sswlib/src/main/java/components/ModularArmor.java
@@ -35,11 +35,11 @@ public class ModularArmor extends abPlaceable {
     private boolean Rear = false;
 
     public ModularArmor() {
-        AC.SetISCodes( 'D', 'X', 'X', 'F' );
-        AC.SetISDates( 3070, 3072, true, 3072, 0, 0, false, false );
+        AC.SetISCodes( 'D', 'X', 'X', 'F', 'E' );
+        AC.SetISDates( 3070, 3072, true, 3096, 0, 0, false, false );
         AC.SetISFactions( "CS", "CS", "", "" );
-        AC.SetCLCodes( 'D', 'X', 'X', 'F' );
-        AC.SetCLDates( 3073, 3074, true, 3074, 0, 0, false, false );
+        AC.SetCLCodes( 'D', 'X', 'X', 'F', 'E' );
+        AC.SetCLDates( 3073, 3074, true, 3075, 0, 0, false, false );
         AC.SetCLFactions( "CWX", "CWX", "", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/components/PPCCapacitor.java
+++ b/sswlib/src/main/java/components/PPCCapacitor.java
@@ -34,9 +34,12 @@ public class PPCCapacitor extends abPlaceable {
     private double OffBV = 0.0;
 
     public PPCCapacitor( RangedWeapon w ) {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
-        AC.SetISDates( 3057, 3060, true, 3060, 0, 0, false, false );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
+        AC.SetISDates( 3057, 3060, true, 3081, 0, 0, false, false );
         AC.SetISFactions( "DC", "DC", "", "" );
+        AC.SetCLCodes( 'E', 'X', 'X', 'E', 'D' );
+        AC.SetCLDates( 0, 0, false, 3101, 0, 0, false, false );
+        AC.SetCLFactions( "", "", "PS", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/components/PartialWing.java
+++ b/sswlib/src/main/java/components/PartialWing.java
@@ -41,11 +41,11 @@ public class PartialWing extends abPlaceable {
 
     public PartialWing( Mech m, boolean clan ) {
         Owner = m;
-        AC.SetISCodes( 'F', 'X', 'X', 'E' );
-        AC.SetISDates( 3061, 3067, true, 3067, 0, 0, false, false );
+        AC.SetISCodes( 'F', 'X', 'X', 'E', 'D' );
+        AC.SetISDates( 3061, 3067, true, 3074, 0, 0, false, false );
         AC.SetISFactions( "", "", "", "" );
-        AC.SetCLCodes( 'F', 'X', 'X', 'E' );
-        AC.SetCLDates( 3061, 3067, true, 3067, 0, 0, false, false );
+        AC.SetCLCodes( 'F', 'X', 'X', 'E', 'D' );
+        AC.SetCLDates( 3061, 3067, true, 3085, 0, 0, false, false );
         AC.SetCLFactions( "CJF", "CJF", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
         Clan = clan;

--- a/sswlib/src/main/java/components/PowerAmplifier.java
+++ b/sswlib/src/main/java/components/PowerAmplifier.java
@@ -36,10 +36,10 @@ public class PowerAmplifier {
     private AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public PowerAmplifier( ifLoadout l ) {
-        AC.SetISCodes( 'D', 'B', 'C', 'B' );
+        AC.SetISCodes( 'D', 'B', 'C', 'B', 'B' );
         AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
         AC.SetISFactions( "", "", "PS", "" );
-        AC.SetCLCodes( 'D', 'X', 'C', 'B' );
+        AC.SetCLCodes( 'D', 'X', 'C', 'B', 'B' );
         AC.SetCLDates( 0, 0, false, 2300, 0, 0, false, false );
         AC.SetCLFactions( "", "", "PS", "" );
         AC.SetPBMAllowed( true );

--- a/sswlib/src/main/java/components/Supercharger.java
+++ b/sswlib/src/main/java/components/Supercharger.java
@@ -33,11 +33,11 @@ public class Supercharger extends abPlaceable {
     private AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public Supercharger( ifLoadout l ) {
-        AC.SetISCodes( 'C', 'F', 'F', 'F' );
-        AC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
+        AC.SetISCodes( 'C', 'F', 'F', 'F', 'D' );
+        AC.SetISDates( 0, 0, false, 3078, 0, 0, false, false );
         AC.SetISFactions( "", "", "ES", "" );
-        AC.SetCLCodes( 'C', 'X', 'F', 'F' );
-        AC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
+        AC.SetCLCodes( 'C', 'X', 'F', 'F', 'D' );
+        AC.SetCLDates( 0, 0, false, 3078, 0, 0, false, false );
         AC.SetCLFactions( "", "", "ES", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
         Owner = (ifLoadout)l;

--- a/sswlib/src/main/java/components/Talons.java
+++ b/sswlib/src/main/java/components/Talons.java
@@ -35,8 +35,8 @@ public class Talons extends PhysicalWeapon {
     private int Crits = 2;
 
     public Talons ( Mech m ) {
-        AC.SetCLCodes( 'E', 'X', 'X', 'F' );
-        AC.SetCLDates( 0, 0, false, 3072, 0, 0, false, false );
+        AC.SetCLCodes( 'E', 'X', 'X', 'F', 'E' );
+        AC.SetCLDates( 0, 0, false, 3087, 0, 0, false, false );
         AC.SetCLFactions( "", "", "CJF", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/components/TargetingComputer.java
+++ b/sswlib/src/main/java/components/TargetingComputer.java
@@ -36,10 +36,10 @@ public class TargetingComputer extends abPlaceable {
     private boolean Clan;
 
     public TargetingComputer( ifMechLoadout l, boolean clan ) {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 3062, 0, 0, false, false );
         AC.SetISFactions( "", "", "FC", "" );
-        AC.SetCLCodes( 'E', 'X', 'D', 'C' );
+        AC.SetCLCodes( 'F', 'X', 'E', 'D', 'D' );
         AC.SetCLDates( 0, 0, false, 2860, 0, 0, false, false );
         AC.SetCLFactions( "", "", "CMN", "" );
         AC.SetPBMAllowed( true );
@@ -51,10 +51,10 @@ public class TargetingComputer extends abPlaceable {
     }
 
     public TargetingComputer( ifCVLoadout l, boolean clan) {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 3062, 0, 0, false, false );
         AC.SetISFactions( "", "", "FC", "" );
-        AC.SetCLCodes( 'E', 'X', 'D', 'C' );
+        AC.SetCLCodes( 'F', 'X', 'E', 'D', 'D' );
         AC.SetCLDates( 0, 0, false, 2860, 0, 0, false, false );
         AC.SetCLFactions( "", "", "CMN", "" );
         AC.SetPBMAllowed( true );

--- a/sswlib/src/main/java/components/Turret.java
+++ b/sswlib/src/main/java/components/Turret.java
@@ -40,11 +40,11 @@ public class Turret extends abPlaceable {
     private double MaxTonnage = 0;
 
     public Turret( ifCVLoadout l, boolean clan) {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
-        AC.SetISDates( 0, 0, false, 3062, 0, 0, false, false );
+        AC.SetISCodes( 'B', 'A', 'A', 'A', 'A' );
+        AC.SetISDates( 0, 0, false, 1900, 0, 0, false, false );
         AC.SetISFactions( "", "", "FC", "" );
-        AC.SetCLCodes( 'E', 'X', 'D', 'C' );
-        AC.SetCLDates( 0, 0, false, 2860, 0, 0, false, false );
+        AC.SetCLCodes( 'B', 'X', 'A', 'A', 'A' );
+        AC.SetCLDates( 0, 0, false, 1900, 0, 0, false, false );
         AC.SetCLFactions( "", "", "CMN", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/components/VehicularGrenadeLauncher.java
+++ b/sswlib/src/main/java/components/VehicularGrenadeLauncher.java
@@ -48,10 +48,10 @@ public class VehicularGrenadeLauncher extends abPlaceable implements ifWeapon {
     private String Manufacturer = "";
 
     public VehicularGrenadeLauncher() {
-        AC.SetISCodes( 'C', 'D', 'E', 'F' );
+        AC.SetISCodes( 'C', 'D', 'E', 'F', 'E' );
         AC.SetISDates( 0, 0, false, 1900, 0, 0, false, false );
         AC.SetISFactions( "", "", "PS", "" );
-        AC.SetCLCodes( 'C', 'X', 'C', 'E' );
+        AC.SetCLCodes( 'C', 'X', 'E', 'F', 'E' );
         AC.SetCLDates( 0, 0, false, 1900, 0, 0, false, false );
         AC.SetCLFactions( "", "", "PS", "" );
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stArmorCLFF.java
+++ b/sswlib/src/main/java/states/stArmorCLFF.java
@@ -39,8 +39,8 @@ public class stArmorCLFF implements ifArmor, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_CLAN );
 
     public stArmorCLFF() {
-        AC.SetCLCodes( 'E', 'X', 'C', 'C' );
-        AC.SetCLDates( 0, 0, false, 2571, 0, 0, false, false );
+        AC.SetCLCodes( 'F', 'X', 'E', 'D', 'C' );
+        AC.SetCLDates( 0, 0, false, 2825, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );
     }

--- a/sswlib/src/main/java/states/stArmorCLFL.java
+++ b/sswlib/src/main/java/states/stArmorCLFL.java
@@ -39,7 +39,7 @@ public class stArmorCLFL implements ifArmor, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_CLAN );
 
     public stArmorCLFL() {
-        AC.SetCLCodes( 'F', 'X', 'X', 'F' );
+        AC.SetCLCodes( 'F', 'X', 'X', 'F', 'E' );
         AC.SetCLDates( 3066, 3070, true, 3070, 0, 0, false, false );
         AC.SetCLFactions( "CSR", "CSR", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );

--- a/sswlib/src/main/java/states/stArmorCLLR.java
+++ b/sswlib/src/main/java/states/stArmorCLLR.java
@@ -39,7 +39,7 @@ public class stArmorCLLR implements ifArmor, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_CLAN );
 
     public stArmorCLLR() {
-        AC.SetCLCodes( 'F', 'X', 'X', 'F' );
+        AC.SetCLCodes( 'F', 'X', 'X', 'F', 'E' );
         AC.SetCLDates( 3059, 3061, true, 3061, 0, 0, false, false );
         AC.SetCLFactions( "CJF", "CJF", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );

--- a/sswlib/src/main/java/states/stArmorCLRE.java
+++ b/sswlib/src/main/java/states/stArmorCLRE.java
@@ -39,7 +39,7 @@ public class stArmorCLRE implements ifArmor, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_CLAN );
 
     public stArmorCLRE() {
-        AC.SetCLCodes( 'F', 'X', 'X', 'F' );
+        AC.SetCLCodes( 'F', 'X', 'X', 'F', 'E' );
         AC.SetCLDates( 3061, 3065, true, 3065, 0, 0, false, false );
         AC.SetCLFactions( "CGB", "CGB", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );

--- a/sswlib/src/main/java/states/stArmorCM.java
+++ b/sswlib/src/main/java/states/stArmorCM.java
@@ -39,10 +39,10 @@ public class stArmorCM implements ifArmor, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public stArmorCM() {
-        AC.SetISCodes( 'B', 'B', 'B', 'A' );
+        AC.SetISCodes( 'B', 'B', 'B', 'A', 'A' );
         AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'B', 'X', 'B', 'A' );
+        AC.SetCLCodes( 'B', 'X', 'B', 'A', 'A' );
         AC.SetCLDates( 0, 0, false, 2300, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/states/stArmorHA.java
+++ b/sswlib/src/main/java/states/stArmorHA.java
@@ -40,10 +40,10 @@ public class stArmorHA implements ifArmor, ifState {
     private final MechModifier MechMod = new MechModifier( 0, -1, 0, 0.0f, 1, 0, 0, 0.0f, 0.0f, 0.0f, 0.0f, true, false );
 
     public stArmorHA() {
-        AC.SetISCodes( 'D', 'X', 'X', 'F' );
+        AC.SetISCodes( 'D', 'X', 'X', 'F', 'E' );
         AC.SetISDates( 3045, 3047, true, 3047, 0, 0, false, false );
         AC.SetISFactions( "FC", "FC", "", "" );
-        AC.SetCLCodes( 'D', 'X', 'X', 'F' );
+        AC.SetCLCodes( 'D', 'X', 'X', 'F', 'E' );
         AC.SetCLDates( 3057, 3061, true, 3061, 0, 0, false, false );
         AC.SetCLFactions( "CGB", "CGB", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stArmorIN.java
+++ b/sswlib/src/main/java/states/stArmorIN.java
@@ -39,11 +39,11 @@ public class stArmorIN implements ifArmor, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public stArmorIN() {
-        AC.SetISCodes( 'C', 'B', 'C', 'B' );
-        AC.SetISDates( 0, 0, false, 2439, 0, 0, false, false );
+        AC.SetISCodes( 'C', 'B', 'C', 'B', 'B' );
+        AC.SetISDates( 0, 0, false, 2430, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'C', 'X', 'B', 'B' );
-        AC.SetCLDates( 0, 0, false, 2439, 0, 0, false, false );
+        AC.SetCLCodes( 'C', 'X', 'C', 'B', 'B' );
+        AC.SetCLDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );
         AC.SetPBMAllowed(true);

--- a/sswlib/src/main/java/states/stArmorISAB.java
+++ b/sswlib/src/main/java/states/stArmorISAB.java
@@ -42,9 +42,6 @@ public class stArmorISAB implements ifArmor, ifState {
         AC.SetISCodes( 'E', 'X', 'X', 'X', 'E' );
         AC.SetISDates( 0, 0, false, 3114, 0, 0, false, false );
         AC.SetISFactions( "", "", "DC", "" );
-        /*AC.SetCLCodes( 'D', 'X', 'B', 'B' );
-        AC.SetCLDates( 0, 0, false, 2470, 0, 0, false, false );
-        AC.SetCLFactions( "", "", "TH", "" );*/
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED );
         AC.SetPBMAllowed(true);
     }

--- a/sswlib/src/main/java/states/stArmorISFF.java
+++ b/sswlib/src/main/java/states/stArmorISFF.java
@@ -39,7 +39,7 @@ public class stArmorISFF implements ifArmor, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stArmorISFF() {
-        AC.SetISCodes( 'E', 'D', 'F', 'D' );
+        AC.SetISCodes( 'E', 'D', 'F', 'D', 'C' );
         AC.SetISDates( 0, 0, false, 2571, 2810, 3040, true, true );
         AC.SetISFactions( "", "", "TH", "DC" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );

--- a/sswlib/src/main/java/states/stArmorISHF.java
+++ b/sswlib/src/main/java/states/stArmorISHF.java
@@ -35,8 +35,8 @@ public class stArmorISHF implements ifArmor, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stArmorISHF() {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
-        AC.SetISDates( 0, 0, false, 3069, 0, 0, false, false );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
+        AC.SetISDates( 0, 0, false, 3056, 0, 0, false, false );
         AC.SetISFactions( "", "", "LA", "" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );
         AC.SetPBMAllowed(true);

--- a/sswlib/src/main/java/states/stArmorISLF.java
+++ b/sswlib/src/main/java/states/stArmorISLF.java
@@ -39,8 +39,8 @@ public class stArmorISLF implements ifArmor, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stArmorISLF() {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
-        AC.SetISDates( 0, 0, false, 3067, 0, 0, false, false );
+        AC.SetISCodes( 'F', 'X', 'X', 'E', 'D' );
+        AC.SetISDates( 0, 0, false, 3055, 0, 0, false, false );
         AC.SetISFactions( "", "", "FW", "" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );
         AC.SetPBMAllowed(true);

--- a/sswlib/src/main/java/states/stArmorISLR.java
+++ b/sswlib/src/main/java/states/stArmorISLR.java
@@ -39,7 +39,7 @@ public class stArmorISLR implements ifArmor, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stArmorISLR() {
-        AC.SetISCodes( 'E', 'X', 'X', 'F' );
+        AC.SetISCodes( 'E', 'X', 'X', 'F', 'E' );
         AC.SetISDates( 3055, 3058, true, 3058, 0, 0, false, false );
         AC.SetISFactions( "FC", "LA", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );

--- a/sswlib/src/main/java/states/stArmorISRE.java
+++ b/sswlib/src/main/java/states/stArmorISRE.java
@@ -39,7 +39,7 @@ public class stArmorISRE implements ifArmor, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stArmorISRE() {
-        AC.SetISCodes( 'E', 'X', 'X', 'F' );
+        AC.SetISCodes( 'E', 'X', 'X', 'F', 'E' );
         AC.SetISDates( 3058, 3063, true, 3063, 0, 0, false, false );
         AC.SetISFactions( "DC", "DC", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );

--- a/sswlib/src/main/java/states/stArmorISST.java
+++ b/sswlib/src/main/java/states/stArmorISST.java
@@ -39,7 +39,7 @@ public class stArmorISST implements ifArmor, ifState {
     private final static MechModifier MechMod = new MechModifier( 0, 0, 0, 0.0f, 0, 0, 10, 0.2f, 0.0f, 0.0f, 0.0f, true, false );
 
     public stArmorISST() {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 3063, 0, 0, false, false );
         AC.SetISFactions( "", "", "CC", "" );
         AC.SetSuperHeavyCompatible(false);

--- a/sswlib/src/main/java/states/stArmorISVST.java
+++ b/sswlib/src/main/java/states/stArmorISVST.java
@@ -35,7 +35,7 @@ public class stArmorISVST implements ifArmor, ifState {
     private final static MechModifier MechMod = new MechModifier( 0, 0, 0, 0.0f, 0, 0, 10, 0.2f, 0.0f, 0.0f, 0.0f, true, false );
 
     public stArmorISVST() {
-        AC.SetISCodes( 'E', 'X', 'X', 'F' );
+        AC.SetISCodes( 'E', 'X', 'X', 'F', 'E' );
         AC.SetISDates( 0, 0, false, 3067, 0, 0, false, false );
         AC.SetISFactions( "", "", "CC", "" );
         AC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );

--- a/sswlib/src/main/java/states/stArmorMS.java
+++ b/sswlib/src/main/java/states/stArmorMS.java
@@ -39,10 +39,10 @@ public class stArmorMS implements ifArmor, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public stArmorMS() {
-        AC.SetISCodes( 'D', 'C', 'C', 'C' );
+        AC.SetISCodes( 'D', 'C', 'C', 'C', 'B' );
         AC.SetISDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'D', 'X', 'B', 'B' );
+        AC.SetCLCodes( 'D', 'C', 'C', 'C', 'B' );
         AC.SetCLDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );

--- a/sswlib/src/main/java/states/stArmorMS.java
+++ b/sswlib/src/main/java/states/stArmorMS.java
@@ -42,7 +42,7 @@ public class stArmorMS implements ifArmor, ifState {
         AC.SetISCodes( 'D', 'C', 'C', 'C', 'B' );
         AC.SetISDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'D', 'C', 'C', 'C', 'B' );
+        AC.SetCLCodes( 'D', 'X', 'C', 'C', 'B' );
         AC.SetCLDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );

--- a/sswlib/src/main/java/states/stArmorPBM.java
+++ b/sswlib/src/main/java/states/stArmorPBM.java
@@ -39,9 +39,12 @@ public class stArmorPBM implements ifArmor, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stArmorPBM() {
-        AC.SetISCodes( 'C', 'E', 'X', 'F' );
+        AC.SetISCodes( 'C', 'B', 'C', 'B', 'B' );
         AC.SetISDates( 0, 0, false, 2439, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
+        AC.SetCLCodes( 'C', 'X', 'C', 'B', 'B' );
+        AC.SetCLDates( 0, 0, false, 2439, 0, 0, false, false );
+        AC.SetCLFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );
         AC.SetPrimitiveOnly( true );
         AC.SetRulesLevels( AvailableCode.RULES_ERA_SPECIFIC, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stArmorPBM.java
+++ b/sswlib/src/main/java/states/stArmorPBM.java
@@ -39,10 +39,11 @@ public class stArmorPBM implements ifArmor, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stArmorPBM() {
-        AC.SetISCodes( 'C', 'B', 'C', 'B', 'B' );
+        // IO page 122 overrides the UAT for primitive components
+        AC.SetISCodes( 'D', 'C', 'F', 'E', 'F' );
         AC.SetISDates( 0, 0, false, 2439, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'C', 'X', 'C', 'B', 'B' );
+        AC.SetCLCodes( 'D', 'X', 'F', 'E', 'F' );
         AC.SetCLDates( 0, 0, false, 2439, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );

--- a/sswlib/src/main/java/states/stArmorPatchwork.java
+++ b/sswlib/src/main/java/states/stArmorPatchwork.java
@@ -39,10 +39,10 @@ public class stArmorPatchwork implements ifArmor, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public stArmorPatchwork() {
-        AC.SetISCodes( 'A', 'A', 'A', 'A' );
+        AC.SetISCodes( 'A', 'A', 'A', 'A', 'A' );
         AC.SetISDates( 0, 0, false, 2400, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'A', 'X', 'A', 'A' );
+        AC.SetCLCodes( 'A', 'X', 'A', 'A', 'A' );
         AC.SetISDates( 0, 0, false, 2400, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );

--- a/sswlib/src/main/java/states/stChassisCLECBP.java
+++ b/sswlib/src/main/java/states/stChassisCLECBP.java
@@ -57,7 +57,7 @@ public class stChassisCLECBP implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_CLAN );
 
     public stChassisCLECBP() {
-        AC.SetCLCodes( 'E', 'X', 'X', 'F' );
+        AC.SetCLCodes( 'E', 'X', 'X', 'F', 'E' );
         AC.SetCLDates( 3071, 3073, true, 3073, 0, 0, false, false );
         AC.SetCLFactions( "CWX", "CWX", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stChassisCLECQD.java
+++ b/sswlib/src/main/java/states/stChassisCLECQD.java
@@ -57,7 +57,7 @@ public class stChassisCLECQD implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_CLAN );
 
     public stChassisCLECQD() {
-        AC.SetCLCodes( 'E', 'X', 'X', 'F' );
+        AC.SetCLCodes( 'E', 'X', 'X', 'F', 'E' );
         AC.SetCLDates( 3071, 3073, true, 3073, 0, 0, false, false );
         AC.SetCLFactions( "CWX", "CWX", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stChassisCLESBP.java
+++ b/sswlib/src/main/java/states/stChassisCLESBP.java
@@ -57,8 +57,8 @@ public class stChassisCLESBP implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_CLAN );
 
     public stChassisCLESBP() {
-        AC.SetCLCodes( 'E', 'X', 'C', 'D' );
-        AC.SetCLDates( 0, 0, false, 2487, 0, 0, false, false );
+        AC.SetCLCodes( 'F', 'X', 'E', 'D', 'D' );
+        AC.SetCLDates( 0, 0, false, 2827, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
     }

--- a/sswlib/src/main/java/states/stChassisCLESQD.java
+++ b/sswlib/src/main/java/states/stChassisCLESQD.java
@@ -57,8 +57,8 @@ public class stChassisCLESQD implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_CLAN );
 
     public stChassisCLESQD() {
-        AC.SetCLCodes( 'E', 'X', 'C', 'D' );
-        AC.SetCLDates( 0, 0, false, 2487, 0, 0, false, false );
+        AC.SetCLCodes( 'F', 'X', 'E', 'D', 'D' );
+        AC.SetCLDates( 0, 0, false, 2827, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
     }

--- a/sswlib/src/main/java/states/stChassisCVIS.java
+++ b/sswlib/src/main/java/states/stChassisCVIS.java
@@ -37,10 +37,10 @@ public class stChassisCVIS implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public stChassisCVIS() {
-        AC.SetISCodes( 'D', 'C', 'C', 'C' );
+        AC.SetISCodes( 'D', 'A', 'A', 'A', 'A' );
         AC.SetISDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'D', 'X', 'B', 'B' );
+        AC.SetCLCodes( 'D', 'X', 'A', 'A', 'A' );
         AC.SetCLDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stChassisIMBP.java
+++ b/sswlib/src/main/java/states/stChassisIMBP.java
@@ -57,10 +57,10 @@ public class stChassisIMBP implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public stChassisIMBP() {
-        AC.SetISCodes( 'C', 'C', 'C', 'C' );
+        AC.SetISCodes( 'C', 'C', 'C', 'C', 'C' );
         AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'C', 'X', 'C', 'C' );
+        AC.SetCLCodes( 'C', 'X', 'C', 'C', 'C' );
         AC.SetCLDates( 0, 0, false, 2300, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stChassisIMQD.java
+++ b/sswlib/src/main/java/states/stChassisIMQD.java
@@ -57,10 +57,10 @@ public class stChassisIMQD implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public stChassisIMQD() {
-        AC.SetISCodes( 'C', 'C', 'C', 'C' );
+        AC.SetISCodes( 'C', 'C', 'C', 'C', 'C' );
         AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'C', 'X', 'C', 'C' );
+        AC.SetCLCodes( 'C', 'X', 'C', 'C', 'C' );
         AC.SetCLDates( 0, 0, false, 2300, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stChassisISCOBP.java
+++ b/sswlib/src/main/java/states/stChassisISCOBP.java
@@ -57,7 +57,7 @@ public class stChassisISCOBP implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisISCOBP() {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
         AC.SetISDates( 3056, 3061, true, 3061, 0, 0, false, false );
         AC.SetISFactions( "FC", "FS", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stChassisISCOQD.java
+++ b/sswlib/src/main/java/states/stChassisISCOQD.java
@@ -57,7 +57,7 @@ public class stChassisISCOQD implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisISCOQD() {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
         AC.SetISDates( 3056, 3061, true, 3061, 0, 0, false, false );
         AC.SetISFactions( "FC", "FS", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stChassisISECBP.java
+++ b/sswlib/src/main/java/states/stChassisISECBP.java
@@ -57,7 +57,7 @@ public class stChassisISECBP implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisISECBP() {
-        AC.SetISCodes( 'E', 'X', 'X', 'F' );
+        AC.SetISCodes( 'E', 'X', 'X', 'F', 'E' );
         AC.SetISDates( 3063, 3067, true, 3067, 0, 0, false, false );
         AC.SetISFactions( "LA", "LA", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stChassisISECQD.java
+++ b/sswlib/src/main/java/states/stChassisISECQD.java
@@ -57,7 +57,7 @@ public class stChassisISECQD implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisISECQD() {
-        AC.SetISCodes( 'E', 'X', 'X', 'F' );
+        AC.SetISCodes( 'E', 'X', 'X', 'F', 'E' );
         AC.SetISDates( 3063, 3067, true, 3067, 0, 0, false, false );
         AC.SetISFactions( "LA", "LA", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stChassisISESBP.java
+++ b/sswlib/src/main/java/states/stChassisISESBP.java
@@ -57,7 +57,7 @@ public class stChassisISESBP implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisISESBP() {
-        AC.SetISCodes( 'E', 'D', 'F', 'E' );
+        AC.SetISCodes( 'E', 'D', 'F', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 2487, 2850, 3035, true, true );
         AC.SetISFactions( "", "", "TH", "DC" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stChassisISESQD.java
+++ b/sswlib/src/main/java/states/stChassisISESQD.java
@@ -57,7 +57,7 @@ public class stChassisISESQD implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisISESQD() {
-        AC.SetISCodes( 'E', 'D', 'F', 'E' );
+        AC.SetISCodes( 'E', 'D', 'F', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 2487, 2850, 3035, true, true );
         AC.SetISFactions( "", "", "TH", "DC" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stChassisISESTP.java
+++ b/sswlib/src/main/java/states/stChassisISESTP.java
@@ -32,7 +32,7 @@ import components.AvailableCode;
 import components.MechModifier;
 
 public class stChassisISESTP implements ifChassis, ifState {
-    // An Inner Sphere EndoSteel Quad chassis
+    // An Inner Sphere EndoSteel Tripod chassis
     private final static double[] Masses = { 1.0, 1.5, 1.5, 2.0, 2.0, 2.5, 2.5, 3.0, 3.0, 3.5, 3.5, 4.0, 4.0, 4.5, 4.5, 5.0, 5.0, 5.5, 5.5 };
     private final static int[][] IntPoints = {
         { 4, 3, 1, 2 },
@@ -57,7 +57,7 @@ public class stChassisISESTP implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisISESTP() {
-        AC.SetISCodes( 'E', 'D', 'F', 'E' );
+        AC.SetISCodes( 'E', 'D', 'F', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 2487, 2850, 3035, true, true );
         AC.SetISFactions( "", "", "TH", "DC" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stChassisMSBP.java
+++ b/sswlib/src/main/java/states/stChassisMSBP.java
@@ -57,10 +57,10 @@ public class stChassisMSBP implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public stChassisMSBP() {
-        AC.SetISCodes( 'D', 'C', 'C', 'C' );
+        AC.SetISCodes( 'D', 'C', 'C', 'C', 'C' );
         AC.SetISDates( 0, 0, false, 2443, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'D', 'X', 'B', 'B' );
+        AC.SetCLCodes( 'D', 'X', 'B', 'B', 'B' );
         AC.SetCLDates( 0, 0, false, 2443, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetSuperHeavyCompatible(false);

--- a/sswlib/src/main/java/states/stChassisMSQD.java
+++ b/sswlib/src/main/java/states/stChassisMSQD.java
@@ -57,10 +57,10 @@ public class stChassisMSQD implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public stChassisMSQD() {
-        AC.SetISCodes( 'D', 'C', 'C', 'C' );
+        AC.SetISCodes( 'D', 'C', 'C', 'C', 'C' );
         AC.SetISDates( 0, 0, false, 2443, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'D', 'X', 'B', 'B' );
+        AC.SetCLCodes( 'D', 'X', 'B', 'B', 'B' );
         AC.SetCLDates( 0, 0, false, 2443, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetSuperHeavyCompatible(false);

--- a/sswlib/src/main/java/states/stChassisMSTP.java
+++ b/sswlib/src/main/java/states/stChassisMSTP.java
@@ -57,7 +57,7 @@ public class stChassisMSTP implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisMSTP() {
-        AC.SetISCodes( 'E', 'F', 'X', 'X', 'F' );
+        AC.SetISCodes( 'E', 'E', 'F', 'X', 'E' );
         AC.SetISDates( 0, 0, false, 2602, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
         AC.SetSuperHeavyCompatible(false);

--- a/sswlib/src/main/java/states/stChassisMSTP.java
+++ b/sswlib/src/main/java/states/stChassisMSTP.java
@@ -57,6 +57,7 @@ public class stChassisMSTP implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisMSTP() {
+        // Considered Tripod Mech Internal Structure in IO
         AC.SetISCodes( 'E', 'E', 'F', 'X', 'E' );
         AC.SetISDates( 0, 0, false, 2602, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );

--- a/sswlib/src/main/java/states/stChassisPBMBP.java
+++ b/sswlib/src/main/java/states/stChassisPBMBP.java
@@ -57,8 +57,8 @@ public class stChassisPBMBP implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisPBMBP() {
-        AC.SetISCodes( 'C', 'E', 'X', 'F' );
-        AC.SetISDates( 0, 0, false, 2443, 0, 0, false, false );
+        AC.SetISCodes( 'D', 'D', 'X', 'F', 'F' );
+        AC.SetISDates( 0, 0, false, 2439, 2520, 0, true, false );
         AC.SetISFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );
         AC.SetPrimitiveOnly( true );

--- a/sswlib/src/main/java/states/stChassisPBMBP.java
+++ b/sswlib/src/main/java/states/stChassisPBMBP.java
@@ -57,7 +57,8 @@ public class stChassisPBMBP implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisPBMBP() {
-        AC.SetISCodes( 'D', 'D', 'X', 'F', 'F' );
+        // IO page 122 overrides the UAT for primitive components
+        AC.SetISCodes( 'D', 'C', 'F', 'E', 'F' );
         AC.SetISDates( 0, 0, false, 2439, 2520, 0, true, false );
         AC.SetISFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );

--- a/sswlib/src/main/java/states/stChassisPBMQD.java
+++ b/sswlib/src/main/java/states/stChassisPBMQD.java
@@ -57,8 +57,8 @@ public class stChassisPBMQD implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisPBMQD() {
-        AC.SetISCodes( 'C', 'E', 'X', 'F' );
-        AC.SetISDates( 0, 0, false, 2443, 0, 0, false, false );
+        AC.SetISCodes( 'D', 'D', 'X', 'F', 'F' );
+        AC.SetISDates( 0, 0, false, 2439, 2520, 0, true, false );
         AC.SetISFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );
         AC.SetPrimitiveOnly( true );

--- a/sswlib/src/main/java/states/stChassisPBMQD.java
+++ b/sswlib/src/main/java/states/stChassisPBMQD.java
@@ -57,7 +57,8 @@ public class stChassisPBMQD implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisPBMQD() {
-        AC.SetISCodes( 'D', 'D', 'X', 'F', 'F' );
+        // IO page 122 overrides the UAT for primitive components
+        AC.SetISCodes( 'D', 'C', 'F', 'E', 'F' );
         AC.SetISDates( 0, 0, false, 2439, 2520, 0, true, false );
         AC.SetISFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );

--- a/sswlib/src/main/java/states/stChassisPIMBP.java
+++ b/sswlib/src/main/java/states/stChassisPIMBP.java
@@ -57,7 +57,8 @@ public class stChassisPIMBP implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisPIMBP() {
-        AC.SetISCodes( 'C', 'C', 'X', 'F', 'F' );
+        // IO page 122 overrides the UAT for primitive components
+        AC.SetISCodes( 'D', 'C', 'F', 'E', 'F' );
         AC.SetISDates( 0, 0, false, 2300, 2520, 0, true, false );
         AC.SetISFactions( "", "", "TH", "" );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/states/stChassisPIMBP.java
+++ b/sswlib/src/main/java/states/stChassisPIMBP.java
@@ -57,8 +57,8 @@ public class stChassisPIMBP implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisPIMBP() {
-        AC.SetISCodes( 'C', 'E', 'X', 'F' );
-        AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
+        AC.SetISCodes( 'C', 'C', 'X', 'F', 'F' );
+        AC.SetISDates( 0, 0, false, 2300, 2520, 0, true, false );
         AC.SetISFactions( "", "", "TH", "" );
         AC.SetPIMAllowed( true );
         AC.SetPrimitiveOnly( true );

--- a/sswlib/src/main/java/states/stChassisPIMQD.java
+++ b/sswlib/src/main/java/states/stChassisPIMQD.java
@@ -57,8 +57,8 @@ public class stChassisPIMQD implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisPIMQD() {
-        AC.SetISCodes( 'C', 'E', 'X', 'F' );
-        AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
+        AC.SetISCodes( 'C', 'C', 'X', 'F', 'F' );
+        AC.SetISDates( 0, 0, false, 2300, 2520, 0, true, false );
         AC.SetISFactions( "", "", "TH", "" );
         AC.SetPIMAllowed( true );
         AC.SetPrimitiveOnly( true );

--- a/sswlib/src/main/java/states/stChassisPIMQD.java
+++ b/sswlib/src/main/java/states/stChassisPIMQD.java
@@ -57,7 +57,8 @@ public class stChassisPIMQD implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisPIMQD() {
-        AC.SetISCodes( 'C', 'C', 'X', 'F', 'F' );
+        // IO page 122 overrides the UAT for primitive components
+        AC.SetISCodes( 'D', 'C', 'F', 'E', 'F' );
         AC.SetISDates( 0, 0, false, 2300, 2520, 0, true, false );
         AC.SetISFactions( "", "", "TH", "" );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/states/stChassisREBP.java
+++ b/sswlib/src/main/java/states/stChassisREBP.java
@@ -57,11 +57,11 @@ public class stChassisREBP implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public stChassisREBP() {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
-        AC.SetISDates( 3055, 3057, true, 3057, 0, 0, false, false );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
+        AC.SetISDates( 3055, 3057, true, 3084, 0, 0, false, false );
         AC.SetISFactions( "CS", "CS/WB", "", "" );
-        AC.SetCLCodes( 'E', 'X', 'X', 'E' );
-        AC.SetCLDates( 3060, 3065, true, 3065, 0, 0, false, false );
+        AC.SetCLCodes( 'E', 'X', 'X', 'E', 'D' );
+        AC.SetCLDates( 3060, 3065, true, 3084, 0, 0, false, false );
         AC.SetCLFactions( "CGB", "CGB", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
     }

--- a/sswlib/src/main/java/states/stChassisREQD.java
+++ b/sswlib/src/main/java/states/stChassisREQD.java
@@ -57,11 +57,11 @@ public class stChassisREQD implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public stChassisREQD() {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
-        AC.SetISDates( 3055, 3057, true, 3057, 0, 0, false, false );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
+        AC.SetISDates( 3055, 3057, true, 3084, 0, 0, false, false );
         AC.SetISFactions( "CS", "CS/WB", "", "" );
-        AC.SetCLCodes( 'E', 'X', 'X', 'E' );
-        AC.SetCLDates( 3060, 3065, true, 3065, 0, 0, false, false );
+        AC.SetCLCodes( 'E', 'X', 'X', 'E', 'D' );
+        AC.SetCLDates( 3060, 3065, true, 3084, 0, 0, false, false );
         AC.SetCLFactions( "CGB", "CGB", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
     }

--- a/sswlib/src/main/java/states/stChassisSHECBP.java
+++ b/sswlib/src/main/java/states/stChassisSHECBP.java
@@ -61,7 +61,7 @@ public class stChassisSHECBP implements ifChassis, ifState {
 
     public stChassisSHECBP() {
         AC.SetISCodes( 'E', 'X', 'X', 'F', 'F' );
-        AC.SetISDates( 0, 0, false, 3076, 0, 0, false, false );
+        AC.SetISDates( 0, 0, false, 3130, 0, 0, false, false );
         AC.SetISFactions( "", "", "WoB", "" );
         AC.SetSuperHeavyOnly(true);
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stChassisSHESBP.java
+++ b/sswlib/src/main/java/states/stChassisSHESBP.java
@@ -61,7 +61,7 @@ public class stChassisSHESBP implements ifChassis, ifState {
 
     public stChassisSHESBP() {
         AC.SetISCodes( 'E', 'X', 'X', 'F', 'F' );
-        AC.SetISDates( 0, 0, false, 3076, 0, 0, false, false );
+        AC.SetISDates( 0, 0, false, 3060, 0, 0, false, false );
         AC.SetISFactions( "", "", "WoB", "" );
         AC.SetSuperHeavyOnly(true);
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stChassisSHTP.java
+++ b/sswlib/src/main/java/states/stChassisSHTP.java
@@ -60,9 +60,9 @@ public class stChassisSHTP implements ifChassis, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stChassisSHTP() {
-        AC.SetISCodes( 'E', 'X', 'X', 'F', 'F' );
-        AC.SetISDates( 0, 0, false, 3076, 0, 0, false, false );
-        AC.SetISFactions( "", "", "WoB", "" );
+        AC.SetISCodes( 'E', 'X', 'X', 'X', 'F' );
+        AC.SetISDates( 0, 0, false, 3135, 0, 0, false, false );
+        AC.SetISFactions( "", "", "RS", "" );
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
     }
 

--- a/sswlib/src/main/java/states/stCockpitISPrimitive.java
+++ b/sswlib/src/main/java/states/stCockpitISPrimitive.java
@@ -41,7 +41,8 @@ public class stCockpitISPrimitive implements ifCockpit, ifState {
     private SimplePlaceable SecondLifeSupport = new SimplePlaceable( "Life Support", "Life Support", "Life Support", "Life Support", "Tech Manual", 1, true, AC );
 
     public stCockpitISPrimitive() {
-        AC.SetISCodes( 'D', 'D', 'X', 'X', 'F' );
+        // IO page 122 overrides the UAT for primitive components
+        AC.SetISCodes( 'D', 'C', 'F', 'E', 'F' );
         AC.SetISDates( 0, 0, false, 2439, 2520, 0, true, false );
         AC.SetISFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );

--- a/sswlib/src/main/java/states/stCockpitISPrimitive.java
+++ b/sswlib/src/main/java/states/stCockpitISPrimitive.java
@@ -41,8 +41,8 @@ public class stCockpitISPrimitive implements ifCockpit, ifState {
     private SimplePlaceable SecondLifeSupport = new SimplePlaceable( "Life Support", "Life Support", "Life Support", "Life Support", "Tech Manual", 1, true, AC );
 
     public stCockpitISPrimitive() {
-        AC.SetISCodes( 'C', 'E', 'X', 'F' );
-        AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
+        AC.SetISCodes( 'D', 'D', 'X', 'X', 'F' );
+        AC.SetISDates( 0, 0, false, 2439, 2520, 0, true, false );
         AC.SetISFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );
         AC.SetPrimitiveOnly( true );

--- a/sswlib/src/main/java/states/stCockpitIndustrial.java
+++ b/sswlib/src/main/java/states/stCockpitIndustrial.java
@@ -45,7 +45,7 @@ public class stCockpitIndustrial implements ifCockpit, ifState {
         AC.SetISDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
         AC.SetCLCodes( 'C', 'B', 'C', 'C', 'B' );
-        AC.SetCLDates( 0, 0, false, 2300, 0, 0, false, false );
+        AC.SetCLDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
     }

--- a/sswlib/src/main/java/states/stCockpitIndustrial.java
+++ b/sswlib/src/main/java/states/stCockpitIndustrial.java
@@ -41,10 +41,10 @@ public class stCockpitIndustrial implements ifCockpit, ifState {
     private SimplePlaceable SecondLifeSupport = new SimplePlaceable( "Life Support", "Life Support", "Life Support", "Life Support", "Tech Manual", 1, true, AC );
 
     public stCockpitIndustrial() {
-        AC.SetISCodes( 'C', 'B', 'C', 'C' );
-        AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
+        AC.SetISCodes( 'C', 'B', 'C', 'C', 'B' );
+        AC.SetISDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'C', 'X', 'C', 'C' );
+        AC.SetCLCodes( 'C', 'B', 'C', 'C', 'B' );
         AC.SetCLDates( 0, 0, false, 2300, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stCockpitIndustrialAFC.java
+++ b/sswlib/src/main/java/states/stCockpitIndustrialAFC.java
@@ -41,11 +41,11 @@ public class stCockpitIndustrialAFC implements ifCockpit, ifState {
     private SimplePlaceable SecondLifeSupport = new SimplePlaceable( "Life Support", "Life Support", "Life Support", "Life Support", "Tech Manual", 1, true, AC );
 
     public stCockpitIndustrialAFC() {
-        AC.SetISCodes( 'D', 'D', 'E', 'E' );
-        AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
+        AC.SetISCodes( 'D', 'D', 'E', 'E', 'D' );
+        AC.SetISDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'D', 'X', 'D', 'D' );
-        AC.SetCLDates( 0, 0, false, 2300, 0, 0, false, false );
+        AC.SetCLCodes( 'D', 'D', 'E', 'E', 'D' );
+        AC.SetCLDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
     }

--- a/sswlib/src/main/java/states/stCockpitIndustrialAFC.java
+++ b/sswlib/src/main/java/states/stCockpitIndustrialAFC.java
@@ -44,7 +44,7 @@ public class stCockpitIndustrialAFC implements ifCockpit, ifState {
         AC.SetISCodes( 'D', 'D', 'E', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'D', 'D', 'E', 'E', 'D' );
+        AC.SetCLCodes( 'D', 'X', 'E', 'E', 'D' );
         AC.SetCLDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stCockpitInterface.java
+++ b/sswlib/src/main/java/states/stCockpitInterface.java
@@ -41,13 +41,13 @@ public class stCockpitInterface implements ifCockpit, ifState {
     private SimplePlaceable SecondLifeSupport = new SimplePlaceable( "Life Support", "Life Support", "Life Support", "Life Support", "Tech Manual", 1, true, AC );
 
     public stCockpitInterface() {
-        AC.SetISCodes( 'E', 'X', 'X', 'F' );
-        AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
+        AC.SetISCodes( 'E', 'X', 'X', 'F', 'X' );
+        AC.SetISDates( 0, 0, false, 3074, 0, 0, false, false );
         AC.SetISFactions( "", "", "WB", "" );
         AC.SetSuperHeavyCompatible(false);
-        //AC.SetCLCodes( 'D', 'X', 'B', 'B' );
-        //AC.SetCLDates( 0, 0, false, 2300, 0, 0, false, false );
-        //AC.SetCLFactions( "", "", "TH", "" );
+        AC.SetCLCodes( 'F', 'X', 'X', 'F', 'F' );
+        AC.SetCLDates( 0, 0, false, 3083, 0, 0, false, false );
+        AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
     }
 

--- a/sswlib/src/main/java/states/stCockpitPrimIndustrial.java
+++ b/sswlib/src/main/java/states/stCockpitPrimIndustrial.java
@@ -41,9 +41,12 @@ public class stCockpitPrimIndustrial implements ifCockpit, ifState {
     private SimplePlaceable SecondLifeSupport = new SimplePlaceable( "Life Support", "Life Support", "Life Support", "Life Support", "Tech Manual", 1, true, AC );
 
     public stCockpitPrimIndustrial() {
-        AC.SetISCodes( 'C', 'E', 'X', 'F' );
-        AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
+        AC.SetISCodes( 'C', 'C', 'X', 'X', 'F' );
+        AC.SetISDates( 0, 0, false, 2350, 2520, 0, true, false );
         AC.SetISFactions( "", "", "TH", "" );
+        AC.SetCLCodes( 'C', 'C', 'X', 'X', 'F' );
+        AC.SetCLDates( 0, 0, false, 2350, 2520, 0, false, false );
+        AC.SetCLFactions( "", "", "TH", "" );
         AC.SetPIMAllowed( true );
         AC.SetPrimitiveOnly( true );
         AC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_ERA_SPECIFIC, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stCockpitPrimIndustrialAFC.java
+++ b/sswlib/src/main/java/states/stCockpitPrimIndustrialAFC.java
@@ -41,7 +41,8 @@ public class stCockpitPrimIndustrialAFC implements ifCockpit, ifState {
     private SimplePlaceable SecondLifeSupport = new SimplePlaceable( "Life Support", "Life Support", "Life Support", "Life Support", "Tech Manual", 1, true, AC );
 
     public stCockpitPrimIndustrialAFC() {
-        AC.SetISCodes( 'C', 'E', 'X', 'F' );
+        // IO page 122 overrides the UAT for primitive components
+        AC.SetISCodes( 'D', 'C', 'F', 'E', 'F' );
         AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/states/stCockpitRobotic.java
+++ b/sswlib/src/main/java/states/stCockpitRobotic.java
@@ -45,11 +45,11 @@ public class stCockpitRobotic implements ifCockpit, ifState {
     private SimplePlaceable SecondLifeSupport = new SimplePlaceable( "Life Support", "Life Support", "Life Support", "Life Support", "Tech Manual", 1, true, AC );
 
     public stCockpitRobotic() {
-        AC.SetISCodes( 'C', 'E', 'X', 'F' );
-        AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
+        AC.SetISCodes( 'C', 'E', 'F', 'F', 'F' );
+        AC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'C', 'X', 'D', 'E' );
-        AC.SetCLDates( 0, 0, false, 2300, 0, 0, false, false );
+        AC.SetCLCodes( 'C', 'X', 'F', 'F', 'F' );
+        AC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetSuperHeavyCompatible(false);
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );

--- a/sswlib/src/main/java/states/stCockpitSmall.java
+++ b/sswlib/src/main/java/states/stCockpitSmall.java
@@ -33,7 +33,7 @@ import components.LocationIndex;
 import components.MechModifier;
 import components.SimplePlaceable;
 
-public class stCockpitISSmall implements ifCockpit, ifState {
+public class stCockpitSmall implements ifCockpit, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
     private SimplePlaceable Sensors = new SimplePlaceable( "Sensors", "Sensors", "Sensors", "Sensors", "Tech Manual", 1, true, AC );
     private SimplePlaceable LifeSupport = new SimplePlaceable( "Life Support", "Life Support", "Life Support", "Life Support", "Tech Manual", 1, true, AC );
@@ -41,10 +41,13 @@ public class stCockpitISSmall implements ifCockpit, ifState {
     private SimplePlaceable SecondLifeSupport = new SimplePlaceable( "Life Support", "Life Support", "Life Support", "Life Support", "Tech Manual", 1, true, AC );
     private final MechModifier MechMod = new MechModifier( 0, 0, 0, 0.0f, 1, 0, 0, 0.0f, 0.0f, 0.0f, 0.0f, true, false );
 
-    public stCockpitISSmall() {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
+    public stCockpitSmall() {
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 3067, 0, 0, false, false );
         AC.SetISFactions( "", "", "FS", "" );
+        AC.SetCLCodes( 'E', 'X', 'X', 'E', 'D' );
+        AC.SetCLDates( 0, 0, false, 3080, 0, 0, false, false );
+        AC.SetCLFactions( "", "", "FS", "" );
         AC.SetSuperHeavyCompatible(false);
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
     }

--- a/sswlib/src/main/java/states/stCockpitStandard.java
+++ b/sswlib/src/main/java/states/stCockpitStandard.java
@@ -44,7 +44,7 @@ public class stCockpitStandard implements ifCockpit, ifState {
         AC.SetISCodes( 'D', 'C', 'C', 'C', 'C' );
         AC.SetISDates( 0, 0, false, 2468, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'D', 'C', 'C', 'C', 'C' );
+        AC.SetCLCodes( 'D', 'X', 'C', 'C', 'C' );
         AC.SetCLDates( 0, 0, false, 2468, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetSuperHeavyCompatible(false);

--- a/sswlib/src/main/java/states/stCockpitStandard.java
+++ b/sswlib/src/main/java/states/stCockpitStandard.java
@@ -41,11 +41,11 @@ public class stCockpitStandard implements ifCockpit, ifState {
     private SimplePlaceable SecondLifeSupport = new SimplePlaceable( "Life Support", "Life Support", "Life Support", "Life Support", "Tech Manual", 1, true, AC );
 
     public stCockpitStandard() {
-        AC.SetISCodes( 'D', 'C', 'C', 'C' );
-        AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
+        AC.SetISCodes( 'D', 'C', 'C', 'C', 'C' );
+        AC.SetISDates( 0, 0, false, 2468, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'D', 'X', 'B', 'B' );
-        AC.SetCLDates( 0, 0, false, 2300, 0, 0, false, false );
+        AC.SetCLCodes( 'D', 'C', 'C', 'C', 'C' );
+        AC.SetCLDates( 0, 0, false, 2468, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetSuperHeavyCompatible(false);
         AC.SetRulesLevels( AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stCockpitSuperHeavy.java
+++ b/sswlib/src/main/java/states/stCockpitSuperHeavy.java
@@ -41,7 +41,7 @@ public class stCockpitSuperHeavy implements ifCockpit, ifState {
     private SimplePlaceable SecondLifeSupport = new SimplePlaceable( "Life Support", "Life Support", "Life Support", "Life Support", "Tech Manual", 1, true, AC );
 
     public stCockpitSuperHeavy() {
-        AC.SetISCodes( 'E', 'X', 'X', 'F', 'F' );
+        AC.SetISCodes( 'E', 'X', 'X', 'F', 'E' );
         AC.SetISDates( 0, 0, false, 3076, 0, 0, false, false );
         AC.SetISFactions( "", "", "WoB", "" );
         AC.SetSuperHeavyOnly(true);

--- a/sswlib/src/main/java/states/stCockpitTorsoMount.java
+++ b/sswlib/src/main/java/states/stCockpitTorsoMount.java
@@ -42,11 +42,11 @@ public class stCockpitTorsoMount implements ifCockpit, ifState {
     private SimplePlaceable ThirdSensors = new SimplePlaceable( "Sensors", "Sensors", "Sensors", "Sensors", "Tech Manual", 1, true, AC );
 
     public stCockpitTorsoMount() {
-        AC.SetISCodes( 'E', 'X', 'X', 'F' );
-        AC.SetISDates( 3044, 3053, true, 3053, 0, 0, false, false );
+        AC.SetISCodes( 'D', 'X', 'X', 'F', 'F' );
+        AC.SetISDates( 3044, 3053, true, 3080, 0, 0, false, false );
         AC.SetISFactions( "FC", "FC", "", "" );
-        AC.SetCLCodes( 'E', 'X', 'X', 'F' );
-        AC.SetCLDates( 3044, 3055, true, 3055, 0, 0, false, false );
+        AC.SetCLCodes( 'D', 'X', 'X', 'F', 'F' );
+        AC.SetCLDates( 3044, 3055, true, 3080, 0, 0, false, false );
         AC.SetCLFactions( "FC", "FC", "", "" );
         AC.SetSuperHeavyCompatible(false);
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stEngineCLXL.java
+++ b/sswlib/src/main/java/states/stEngineCLXL.java
@@ -51,12 +51,12 @@ public class stEngineCLXL implements ifEngine, ifState {
     private Engine Owner;
 
     public stEngineCLXL( Engine e ) {
-        AC.SetCLCodes( 'E', 'X', 'C', 'D' );
-        AC.SetCLDates( 0, 0, false, 2579, 0, 0, false, false );
+        AC.SetCLCodes( 'F', 'D', 'E', 'D', 'D' );
+        AC.SetCLDates( 0, 0, false, 2827, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED );
-        LARGE_AC.SetCLCodes( 'E', 'X', 'C', 'D' );
-        LARGE_AC.SetCLDates( 2579, 2630, true, 2630, 0, 0, false, false );
+        LARGE_AC.SetCLCodes( 'F', 'D', 'E', 'D', 'D' );
+        LARGE_AC.SetCLDates( 2579, 2630, true, 2827, 0, 0, false, false );
         LARGE_AC.SetCLFactions( "TH", "TH", "", "" );
         LARGE_AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );
         Owner = e;

--- a/sswlib/src/main/java/states/stEngineCLXXL.java
+++ b/sswlib/src/main/java/states/stEngineCLXXL.java
@@ -51,11 +51,11 @@ public class stEngineCLXXL implements ifEngine, ifState {
     private Engine Owner;
 
     public stEngineCLXXL( Engine e ) {
-        AC.SetCLCodes( 'F', 'X', 'F', 'F' );
+        AC.SetCLCodes( 'F', 'X', 'X', 'F', 'E' );
         AC.SetCLDates( 2582, 2954, true, 2954, 0, 0, false, false );
         AC.SetCLFactions( "TH", "CDS", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );
-        LARGE_AC.SetCLCodes( 'F', 'X', 'F', 'F' );
+        LARGE_AC.SetCLCodes( 'F', 'X', 'X', 'F', 'E' );
         LARGE_AC.SetCLDates( 2582, 2954, true, 2954, 0, 0, false, false );
         LARGE_AC.SetCLFactions( "TH", "CDS", "", "" );
         LARGE_AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );

--- a/sswlib/src/main/java/states/stEngineFission.java
+++ b/sswlib/src/main/java/states/stEngineFission.java
@@ -46,11 +46,11 @@ public class stEngineFission implements ifEngine, ifState {
     private final static int[] BFStructure = {1,1,2,2,3,3,3,4,4,5,5,5,6,6,6,7,7,8,8};
 
     public stEngineFission() {
-        AC.SetISCodes( 'D', 'E', 'E', 'D' );
-        AC.SetISDates( 0, 0, false, 1960, 0, 0, false, false );
+        AC.SetISCodes( 'D', 'E', 'E', 'D', 'D' );
+        AC.SetISDates( 0, 0, false, 2882, 0, 0, false, false );
         AC.SetISFactions( "", "", "ES", "" );
-        AC.SetCLCodes( 'D', 'X', 'E', 'D' );
-        AC.SetCLDates( 0, 0, false, 1960, 0, 0, false, false );
+        AC.SetCLCodes( 'D', 'X', 'E', 'D', 'D' );
+        AC.SetCLDates( 0, 0, false, 2882, 0, 0, false, false );
         AC.SetCLFactions( "", "", "ES", "" );
         AC.SetSuperHeavyCompatible( false );
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_ADVANCED );

--- a/sswlib/src/main/java/states/stEngineFuelCell.java
+++ b/sswlib/src/main/java/states/stEngineFuelCell.java
@@ -46,11 +46,11 @@ public class stEngineFuelCell implements ifEngine, ifState {
     private final static int[] BFStructure = {1,1,2,2,3,3,3,4,4,5,5,5,6,6,6,7,7,8,8};
 
     public stEngineFuelCell() {
-        AC.SetISCodes( 'D', 'C', 'D', 'D' );
-        AC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
+        AC.SetISCodes( 'D', 'C', 'D', 'D', 'C' );
+        AC.SetISDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetISFactions( "", "", "PS", "" );
-        AC.SetCLCodes( 'D', 'X', 'C', 'D' );
-        AC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
+        AC.SetCLCodes( 'D', 'X', 'C', 'D', 'C' );
+        AC.SetCLDates( 0, 0, false, 2470, 0, 0, false, false );
         AC.SetCLFactions( "", "", "PS", "" );
         AC.SetSuperHeavyCompatible( false );
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stEngineFusion.java
+++ b/sswlib/src/main/java/states/stEngineFusion.java
@@ -55,14 +55,14 @@ public class stEngineFusion implements ifEngine, ifState {
         AC.SetISCodes( 'D', 'C', 'E', 'D', 'D' );
         AC.SetISDates( 0, 0, false, 2021, 0, 0, false, false );
         AC.SetISFactions( "", "", "WA", "" );
-        AC.SetCLCodes( 'D', 'C', 'E', 'D', 'D' );
+        AC.SetCLCodes( 'D', 'X', 'E', 'D', 'D' );
         AC.SetCLDates( 0, 0, false, 2021, 0, 0, false, false );
         AC.SetCLFactions( "", "", "WA", "" );
         AC.SetRulesLevels( AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );
         LARGE_AC.SetISCodes( 'D', 'C', 'E', 'D', 'D' );
         LARGE_AC.SetISDates( 2550, 2630, true, 2630, 0, 0, false, false );
         LARGE_AC.SetISFactions( "WA", "TH", "", "" );
-        LARGE_AC.SetCLCodes( 'D', 'C', 'E', 'D', 'D' );
+        LARGE_AC.SetCLCodes( 'D', 'X', 'E', 'D', 'D' );
         LARGE_AC.SetCLDates( 2550, 2630, true, 2630, 0, 0, false, false );
         LARGE_AC.SetCLFactions( "WA", "TH", "", "" );
         LARGE_AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );

--- a/sswlib/src/main/java/states/stEngineFusion.java
+++ b/sswlib/src/main/java/states/stEngineFusion.java
@@ -52,17 +52,17 @@ public class stEngineFusion implements ifEngine, ifState {
     private Engine Owner;
     
     public stEngineFusion( Engine e ) {
-        AC.SetISCodes( 'D', 'C', 'E', 'D' );
+        AC.SetISCodes( 'D', 'C', 'E', 'D', 'D' );
         AC.SetISDates( 0, 0, false, 2021, 0, 0, false, false );
         AC.SetISFactions( "", "", "WA", "" );
-        AC.SetCLCodes( 'D', 'X', 'B', 'C' );
+        AC.SetCLCodes( 'D', 'C', 'E', 'D', 'D' );
         AC.SetCLDates( 0, 0, false, 2021, 0, 0, false, false );
         AC.SetCLFactions( "", "", "WA", "" );
         AC.SetRulesLevels( AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );
-        LARGE_AC.SetISCodes( 'D', 'C', 'E', 'D' );
+        LARGE_AC.SetISCodes( 'D', 'C', 'E', 'D', 'D' );
         LARGE_AC.SetISDates( 2550, 2630, true, 2630, 0, 0, false, false );
         LARGE_AC.SetISFactions( "WA", "TH", "", "" );
-        LARGE_AC.SetCLCodes( 'D', 'X', 'B', 'C' );
+        LARGE_AC.SetCLCodes( 'D', 'C', 'E', 'D', 'D' );
         LARGE_AC.SetCLDates( 2550, 2630, true, 2630, 0, 0, false, false );
         LARGE_AC.SetCLFactions( "WA", "TH", "", "" );
         LARGE_AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );

--- a/sswlib/src/main/java/states/stEngineICE.java
+++ b/sswlib/src/main/java/states/stEngineICE.java
@@ -52,18 +52,18 @@ public class stEngineICE implements ifEngine, ifState {
     private Engine Owner;
 
     public stEngineICE( Engine e ) {
-        AC.SetISCodes( 'C', 'A', 'A', 'A' );
-        AC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
+        AC.SetISCodes( 'C', 'A', 'A', 'A', 'A' );
+        AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
         AC.SetISFactions( "", "", "PS", "" );
-        AC.SetCLCodes( 'C', 'X', 'A', 'A' );
-        AC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
+        AC.SetCLCodes( 'C', 'A', 'A', 'A', 'A' );
+        AC.SetCLDates( 0, 0, false, 2300, 0, 0, false, false );
         AC.SetCLFactions( "", "", "PS", "" );
         AC.SetSuperHeavyCompatible( false );
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_TOURNAMENT );
-        LARGE_AC.SetISCodes( 'C', 'A', 'A', 'A' );
+        LARGE_AC.SetISCodes( 'C', 'A', 'A', 'A', 'A' );
         LARGE_AC.SetISDates( 2550, 2630, true, 2630, 0, 0, false, false );
         LARGE_AC.SetISFactions( "PS", "PS", "", "" );
-        LARGE_AC.SetCLCodes( 'C', 'X', 'A', 'A' );
+        LARGE_AC.SetCLCodes( 'C', 'X', 'A', 'A', 'A' );
         LARGE_AC.SetCLDates( 2550, 2630, true, 2630, 0, 0, false, false );
         LARGE_AC.SetCLFactions( "PS", "PS", "", "" );
         LARGE_AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );

--- a/sswlib/src/main/java/states/stEngineISCF.java
+++ b/sswlib/src/main/java/states/stEngineISCF.java
@@ -46,7 +46,7 @@ public class stEngineISCF implements ifEngine, ifState {
     private final static int[] BFStructure = {1,2,2,3,3,4,4,5,5,6,7,7,7,8,8,9,10,10,10};
 
     public stEngineISCF() {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 3068, 0, 0, false, false );
         AC.SetISFactions( "", "", "LA", "" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED );

--- a/sswlib/src/main/java/states/stEngineISLF.java
+++ b/sswlib/src/main/java/states/stEngineISLF.java
@@ -51,11 +51,11 @@ public class stEngineISLF implements ifEngine, ifState {
     private Engine Owner;
 
     public stEngineISLF( Engine e ) {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 3062, 0, 0, false, false );
         AC.SetISFactions( "", "", "LA", "" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED );
-        LARGE_AC.SetISCodes( 'E', 'X', 'X', 'E' );
+        LARGE_AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
         LARGE_AC.SetISDates( 3062, 3062, true, 3062, 0, 0, false, false );
         LARGE_AC.SetISFactions( "LA", "LA", "LA", "" );
         LARGE_AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );

--- a/sswlib/src/main/java/states/stEngineISXL.java
+++ b/sswlib/src/main/java/states/stEngineISXL.java
@@ -51,12 +51,12 @@ public class stEngineISXL implements ifEngine, ifState {
     private Engine Owner;
 
     public stEngineISXL( Engine e ) {
-        AC.SetISCodes( 'E', 'D', 'F', 'E' );
-        AC.SetISDates( 0, 0, false, 2579, 2865, 3035, true, true );
+        AC.SetISCodes( 'E', 'D', 'F', 'E', 'D' );
+        AC.SetISDates( 0, 0, false, 2556, 2865, 3035, true, true );
         AC.SetISFactions( "", "", "TH", "LC" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED );
-        LARGE_AC.SetISCodes( 'E', 'D', 'F', 'E' );
-        LARGE_AC.SetISDates( 2579, 2630, true, 2630, 2865, 3035, true, true );
+        LARGE_AC.SetISCodes( 'E', 'D', 'F', 'E', 'D' );
+        LARGE_AC.SetISDates( 2579, 2630, true, 2556, 2865, 3035, true, true );
         LARGE_AC.SetISFactions( "TH", "TH", "TH", "LC" );
         LARGE_AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );
         Owner = e;

--- a/sswlib/src/main/java/states/stEngineISXXL.java
+++ b/sswlib/src/main/java/states/stEngineISXXL.java
@@ -51,12 +51,12 @@ public class stEngineISXXL implements ifEngine, ifState {
     private Engine Owner;
 
     public stEngineISXXL( Engine e ) {
-        AC.SetISCodes( 'F', 'X', 'X', 'F' );
-        AC.SetISDates( 2582, 3055, true, 3055, 0, 0, false, false );
+        AC.SetISCodes( 'F', 'X', 'X', 'F', 'E' );
+        AC.SetISDates( 2582, 3055, true, 3110, 0, 0, false, false );
         AC.SetISFactions( "TH", "FC", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );
-        LARGE_AC.SetISCodes( 'F', 'X', 'X', 'F' );
-        LARGE_AC.SetISDates( 2582, 3055, true, 3055, 0, 0, false, false );
+        LARGE_AC.SetISCodes( 'F', 'X', 'X', 'F', 'E' );
+        LARGE_AC.SetISDates( 2582, 3055, true, 3110, 0, 0, false, false );
         LARGE_AC.SetISFactions( "TH", "FC", "", "" );
         LARGE_AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_EXPERIMENTAL );
         Owner = e;

--- a/sswlib/src/main/java/states/stEngineNone.java
+++ b/sswlib/src/main/java/states/stEngineNone.java
@@ -41,17 +41,17 @@ public class stEngineNone implements ifEngine, ifState {
     private Engine Owner;
 
     public stEngineNone( Engine e ) {
-        AC.SetISCodes( 'C', 'A', 'A', 'A' );
+        AC.SetISCodes( 'C', 'A', 'A', 'A', 'A' );
         AC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetISFactions( "", "", "PS", "" );
-        AC.SetCLCodes( 'C', 'X', 'A', 'A' );
+        AC.SetCLCodes( 'C', 'X', 'A', 'A', 'A' );
         AC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetCLFactions( "", "", "PS", "" );
         AC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_INTRODUCTORY, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
-        LARGE_AC.SetISCodes( 'C', 'A', 'A', 'A' );
+        LARGE_AC.SetISCodes( 'C', 'A', 'A', 'A', 'A' );
         LARGE_AC.SetISDates( 2550, 2630, true, 2630, 0, 0, false, false );
         LARGE_AC.SetISFactions( "PS", "PS", "", "" );
-        LARGE_AC.SetCLCodes( 'C', 'X', 'A', 'A' );
+        LARGE_AC.SetCLCodes( 'C', 'X', 'A', 'A', 'A' );
         LARGE_AC.SetCLDates( 2550, 2630, true, 2630, 0, 0, false, false );
         LARGE_AC.SetCLFactions( "PS", "PS", "", "" );
         LARGE_AC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stEnginePrimitiveFission.java
+++ b/sswlib/src/main/java/states/stEnginePrimitiveFission.java
@@ -46,10 +46,11 @@ public class stEnginePrimitiveFission implements ifEngine, ifState {
     private final static int[] BFStructure = {1,1,2,2,3,3,3,4,4,5,5,5,6,6,6,7,7,8,8};
 
     public stEnginePrimitiveFission() {
-        AC.SetISCodes( 'D', 'E', 'E', 'D' );
+        // IO page 122 overrides the UAT for primitive components
+        AC.SetISCodes( 'D', 'C', 'F', 'E', 'F' );
         AC.SetISDates( 0, 0, false, 1960, 0, 0, false, false );
         AC.SetISFactions( "", "", "ES", "" );
-        AC.SetCLCodes( 'D', 'X', 'E', 'D' );
+        AC.SetCLCodes( 'D', 'X', 'F', 'E', 'F' );
         AC.SetCLDates( 0, 0, false, 1960, 0, 0, false, false );
         AC.SetCLFactions( "", "", "ES", "" );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/states/stEnginePrimitiveFuelCell.java
+++ b/sswlib/src/main/java/states/stEnginePrimitiveFuelCell.java
@@ -46,10 +46,11 @@ public class stEnginePrimitiveFuelCell implements ifEngine, ifState {
     private final static int[] BFStructure = {1,1,2,2,3,3,3,4,4,5,5,5,6,6,6,7,7,8,8};
 
     public stEnginePrimitiveFuelCell() {
-        AC.SetISCodes( 'D', 'C', 'D', 'D' );
+        // IO page 122 overrides the UAT for primitive components
+        AC.SetISCodes( 'D', 'C', 'F', 'E', 'F' );
         AC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetISFactions( "", "", "PS", "" );
-        AC.SetCLCodes( 'D', 'X', 'C', 'D' );
+        AC.SetCLCodes( 'D', 'X', 'F', 'E', 'F' );
         AC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetCLFactions( "", "", "PS", "" );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/states/stEnginePrimitiveFusion.java
+++ b/sswlib/src/main/java/states/stEnginePrimitiveFusion.java
@@ -45,10 +45,11 @@ public class stEnginePrimitiveFusion implements ifEngine, ifState {
     private final static int[] BFStructure = {1,1,2,2,3,3,3,4,4,5,5,5,6,6,6,7,7,8,8};
     
     public stEnginePrimitiveFusion() {
-        AC.SetISCodes( 'D', 'C', 'E', 'D' );
+        // IO page 122 overrides the UAT for primitive components
+        AC.SetISCodes( 'D', 'C', 'F', 'E', 'F' );
         AC.SetISDates( 0, 0, false, 2021, 0, 0, false, false );
         AC.SetISFactions( "", "", "WA", "" );
-        AC.SetCLCodes( 'D', 'X', 'B', 'C' );
+        AC.SetCLCodes( 'D', 'X', 'F', 'E', 'F' );
         AC.SetCLDates( 0, 0, false, 2021, 0, 0, false, false );
         AC.SetCLFactions( "", "", "WA", "" );
         AC.SetPBMAllowed( true );

--- a/sswlib/src/main/java/states/stEnginePrimitiveICE.java
+++ b/sswlib/src/main/java/states/stEnginePrimitiveICE.java
@@ -49,7 +49,7 @@ public class stEnginePrimitiveICE implements ifEngine, ifState {
         AC.SetISCodes( 'D', 'C', 'F', 'E', 'F' );
         AC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetISFactions( "", "", "PS", "" );
-        AC.SetCLCodes( 'D', 'C', 'F', 'E', 'F' );
+        AC.SetCLCodes( 'D', 'X', 'F', 'E', 'F' );
         AC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetCLFactions( "", "", "PS", "" );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/states/stEnginePrimitiveICE.java
+++ b/sswlib/src/main/java/states/stEnginePrimitiveICE.java
@@ -45,10 +45,11 @@ public class stEnginePrimitiveICE implements ifEngine, ifState {
     private final static int[] BFStructure = {1,1,2,2,3,3,3,4,4,5,5,5,6,6,6,7,7,8,8};
 
     public stEnginePrimitiveICE() {
-        AC.SetISCodes( 'C', 'A', 'A', 'A' );
+        // IO page 122 overrides the UAT for primitive components
+        AC.SetISCodes( 'D', 'C', 'F', 'E', 'F' );
         AC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetISFactions( "", "", "PS", "" );
-        AC.SetCLCodes( 'C', 'X', 'A', 'A' );
+        AC.SetCLCodes( 'D', 'C', 'F', 'E', 'F' );
         AC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetCLFactions( "", "", "PS", "" );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/states/stGyroISCompact.java
+++ b/sswlib/src/main/java/states/stGyroISCompact.java
@@ -35,7 +35,7 @@ public class stGyroISCompact implements ifGyro, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stGyroISCompact() {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 3068, 0, 0, false, false );
         AC.SetISFactions( "", "", "FS", "" );
         AC.SetSuperHeavyCompatible( false );

--- a/sswlib/src/main/java/states/stGyroISHeavy.java
+++ b/sswlib/src/main/java/states/stGyroISHeavy.java
@@ -35,8 +35,8 @@ public class stGyroISHeavy implements ifGyro, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stGyroISHeavy() {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
-        AC.SetISDates( 0, 0, false, 3067, 0, 0, false, false );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
+        AC.SetISDates( 0, 0, false, 3068, 0, 0, false, false );
         AC.SetISFactions( "", "", "DC", "" );
         AC.SetSuperHeavyCompatible( false );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stGyroISSuperHeavy.java
+++ b/sswlib/src/main/java/states/stGyroISSuperHeavy.java
@@ -35,7 +35,7 @@ public class stGyroISSuperHeavy implements ifGyro, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stGyroISSuperHeavy() {
-        AC.SetISCodes( 'X', 'F', 'F', 'F' );
+        AC.SetISCodes( 'D', 'X', 'F', 'F', 'F' );
         AC.SetISDates( 0, 0, false, 2940, 0, 0, false, false );
         AC.SetISFactions( "", "", "", "" );
         AC.SetSuperHeavyCompatible( true );

--- a/sswlib/src/main/java/states/stGyroISXL.java
+++ b/sswlib/src/main/java/states/stGyroISXL.java
@@ -35,7 +35,7 @@ public class stGyroISXL implements ifGyro, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stGyroISXL() {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 3067, 0, 0, false, false );
         AC.SetISFactions( "", "", "CS", "" );
         AC.SetSuperHeavyCompatible( false );

--- a/sswlib/src/main/java/states/stGyroNone.java
+++ b/sswlib/src/main/java/states/stGyroNone.java
@@ -35,7 +35,7 @@ public class stGyroNone implements ifGyro, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stGyroNone() {
-        AC.SetISCodes( 'E', 'X', 'X', 'F' );
+        AC.SetISCodes( 'E', 'X', 'X', 'F', 'X' );
         AC.SetISDates( 0, 0, false, 2300, 0, 0, false, false );
         AC.SetISFactions( "", "", "WB", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stGyroStandard.java
+++ b/sswlib/src/main/java/states/stGyroStandard.java
@@ -35,11 +35,11 @@ public class stGyroStandard implements ifGyro, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public stGyroStandard() {
-        AC.SetISCodes( 'D', 'C', 'C', 'C' );
-        AC.SetISDates( 0, 0, false, 2443, 0, 0, false, false );
+        AC.SetISCodes( 'D', 'C', 'C', 'C', 'C' );
+        AC.SetISDates( 0, 0, false, 2350, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'D', 'X', 'B', 'B' );
-        AC.SetCLDates( 0, 0, false, 2443, 0, 0, false, false );
+        AC.SetCLCodes( 'D', 'C', 'C', 'C', 'C' );
+        AC.SetCLDates( 0, 0, false, 2350, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/states/stGyroStandard.java
+++ b/sswlib/src/main/java/states/stGyroStandard.java
@@ -38,7 +38,7 @@ public class stGyroStandard implements ifGyro, ifState {
         AC.SetISCodes( 'D', 'C', 'C', 'C', 'C' );
         AC.SetISDates( 0, 0, false, 2350, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'D', 'C', 'C', 'C', 'C' );
+        AC.SetCLCodes( 'D', 'X', 'C', 'C', 'C' );
         AC.SetCLDates( 0, 0, false, 2350, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );

--- a/sswlib/src/main/java/states/stHeatSinkCLDHS.java
+++ b/sswlib/src/main/java/states/stHeatSinkCLDHS.java
@@ -37,8 +37,8 @@ public class stHeatSinkCLDHS implements ifHeatSinkFactory, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_CLAN );
 
     public stHeatSinkCLDHS() {
-        AC.SetCLCodes( 'E', 'X', 'B', 'C' );
-        AC.SetCLDates( 0, 0, false, 2567, 0, 0, false, false );
+        AC.SetCLCodes( 'F', 'X', 'E', 'D', 'C' );
+        AC.SetCLDates( 0, 0, false, 2827, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
     }

--- a/sswlib/src/main/java/states/stHeatSinkCLLaser.java
+++ b/sswlib/src/main/java/states/stHeatSinkCLLaser.java
@@ -37,7 +37,7 @@ public class stHeatSinkCLLaser implements ifHeatSinkFactory, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_CLAN );
 
     public stHeatSinkCLLaser() {
-        AC.SetCLCodes( 'F', 'X', 'X', 'E' );
+        AC.SetCLCodes( 'F', 'X', 'X', 'E', 'D' );
         AC.SetCLDates( 0, 0, false, 3051, 0, 0, false, false );
         AC.SetCLFactions( "", "", "CJF", "" );
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stHeatSinkISCompact.java
+++ b/sswlib/src/main/java/states/stHeatSinkISCompact.java
@@ -36,8 +36,8 @@ public class stHeatSinkISCompact implements ifHeatSinkFactory, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stHeatSinkISCompact() {
-        AC.SetISCodes( 'E', 'X', 'X', 'F' );
-        AC.SetISDates( 3056, 3058, true, 3058, 0, 0, false, false );
+        AC.SetISCodes( 'E', 'X', 'X', 'F', 'E' );
+        AC.SetISDates( 3056, 3058, true, 3079, 0, 0, false, false );
         AC.SetISFactions( "FS", "FS", "", "" );
         AC.SetRulesLevels( AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
     }

--- a/sswlib/src/main/java/states/stHeatSinkISDHS.java
+++ b/sswlib/src/main/java/states/stHeatSinkISDHS.java
@@ -37,7 +37,7 @@ public class stHeatSinkISDHS implements ifHeatSinkFactory, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stHeatSinkISDHS() {
-        AC.SetISCodes( 'E', 'C', 'E', 'D' );
+        AC.SetISCodes( 'E', 'C', 'E', 'D', 'C' );
         AC.SetISDates( 0, 0, false, 2567, 2865, 3040, true, true );
         AC.SetISFactions( "", "", "TH", "FS" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stHeatSinkSingle.java
+++ b/sswlib/src/main/java/states/stHeatSinkSingle.java
@@ -36,10 +36,10 @@ public class stHeatSinkSingle implements ifHeatSinkFactory, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public stHeatSinkSingle() {
-        AC.SetISCodes( 'C', 'B', 'B', 'B' );
+        AC.SetISCodes( 'C', 'B', 'B', 'B', 'B' );
         AC.SetISDates( 0, 0, false, 2022, 0, 0, false, false );
         AC.SetISFactions( "", "", "WA", "" );
-        AC.SetCLCodes( 'C', 'X', 'A', 'A' );
+        AC.SetCLCodes( 'C', 'B', 'B', 'B', 'B' );
         AC.SetCLDates( 0, 0, false, 2022, 0, 0, false, false );
         AC.SetCLFactions( "", "", "WA", "" );
         AC.SetPBMAllowed( true );

--- a/sswlib/src/main/java/states/stHeatSinkSingle.java
+++ b/sswlib/src/main/java/states/stHeatSinkSingle.java
@@ -37,10 +37,10 @@ public class stHeatSinkSingle implements ifHeatSinkFactory, ifState {
 
     public stHeatSinkSingle() {
         AC.SetISCodes( 'C', 'B', 'B', 'B', 'B' );
-        AC.SetISDates( 0, 0, false, 2022, 0, 0, false, false );
+        AC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetISFactions( "", "", "WA", "" );
-        AC.SetCLCodes( 'C', 'B', 'B', 'B', 'B' );
-        AC.SetCLDates( 0, 0, false, 2022, 0, 0, false, false );
+        AC.SetCLCodes( 'C', 'X', 'B', 'B', 'B' );
+        AC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetCLFactions( "", "", "WA", "" );
         AC.SetPBMAllowed( true );
         AC.SetPIMAllowed( true );

--- a/sswlib/src/main/java/states/stJumpJetImproved.java
+++ b/sswlib/src/main/java/states/stJumpJetImproved.java
@@ -36,10 +36,10 @@ public class stJumpJetImproved implements ifJumpJetFactory, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public stJumpJetImproved() {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
-        AC.SetISDates( 0, 0, false, 3069, 0, 0, false, false );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
+        AC.SetISDates( 0, 0, false, 3070, 0, 0, false, false );
         AC.SetISFactions( "", "", "CWX", "" );
-        AC.SetCLCodes( 'E', 'X', 'X', 'D' );
+        AC.SetCLCodes( 'E', 'X', 'X', 'E', 'D' );
         AC.SetCLDates( 0, 0, false, 3069, 0, 0, false, false );
         AC.SetCLFactions( "", "", "CWF", "" );
         AC.SetSuperHeavyCompatible( false );

--- a/sswlib/src/main/java/states/stJumpJetStandard.java
+++ b/sswlib/src/main/java/states/stJumpJetStandard.java
@@ -39,7 +39,7 @@ public class stJumpJetStandard implements ifJumpJetFactory, ifState {
         AC.SetISCodes( 'D', 'C', 'C', 'C', 'C' );
         AC.SetISDates( 0, 0, false, 2471, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'D', 'C', 'C', 'C', 'C' );
+        AC.SetCLCodes( 'D', 'X', 'C', 'C', 'C' );
         AC.SetCLDates( 0, 0, false, 2471, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );

--- a/sswlib/src/main/java/states/stJumpJetStandard.java
+++ b/sswlib/src/main/java/states/stJumpJetStandard.java
@@ -36,10 +36,10 @@ public class stJumpJetStandard implements ifJumpJetFactory, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public stJumpJetStandard() {
-        AC.SetISCodes( 'D', 'C', 'C', 'C' );
+        AC.SetISCodes( 'D', 'C', 'C', 'C', 'C' );
         AC.SetISDates( 0, 0, false, 2471, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'D', 'X', 'B', 'B' );
+        AC.SetCLCodes( 'D', 'C', 'C', 'C', 'C' );
         AC.SetCLDates( 0, 0, false, 2471, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );

--- a/sswlib/src/main/java/states/stJumpJetUMU.java
+++ b/sswlib/src/main/java/states/stJumpJetUMU.java
@@ -36,10 +36,10 @@ public class stJumpJetUMU implements ifJumpJetFactory, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public stJumpJetUMU() {
-        AC.SetISCodes( 'E', 'X', 'X', 'E' );
-        AC.SetISDates( 3062, 3066, true, 3066, 0, 0, false, false );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
+        AC.SetISDates( 3062, 3066, true, 3062, 0, 0, false, false );
         AC.SetISFactions( "LA", "LA", "", "" );
-        AC.SetCLCodes( 'E', 'X', 'X', 'E' );
+        AC.SetCLCodes( 'E', 'X', 'X', 'E', 'D' );
         AC.SetCLDates( 3057, 3061, true, 3061, 0, 0, false, false );
         AC.SetCLFactions( "CGS", "CGS", "", "" );
         AC.SetSuperHeavyCompatible( false );

--- a/sswlib/src/main/java/states/stPECLMASC.java
+++ b/sswlib/src/main/java/states/stPECLMASC.java
@@ -37,8 +37,8 @@ public class stPECLMASC implements ifPhysEnhance, ifState {
     private final MechModifier MechMod = new MechModifier( 0, 0, 0, 0.5f, 0, 0, 0, 0.0f, 0.0f, 0.0f, 0.0f, true, false );
 
     public stPECLMASC() {
-        AC.SetCLCodes( 'E', 'X', 'C', 'D' );
-        AC.SetCLDates( 0, 0, false, 2740, 0, 0, false, false );
+        AC.SetCLCodes( 'F', 'X', 'F', 'E', 'D' );
+        AC.SetCLDates( 0, 0, false, 2827, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
     }

--- a/sswlib/src/main/java/states/stPEISITSM.java
+++ b/sswlib/src/main/java/states/stPEISITSM.java
@@ -36,7 +36,7 @@ public class stPEISITSM implements ifPhysEnhance, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
 
     public stPEISITSM() {
-        AC.SetISCodes( 'E', 'X', 'F', 'E' );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 3045, 0, 0, false, false );
         AC.SetISFactions( "", "", "FC", "" );
         AC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stPEISMASC.java
+++ b/sswlib/src/main/java/states/stPEISMASC.java
@@ -37,7 +37,7 @@ public class stPEISMASC implements ifPhysEnhance, ifState {
     private final MechModifier MechMod = new MechModifier( 0, 0, 0, 0.5f, 0, 0, 0, 0.0f, 0.0f, 0.0f, 0.0f, true, false );
 
     public stPEISMASC() {
-        AC.SetISCodes( 'E', 'D', 'F', 'E' );
+        AC.SetISCodes( 'E', 'D', 'F', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 2740, 2795, 3035, true, true );
         AC.SetISFactions( "", "", "TH", "CC" );
         AC.SetSuperHeavyCompatible( false );

--- a/sswlib/src/main/java/states/stPEISTSM.java
+++ b/sswlib/src/main/java/states/stPEISTSM.java
@@ -37,8 +37,8 @@ public class stPEISTSM implements ifPhysEnhance, ifState {
     private final MechModifier MechMod = new MechModifier( 1, 0, 0, 0.0f, 0, 0, 0, 0.0f, 0.0f, 0.0f, 0.0f, true, false );
 
     public stPEISTSM() {
-        AC.SetISCodes( 'E', 'X', 'X', 'D' );
-        AC.SetISDates( 0, 0, false, 3050, 0, 0, false, false );
+        AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
+        AC.SetISDates( 0, 0, false, 3045, 0, 0, false, false );
         AC.SetISFactions( "", "", "CC", "" );
         AC.SetSuperHeavyCompatible( false );
         AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stPENone.java
+++ b/sswlib/src/main/java/states/stPENone.java
@@ -36,10 +36,10 @@ public class stPENone implements ifPhysEnhance, ifState {
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
 
     public stPENone() {
-        AC.SetISCodes( 'A', 'A', 'A', 'A' );
+        AC.SetISCodes( 'A', 'A', 'A', 'A', 'A' );
         AC.SetISDates( 0, 0, false, 2443, 0, 0, false, false );
         AC.SetISFactions( "", "", "TH", "" );
-        AC.SetCLCodes( 'A', 'X', 'A', 'A' );
+        AC.SetCLCodes( 'A', 'X', 'A', 'A', 'A' );
         AC.SetCLDates( 0, 0, false, 2443, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );
         AC.SetPBMAllowed( true );


### PR DESCRIPTION
This PR addresses #8 by implementing Dark Age availability codes for all existing components. The UIs for SSW and SAW have also been updated to include this information.