### PR TITLE
Implement missing ACs on SAW summary pane

### DIFF
--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -5142,9 +5142,12 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         txtSumPATons.setText( "" + CurVee.GetLoadout().GetPowerAmplifier().GetTonnage() );
         txtSumIntAV.setText( CurVee.GetIntStruc().GetAvailability().GetBestCombinedCode() );
         txtSumEngAV.setText( CurVee.GetEngine().GetAvailability().GetBestCombinedCode() );
-//        txtSumConAV.setText( locArmor.GetCockpit().GetAvailability().GetBestCombinedCode() );
+        txtSumLifAV.setText( "D/B-B-B-B" );
+        txtSumConAV.setText( "C/A-A-A-A" );
         txtSumHSAV.setText( CurVee.GetHeatSinks().GetAvailability().GetBestCombinedCode() );
+        txtSumArmAV.setText(CurVee.GetArmor().GetAvailability().GetBestCombinedCode() );
         txtSumJJAV.setText( CurVee.GetJumpJets().GetAvailability().GetBestCombinedCode() );
+        txtSumSpnAV.setText( "B/F-F-F-D" );
         txtSumPAAV.setText( CurVee.GetLoadout().GetPowerAmplifier().GetAvailability().GetBestCombinedCode() );
         txtInfoFreeCrits.setText( "Space: " + CurVee.GetAvailableSlots() );
         txtSumHSTons.setText("" + CurVee.GetHeatSinks().GetTonnage() );

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -5100,9 +5100,12 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         txtSumPATons.setText( "" + CurVee.GetLoadout().GetPowerAmplifier().GetTonnage() );
         txtSumIntAV.setText( CurVee.GetIntStruc().GetAvailability().GetBestCombinedCode() );
         txtSumEngAV.setText( CurVee.GetEngine().GetAvailability().GetBestCombinedCode() );
-//        txtSumConAV.setText( locArmor.GetCockpit().GetAvailability().GetBestCombinedCode() );
+        txtSumLifAV.setText( "D/B-B-B-B" );
+        txtSumConAV.setText( "C/A-A-A-A" );
         txtSumHSAV.setText( CurVee.GetHeatSinks().GetAvailability().GetBestCombinedCode() );
+        txtSumArmAV.setText(CurVee.GetArmor().GetAvailability().GetBestCombinedCode() );
         txtSumJJAV.setText( CurVee.GetJumpJets().GetAvailability().GetBestCombinedCode() );
+        txtSumSpnAV.setText( "B/F-F-F-D" );
         txtSumPAAV.setText( CurVee.GetLoadout().GetPowerAmplifier().GetAvailability().GetBestCombinedCode() );
         txtInfoFreeCrits.setText( "Space: " + CurVee.GetAvailableSlots() );
         txtSumHSTons.setText("" + CurVee.GetHeatSinks().GetTonnage() );


### PR DESCRIPTION
Currently SAW has hardcoded values of "X/X-X-X" for a few items in the summary pane:

![Screenshot_20190928_002049](https://user-images.githubusercontent.com/5447759/65811402-64e49200-e1a7-11e9-82ea-c7d13a8503b8.png)

This PR dynamically calculates the AC for the armor and uses universal codes for the others as outlined in Interstellar Operations.