### PR TITLE
Fix error with voidsig BV calculation

### DIFF
--- a/sswlib/src/main/java/components/Mech.java
+++ b/sswlib/src/main/java/components/Mech.java
@@ -2784,9 +2784,9 @@ public class Mech implements ifUnit, ifBattleforce {
             // GetTotalModifiers currently doesn't account for VoidSig, so ignore it and compare the voidsig bonus to
             // our current tally
             if (retval < 1.3) {
-                retval += 0.3;
+                retval = 1.3;
             } else if (retval == 1.3) {
-                retval += 0.1;
+                retval = 1.4;
             }
         } else {
             retval += m.DefensiveBonus();


### PR DESCRIPTION
When applying errata for the void sig, we forgot to remove the movement modifier when void sig is being used, so a unit with a +2 movement modifier and a void sig was getting a +5 defensive modifier instead of a +3.