### PR TITLE
Allow newer JDKs to compile Java 8 bytecode

### DIFF
--- a/BFB/build.gradle
+++ b/BFB/build.gradle
@@ -2,6 +2,11 @@ plugins {
     id 'application'
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     compile project(':sswlib')

--- a/binconvert/build.gradle
+++ b/binconvert/build.gradle
@@ -2,6 +2,11 @@ plugins {
     id 'application'
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     compile project(':sswlib')

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ allprojects {
 
 subprojects {
     group 'com.solarisskunkwerks'
-    sourceCompatibility = 1.8
     repositories {
         mavenCentral()
     }

--- a/saw/build.gradle
+++ b/saw/build.gradle
@@ -2,6 +2,11 @@ plugins {
     id 'application'
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     compile project(':sswlib')

--- a/ssw/build.gradle
+++ b/ssw/build.gradle
@@ -2,6 +2,11 @@ plugins {
     id 'application'
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     compile project(':sswlib')

--- a/sswlib/build.gradle
+++ b/sswlib/build.gradle
@@ -2,6 +2,11 @@ plugins {
     id 'java'
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }


### PR DESCRIPTION
This PR adds the `targetCompatibility` and `sourceCompatibility` directives to each project's gradle config so that any JDK >= 1.8 can compile the project and have it emit Java 8 bytecode. This means you can compile SSW on JDK 13 for instance but users with JRE8 can run the application normally.

Tested on Linux with OpenJDK 8, 11, and 13.