### PR TITLE
Fix booby trap not being exported in txt/html formats

### DIFF
--- a/ssw/src/main/java/ssw/filehandlers/HTMLWriter.java
+++ b/ssw/src/main/java/ssw/filehandlers/HTMLWriter.java
@@ -1196,6 +1196,9 @@ public class HTMLWriter {
             if( CurMech.GetLoadout().HasSupercharger() ) {
                 ret.add( CurMech.GetLoadout().GetSupercharger() );
             }
+            if( CurMech.GetLoadout().HasBoobyTrap() ) {
+                ret.add( CurMech.GetLoadout().GetBoobyTrap() );
+            }
             if( CurMech.GetLoadout().HasHDTurret() ) {
                 ret.add( CurMech.GetLoadout().GetHDTurret() );
             }

--- a/sswlib/src/main/java/filehandlers/TXTWriter.java
+++ b/sswlib/src/main/java/filehandlers/TXTWriter.java
@@ -613,6 +613,9 @@ public class TXTWriter {
         if( CurMech.GetLoadout().HasSupercharger() ) {
             v.add( CurMech.GetLoadout().GetSupercharger() );
         }
+        if( CurMech.GetLoadout().HasBoobyTrap() ) {
+            v.add( CurMech.GetLoadout().GetBoobyTrap() );
+        }
         if( CurMech.IsQuad() ) {
             if( CurMech.HasLegAES() ) {
                 v.add( CurMech.GetRAAES() );


### PR DESCRIPTION
Closes #33 by exporting the booby trap in the TXT and HTML writer implementations. This causes it to appear correctly in all of the TXT export options, the "Show Text TRO Format" dialog, and the HTML export options. Let me know if there is anywhere else I missed where it still doesn't show up.