### PR TITLE
Escape single quotes in file paths to handle paths containing them

### DIFF
--- a/sswlib/src/main/java/common/CommonTools.java
+++ b/sswlib/src/main/java/common/CommonTools.java
@@ -761,7 +761,7 @@ public class CommonTools {
         s = s.replaceAll(" ", "%20");
         s = s.replaceAll("!", "%21");
         s = s.replaceAll("\"", "");
-        s = s.replaceAll("'", "");
+        s = s.replaceAll("'", "%27");
         s = s.replaceAll("[{(}]", "%28");
         s = s.replaceAll("[{)}]", "%29");
         s = s.replaceAll("[{;}]", "%3B");


### PR DESCRIPTION
sswlib did not correctly handle loading from/saving to file paths containing `'`, which caused `FileNotFoundException`s when it encountered them. Now, instead of simply stripping them out, SSW URL encodes them like it does for other special characters.