### PR TITLE
Fix #101 - Convert Windows filepath separators to unix and vice versa

### DIFF
--- a/sswlib/src/main/java/IO/Utils.java
+++ b/sswlib/src/main/java/IO/Utils.java
@@ -1,0 +1,13 @@
+package IO;
+
+import java.io.File;
+
+public class Utils {
+    public static String convertFilePathSeparator(String path) {
+        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+            return path.replace("/", File.separator);
+        } else {
+            return path.replace("\\", File.separator);
+        }
+    }
+}

--- a/sswlib/src/main/java/list/UnitList.java
+++ b/sswlib/src/main/java/list/UnitList.java
@@ -270,6 +270,7 @@ public class UnitList extends AbstractTableModel {
                             hasData = true;
                             String[] Items = read.split(",");
                             if (Items.length >= 11) {
+                                Items[11] = IO.Utils.convertFilePathSeparator(Items[11]);
                                 List.add(new UnitListData(Items));
                             }
                         }


### PR DESCRIPTION
This PR fixes #101 by converting Windows file path separators to Unix on Unix platforms and Unix file path separators to Windows on Windows platforms when reading the `index.ssi` cache in the SSW-Master folder.  It also adds a new IO.Utils class that we can add static helper methods to later.

Tested on Windows and Linux.