### PR TITLE
SAW/sswlib: Implement Sponson Turrets

### DIFF
--- a/saw/src/main/java/saw/gui/frmVee.form
+++ b/saw/src/main/java/saw/gui/frmVee.form
@@ -2273,7 +2273,7 @@
                 </Component>
                 <Component class="javax.swing.JLabel" name="jLabel26">
                   <Properties>
-                    <Property name="text" type="java.lang.String" value="Sponsoons:"/>
+                    <Property name="text" type="java.lang.String" value="Sponsons:"/>
                   </Properties>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">

--- a/saw/src/main/java/saw/gui/frmVee.form
+++ b/saw/src/main/java/saw/gui/frmVee.form
@@ -1645,6 +1645,7 @@
                               <Component id="chkMinesweeper" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="chkCommandConsole" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="chkEscapePod" alignment="0" min="-2" max="-2" attributes="0"/>
+                              <Component id="chkSponsonTurret" alignment="0" min="-2" max="-2" attributes="0"/>
                           </Group>
                           <EmptySpace max="32767" attributes="0"/>
                       </Group>
@@ -1664,6 +1665,8 @@
                           <Component id="chkJetBooster" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="chkEscapePod" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="chkSponsonTurret" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
                       </Group>
                   </Group>
@@ -1690,6 +1693,9 @@
                       <ComponentRef name="chkFractional"/>
                     </Property>
                   </Properties>
+                  <Events>
+                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="chkEscapePodActionPerformed"/>
+                  </Events>
                 </Component>
                 <Component class="javax.swing.JCheckBox" name="chkMinesweeper">
                   <Properties>
@@ -1710,6 +1716,18 @@
                   </Properties>
                   <Events>
                     <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="chkSuperchargerActionPerformed"/>
+                  </Events>
+                </Component>
+                <Component class="javax.swing.JCheckBox" name="chkSponsonTurret">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" value="Sponson Turret"/>
+                    <Property name="enabled" type="boolean" value="false"/>
+                    <Property name="nextFocusableComponent" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+                      <ComponentRef name="chkFractional"/>
+                    </Property>
+                  </Properties>
+                  <Events>
+                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="chkSponsonTurretActionPerformed"/>
                   </Events>
                 </Component>
               </SubComponents>

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -6894,6 +6894,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         BuildChassisSelector();
         BuildEngineSelector();
         BuildArmorSelector();
+        BuildExpEquipmentSelector();
         CheckOmni();
         //cmbEngineType.setSelectedItem( saw.Constants.DEFAULT_ENGINE );
         //cmbArmorType.setSelectedItem( saw.Constants.DEFAULT_ARMOR );
@@ -8883,6 +8884,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         BuildEngineSelector();
         BuildArmorSelector();
         BuildTurretSelector();
+        BuildExpEquipmentSelector();
         cmbEngineType.setSelectedItem( BuildLookupName( CurVee.GetEngine().GetCurrentState() ) );
         cmbArmorType.setSelectedItem( BuildLookupName( CurVee.GetArmor().GetCurrentState() ) );
         SetPatchworkArmor();

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -5220,6 +5220,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         txtTurretInfo.setText("Turret: " + CurVee.GetLoadout().GetTurret().GetTonnage() );
         txtSumRTuTons.setText("" + CurVee.GetLoadout().GetRearTurret().GetTonnage() );
         txtSumRTuAV.setText( CurVee.GetLoadout().GetRearTurret().GetAvailability().GetBestCombinedCode() );
+        txtSumSpnTons.setText("" + CurVee.GetLoadout().GetSponsonTurretTonnage() );
         lblFreeHeatSinks.setText("" + CurVee.GetEngine().FreeHeatSinks() );
         lblNumCrew.setText("" + CurVee.GetCrew() );
 
@@ -5376,7 +5377,11 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         ArrayList locs = new ArrayList();
         locs.add("Front");
         locs.add("Left");
+        if ( CurVee.isHasSponsonTurret() )
+            locs.add("Left Sponson Turret");
         locs.add("Right");
+        if ( CurVee.isHasSponsonTurret() )
+            locs.add("Right Sponson Turret");
         locs.add("Rear");
         locs.add("Body");
         if ( CurVee.isHasTurret1() )
@@ -9754,7 +9759,12 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
     }//GEN-LAST:event_cmbLocationMouseClicked
 
     private void chkSponsonTurretActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_chkSponsonTurretActionPerformed
-        //CurVee.SetSpon;
+        if (chkSponsonTurret.isSelected())
+            CurVee.setHasSponsonTurret(true);
+        else
+            CurVee.setHasSponsonTurret(false);
+        RefreshSelectedEquipment();
+        BuildLocationSelector();
         RefreshSummary();
         RefreshInfoPane();
     }//GEN-LAST:event_chkSponsonTurretActionPerformed

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -1130,6 +1130,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         chkMinesweeper = new javax.swing.JCheckBox();
         chkJetBooster = new javax.swing.JCheckBox();
         chkSupercharger = new javax.swing.JCheckBox();
+        chkSponsonTurret = new javax.swing.JCheckBox();
         jPanel11 = new javax.swing.JPanel();
         chkFractional = new javax.swing.JCheckBox();
         pnlSummary = new javax.swing.JPanel();
@@ -1930,10 +1931,10 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             }
         });
         spnTonnage.addInputMethodListener(new java.awt.event.InputMethodListener() {
-            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
-            }
             public void inputMethodTextChanged(java.awt.event.InputMethodEvent evt) {
                 spnTonnageInputMethodTextChanged(evt);
+            }
+            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
             }
         });
 
@@ -1979,10 +1980,10 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             }
         });
         spnHeatSinks.addInputMethodListener(new java.awt.event.InputMethodListener() {
-            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
-            }
             public void inputMethodTextChanged(java.awt.event.InputMethodEvent evt) {
                 spnHeatSinksInputMethodTextChanged(evt);
+            }
+            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
             }
         });
 
@@ -2092,10 +2093,10 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             }
         });
         spnCruiseMP.addInputMethodListener(new java.awt.event.InputMethodListener() {
-            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
-            }
             public void inputMethodTextChanged(java.awt.event.InputMethodEvent evt) {
                 spnCruiseMPInputMethodTextChanged(evt);
+            }
+            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
             }
         });
 
@@ -2235,6 +2236,11 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         chkEscapePod.setText("Combat Vehicle Escape Pod");
         chkEscapePod.setEnabled(false);
         chkEscapePod.setNextFocusableComponent(chkFractional);
+        chkEscapePod.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                chkEscapePodActionPerformed(evt);
+            }
+        });
 
         chkMinesweeper.setText("Minesweeper");
         chkMinesweeper.setEnabled(false);
@@ -2250,6 +2256,15 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             }
         });
 
+        chkSponsonTurret.setText("Sponson Turret");
+        chkSponsonTurret.setEnabled(false);
+        chkSponsonTurret.setNextFocusableComponent(chkFractional);
+        chkSponsonTurret.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                chkSponsonTurretActionPerformed(evt);
+            }
+        });
+
         javax.swing.GroupLayout pnlExperimentalLayout = new javax.swing.GroupLayout(pnlExperimental);
         pnlExperimental.setLayout(pnlExperimentalLayout);
         pnlExperimentalLayout.setHorizontalGroup(
@@ -2261,7 +2276,8 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
                     .addComponent(chkJetBooster)
                     .addComponent(chkMinesweeper)
                     .addComponent(chkCommandConsole)
-                    .addComponent(chkEscapePod))
+                    .addComponent(chkEscapePod)
+                    .addComponent(chkSponsonTurret))
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         pnlExperimentalLayout.setVerticalGroup(
@@ -2278,6 +2294,8 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
                 .addComponent(chkJetBooster)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(chkEscapePod)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(chkSponsonTurret)
                 .addContainerGap())
         );
 
@@ -5565,6 +5583,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             BuildChassisSelector();
             BuildEngineSelector();
             BuildArmorSelector();
+            BuildExpEquipmentSelector();
             FixMPSpinner();
             FixJJSpinnerModel();
             RefreshEquipment();
@@ -5621,7 +5640,6 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         list.add("No Turret");
         if ( CurVee.CanUseTurret() ) list.add("Single Turret");
         if ( CurVee.CanUseDualTurret() ) list.add("Dual Turret");
-        if ( CurVee.CanUseSponson() ) list.add("Sponson Turret");
 
         if ( list.isEmpty() ) {
             list.add("No Turret Allowed");
@@ -5677,6 +5695,24 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             chkDuneBuggy.setEnabled(false);
             chkEnviroSealing.setEnabled(false);
         }
+    }
+    
+    private void BuildExpEquipmentSelector() {
+        JCheckBox[] ExpEquipmentCheckboxes = { chkArmoredMotive,
+                                               chkSupercharger,
+                                               chkCommandConsole,
+                                               chkMinesweeper,
+                                               chkJetBooster,
+                                               chkEscapePod,
+                                               chkSponsonTurret };
+        if (cmbRulesLevel.getSelectedIndex() > 1) {
+            if (CurVee.CanUseSponson())
+                chkSponsonTurret.setEnabled(true);
+        } else
+            for (JCheckBox item : ExpEquipmentCheckboxes) {
+                item.setSelected(false);
+                item.setEnabled(false);
+            }
     }
 
     private void cmbMotiveTypeActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cmbMotiveTypeActionPerformed
@@ -9717,6 +9753,16 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             btnAddEquipActionPerformed(null);
     }//GEN-LAST:event_cmbLocationMouseClicked
 
+    private void chkSponsonTurretActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_chkSponsonTurretActionPerformed
+        //CurVee.SetSpon;
+        RefreshSummary();
+        RefreshInfoPane();
+    }//GEN-LAST:event_chkSponsonTurretActionPerformed
+
+    private void chkEscapePodActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_chkEscapePodActionPerformed
+        // TODO add your handling code here:
+    }//GEN-LAST:event_chkEscapePodActionPerformed
+
     private void chkFullAmphActionPerformed(java.awt.event.ActionEvent evt) {
         CurVee.SetFullAmphibious(chkFullAmph.isSelected());
         RefreshSummary();
@@ -9854,6 +9900,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
     private javax.swing.JCheckBox chkLimitedAmph;
     private javax.swing.JCheckBox chkMinesweeper;
     private javax.swing.JCheckBox chkOmniVee;
+    private javax.swing.JCheckBox chkSponsonTurret;
     private javax.swing.JCheckBox chkSupercharger;
     private javax.swing.JCheckBox chkTrailer;
     private javax.swing.JCheckBox chkUseTC;

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -2620,7 +2620,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         pnlSummary.add(txtSumRTuAV, gridBagConstraints);
 
-        jLabel26.setText("Sponsoons:");
+        jLabel26.setText("Sponsons:");
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 10;
@@ -5621,7 +5621,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         list.add("No Turret");
         if ( CurVee.CanUseTurret() ) list.add("Single Turret");
         if ( CurVee.CanUseDualTurret() ) list.add("Dual Turret");
-        if ( CurVee.CanUseSponsoon() ) list.add("Sponson Turret");
+        if ( CurVee.CanUseSponson() ) list.add("Sponson Turret");
 
         if ( list.isEmpty() ) {
             list.add("No Turret Allowed");

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -8885,6 +8885,8 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         BuildArmorSelector();
         BuildTurretSelector();
         BuildExpEquipmentSelector();
+        if (CurVee.isHasSponsonTurret())
+            chkSponsonTurret.setSelected(true);
         cmbEngineType.setSelectedItem( BuildLookupName( CurVee.GetEngine().GetCurrentState() ) );
         cmbArmorType.setSelectedItem( BuildLookupName( CurVee.GetArmor().GetCurrentState() ) );
         SetPatchworkArmor();

--- a/saw/src/main/java/saw/gui/frmVeeWide.form
+++ b/saw/src/main/java/saw/gui/frmVeeWide.form
@@ -2286,7 +2286,7 @@
                 </Component>
                 <Component class="javax.swing.JLabel" name="jLabel26">
                   <Properties>
-                    <Property name="text" type="java.lang.String" value="Sponsoons:"/>
+                    <Property name="text" type="java.lang.String" value="Sponsons:"/>
                   </Properties>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">

--- a/saw/src/main/java/saw/gui/frmVeeWide.form
+++ b/saw/src/main/java/saw/gui/frmVeeWide.form
@@ -1658,6 +1658,7 @@
                               <Component id="chkMinesweeper" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="chkCommandConsole" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="chkEscapePod" alignment="0" min="-2" max="-2" attributes="0"/>
+                              <Component id="chkSponsonTurret" alignment="0" min="-2" max="-2" attributes="0"/>
                           </Group>
                           <EmptySpace max="32767" attributes="0"/>
                       </Group>
@@ -1677,6 +1678,8 @@
                           <Component id="chkJetBooster" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="chkEscapePod" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="chkSponsonTurret" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
                       </Group>
                   </Group>
@@ -1723,6 +1726,18 @@
                   </Properties>
                   <Events>
                     <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="chkSuperchargerActionPerformed"/>
+                  </Events>
+                </Component>
+                <Component class="javax.swing.JCheckBox" name="chkSponsonTurret">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" value="Sponson Turret"/>
+                    <Property name="enabled" type="boolean" value="false"/>
+                    <Property name="nextFocusableComponent" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+                      <ComponentRef name="chkFractional"/>
+                    </Property>
+                  </Properties>
+                  <Events>
+                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="chkSponsonTurretActionPerformed"/>
                   </Events>
                 </Component>
               </SubComponents>

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -1121,6 +1121,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         chkMinesweeper = new javax.swing.JCheckBox();
         chkJetBooster = new javax.swing.JCheckBox();
         chkSupercharger = new javax.swing.JCheckBox();
+        chkSponsonTurret = new javax.swing.JCheckBox();
         jPanel11 = new javax.swing.JPanel();
         chkFractional = new javax.swing.JCheckBox();
         pnlSummary = new javax.swing.JPanel();
@@ -1919,10 +1920,10 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             }
         });
         spnTonnage.addInputMethodListener(new java.awt.event.InputMethodListener() {
-            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
-            }
             public void inputMethodTextChanged(java.awt.event.InputMethodEvent evt) {
                 spnTonnageInputMethodTextChanged(evt);
+            }
+            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
             }
         });
 
@@ -1968,10 +1969,10 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             }
         });
         spnHeatSinks.addInputMethodListener(new java.awt.event.InputMethodListener() {
-            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
-            }
             public void inputMethodTextChanged(java.awt.event.InputMethodEvent evt) {
                 spnHeatSinksInputMethodTextChanged(evt);
+            }
+            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
             }
         });
 
@@ -2081,10 +2082,10 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             }
         });
         spnCruiseMP.addInputMethodListener(new java.awt.event.InputMethodListener() {
-            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
-            }
             public void inputMethodTextChanged(java.awt.event.InputMethodEvent evt) {
                 spnCruiseMPInputMethodTextChanged(evt);
+            }
+            public void caretPositionChanged(java.awt.event.InputMethodEvent evt) {
             }
         });
 
@@ -2239,6 +2240,15 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             }
         });
 
+        chkSponsonTurret.setText("Sponson Turret");
+        chkSponsonTurret.setEnabled(false);
+        chkSponsonTurret.setNextFocusableComponent(chkFractional);
+        chkSponsonTurret.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                chkSponsonTurretActionPerformed(evt);
+            }
+        });
+
         javax.swing.GroupLayout pnlExperimentalLayout = new javax.swing.GroupLayout(pnlExperimental);
         pnlExperimental.setLayout(pnlExperimentalLayout);
         pnlExperimentalLayout.setHorizontalGroup(
@@ -2250,7 +2260,8 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
                     .addComponent(chkJetBooster)
                     .addComponent(chkMinesweeper)
                     .addComponent(chkCommandConsole)
-                    .addComponent(chkEscapePod))
+                    .addComponent(chkEscapePod)
+                    .addComponent(chkSponsonTurret))
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         pnlExperimentalLayout.setVerticalGroup(
@@ -2267,6 +2278,8 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
                 .addComponent(chkJetBooster)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(chkEscapePod)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(chkSponsonTurret)
                 .addContainerGap())
         );
 
@@ -4179,7 +4192,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(pnlSelected, javax.swing.GroupLayout.PREFERRED_SIZE, 264, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(pnlEquipInfo, javax.swing.GroupLayout.DEFAULT_SIZE, 544, Short.MAX_VALUE)
+                .addComponent(pnlEquipInfo, javax.swing.GroupLayout.PREFERRED_SIZE, 544, Short.MAX_VALUE)
                 .addContainerGap())
         );
         pnlEquipmentLayout.setVerticalGroup(
@@ -5491,7 +5504,6 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         list.add("No Turret");
         if ( CurVee.CanUseTurret() ) list.add("Single Turret");
         if ( CurVee.CanUseDualTurret() ) list.add("Dual Turret");
-        if ( CurVee.CanUseSponson() ) list.add("Sponson Turret");
 
         if ( list.isEmpty() ) {
             list.add("No Turret Allowed");
@@ -5547,6 +5559,24 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             chkDuneBuggy.setEnabled(false);
             chkEnviroSealing.setEnabled(false);
         }
+    }
+    
+        private void BuildExpEquipmentSelector() {
+        JCheckBox[] ExpEquipmentCheckboxes = { chkArmoredMotive,
+                                               chkSupercharger,
+                                               chkCommandConsole,
+                                               chkMinesweeper,
+                                               chkJetBooster,
+                                               chkEscapePod,
+                                               chkSponsonTurret };
+        if (cmbRulesLevel.getSelectedIndex() > 1) {
+            if (CurVee.CanUseSponson())
+                chkSponsonTurret.setEnabled(true);
+        } else
+            for (JCheckBox item : ExpEquipmentCheckboxes) {
+                item.setSelected(false);
+                item.setEnabled(false);
+            }
     }
 
     private void ShowInfoOn( abPlaceable p ) {
@@ -9707,6 +9737,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             BuildChassisSelector();
             BuildEngineSelector();
             BuildArmorSelector();
+            BuildExpEquipmentSelector();
             FixMPSpinner();
             FixJJSpinnerModel();
             RefreshEquipment();
@@ -9733,6 +9764,10 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         if ( evt.getClickCount() == 2 )
             btnAddEquipActionPerformed(null);
     }//GEN-LAST:event_cmbLocationMouseClicked
+
+    private void chkSponsonTurretActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_chkSponsonTurretActionPerformed
+        // TODO add your handling code here:
+    }//GEN-LAST:event_chkSponsonTurretActionPerformed
     
     private PagePrinter SetupPrinter() {
         PagePrinter printer = new PagePrinter();
@@ -9865,6 +9900,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
     private javax.swing.JCheckBox chkLimitedAmph;
     private javax.swing.JCheckBox chkMinesweeper;
     private javax.swing.JCheckBox chkOmniVee;
+    private javax.swing.JCheckBox chkSponsonTurret;
     private javax.swing.JCheckBox chkSupercharger;
     private javax.swing.JCheckBox chkTrailer;
     private javax.swing.JCheckBox chkUseTC;

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -6227,6 +6227,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         BuildChassisSelector();
         BuildEngineSelector();
         BuildArmorSelector();
+        BuildExpEquipmentSelector();
         CheckOmni();
         //cmbEngineType.setSelectedItem( saw.Constants.DEFAULT_ENGINE );
         //cmbArmorType.setSelectedItem( saw.Constants.DEFAULT_ARMOR );
@@ -7092,6 +7093,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         BuildEngineSelector();
         BuildArmorSelector();
         BuildTurretSelector();
+        BuildExpEquipmentSelector();
         cmbEngineType.setSelectedItem( BuildLookupName( CurVee.GetEngine().GetCurrentState() ) );
         cmbArmorType.setSelectedItem( BuildLookupName( CurVee.GetArmor().GetCurrentState() ) );
         SetPatchworkArmor();

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -7094,6 +7094,8 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         BuildArmorSelector();
         BuildTurretSelector();
         BuildExpEquipmentSelector();
+        if (CurVee.isHasSponsonTurret())
+            chkSponsonTurret.setSelected(true);
         cmbEngineType.setSelectedItem( BuildLookupName( CurVee.GetEngine().GetCurrentState() ) );
         cmbArmorType.setSelectedItem( BuildLookupName( CurVee.GetArmor().GetCurrentState() ) );
         SetPatchworkArmor();

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -5172,6 +5172,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         txtTurretInfo.setText("Turret: " + CurVee.GetLoadout().GetTurret().GetTonnage() );
         txtSumRTuTons.setText("" + CurVee.GetLoadout().GetRearTurret().GetTonnage() );
         txtSumRTuAV.setText( CurVee.GetLoadout().GetRearTurret().GetAvailability().GetBestCombinedCode() );
+        txtSumSpnTons.setText("" + CurVee.GetLoadout().GetSponsonTurretTonnage() );
         lblFreeHeatSinks.setText("" + CurVee.GetEngine().FreeHeatSinks() );
         lblNumCrew.setText("" + CurVee.GetCrew() );
 
@@ -5328,7 +5329,11 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         ArrayList locs = new ArrayList();
         locs.add("Front");
         locs.add("Left");
+        if ( CurVee.isHasSponsonTurret() )
+            locs.add("Left Sponson Turret");
         locs.add("Right");
+        if ( CurVee.isHasSponsonTurret() )
+            locs.add("Right Sponson Turret");
         locs.add("Rear");
         locs.add("Body");
         if ( CurVee.isHasTurret1() )
@@ -9766,7 +9771,12 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
     }//GEN-LAST:event_cmbLocationMouseClicked
 
     private void chkSponsonTurretActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_chkSponsonTurretActionPerformed
-        // TODO add your handling code here:
+        if (chkSponsonTurret.isSelected())
+            CurVee.setHasSponsonTurret(true);
+        else
+            CurVee.setHasSponsonTurret(false);
+        RefreshSelectedEquipment();
+        BuildLocationSelector();
     }//GEN-LAST:event_chkSponsonTurretActionPerformed
     
     private PagePrinter SetupPrinter() {

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -2609,7 +2609,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         pnlSummary.add(txtSumRTuAV, gridBagConstraints);
 
-        jLabel26.setText("Sponsoons:");
+        jLabel26.setText("Sponsons:");
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 10;
@@ -5491,7 +5491,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         list.add("No Turret");
         if ( CurVee.CanUseTurret() ) list.add("Single Turret");
         if ( CurVee.CanUseDualTurret() ) list.add("Dual Turret");
-        if ( CurVee.CanUseSponsoon() ) list.add("Sponson Turret");
+        if ( CurVee.CanUseSponson() ) list.add("Sponson Turret");
 
         if ( list.isEmpty() ) {
             list.add("No Turret Allowed");

--- a/sswlib/src/main/java/Print/PrintConsts.java
+++ b/sswlib/src/main/java/Print/PrintConsts.java
@@ -406,6 +406,10 @@ public class PrintConsts {
         Data.addAll(HandleLocation( CurUnit, MiniConvRate, a, LocationIndex.CV_LOC_TURRET1));
         a = CurUnit.GetLoadout().GetTurret2Items().toArray(a);
         Data.addAll(HandleLocation( CurUnit, MiniConvRate, a, LocationIndex.CV_LOC_TURRET2));
+        a = CurUnit.GetLoadout().GetSponsonTurretLeftItems().toArray(a);
+        Data.addAll(HandleLocation( CurUnit, MiniConvRate, a, LocationIndex.CV_LOC_SPONSON_LEFT));
+        a = CurUnit.GetLoadout().GetSponsonTurretRightItems().toArray(a);
+        Data.addAll(HandleLocation( CurUnit, MiniConvRate, a, LocationIndex.CV_LOC_SPONSON_RIGHT));
         
         return Data;
     }

--- a/sswlib/src/main/java/components/CVArmor.java
+++ b/sswlib/src/main/java/components/CVArmor.java
@@ -41,8 +41,8 @@ public class CVArmor extends abPlaceable {
 
     // Declares
     private CombatVehicle Owner;
-    private int[] ArmorPoints = { 0, 0, 0, 0, 0, 0, 0, 0 };
-    private int[] MaxArmor = { 390, 390, 390, 390, 390, 390, 2, 390 };
+    private int[] ArmorPoints = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    private int[] MaxArmor = { 390, 390, 390, 390, 390, 390, 0, 0, 2, 390 };
     private ifArmor Industrial = new stArmorIN(),
                     Standard = new stArmorMS(),
                     ISFF = new stArmorISFF(),

--- a/sswlib/src/main/java/components/CVLoadout.java
+++ b/sswlib/src/main/java/components/CVLoadout.java
@@ -53,6 +53,8 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
                                 Turret1Items = new ArrayList<abPlaceable>(),
                                 RotorItems = new ArrayList<abPlaceable>(),
                                 Turret2Items = new ArrayList<abPlaceable>(),
+                                SponsonTurretLeftItems = new ArrayList<abPlaceable>(),
+                                SponsonTurretRightItems = new ArrayList<abPlaceable>(),
                                 BodyItems = new ArrayList<abPlaceable>(),
                                 NonCore = new ArrayList<abPlaceable>(),
                                 TCList = new ArrayList<abPlaceable>();
@@ -68,7 +70,9 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
                     YearSpecified = false,
                     YearRestricted = false;
     private Turret Turret1 = new Turret(this, false),
-                    Turret2 = new Turret(this, false);
+                   Turret2 = new Turret(this, false);
+    private SponsonTurret SponsonTurretLeft = new SponsonTurret(this, false),
+                          SponsonTurretRight = new SponsonTurret(this, false);
     private CVPowerAmplifier PowerAmplifier = new CVPowerAmplifier(this);
     
     private int RulesLevel = AvailableCode.RULES_TOURNAMENT,
@@ -210,6 +214,8 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
         all.addAll(RearItems);
         all.addAll(Turret1Items);
         all.addAll(Turret2Items);
+        all.addAll(SponsonTurretLeftItems);
+        all.addAll(SponsonTurretRightItems);
         all.addAll(BodyItems);
         all.addAll(Queue);
         return all;
@@ -239,6 +245,8 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
         Turret1Items = new ArrayList<abPlaceable>();
         RotorItems = new ArrayList<abPlaceable>();
         Turret2Items = new ArrayList<abPlaceable>();
+        SponsonTurretLeftItems = new ArrayList<abPlaceable>();
+        SponsonTurretRightItems = new ArrayList<abPlaceable>();
         BodyItems = new ArrayList<abPlaceable>();
         NonCore = new ArrayList<abPlaceable>();
         TCList = new ArrayList<abPlaceable>();
@@ -260,6 +268,8 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
         Items.add(BodyItems);
         Items.add(Turret1Items);
         Items.add(Turret2Items);
+        Items.add(SponsonTurretLeftItems);
+        Items.add(SponsonTurretRightItems);
         
         ArrayList<abPlaceable> remove = new ArrayList<abPlaceable>();
         
@@ -358,6 +368,20 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
                     Turret2Items.add(p);
                 else
                     throw new Exception(p.ActualName() + " cannot be allocated to the Rear Turret.");
+                break;
+            case LocationIndex.CV_LOC_SPONSON_LEFT:
+                if ( p.CanAllocCVTurret() ) {
+                    SponsonTurretLeftItems.add(p);
+                } else
+                    throw new Exception(p.ActualName() + " cannot be allocated to the Sponson Turret.");
+
+                break;
+            case LocationIndex.CV_LOC_SPONSON_RIGHT:
+                if ( p.CanAllocCVTurret() ) {
+                    SponsonTurretRightItems.add(p);
+                } else
+                    throw new Exception(p.ActualName() + " cannot be allocated to the Sponson Turret.");
+
                 break;
             default:
                 throw new Exception( "Location not recognized or not an integer\nwhile placing " + p.CritName() );
@@ -468,6 +492,22 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
             throw new Exception(p.ActualName() + " cannot be allocated to the Turret.");
     }
 
+    public void AddToSponsonTurretLeft(abPlaceable p) throws Exception {
+        if ( p.CanAllocCVTurret() ) {
+            AddTo(p, LocationIndex.CV_LOC_SPONSON_LEFT);
+            Owner.SetChanged( true );
+        } else
+            throw new Exception(p.ActualName() + " cannot be allocated to the Sponson Turret.");
+    }
+
+    public void AddToSponsonTurretRight(abPlaceable p) throws Exception {
+        if ( p.CanAllocCVTurret() ) {
+            AddTo(p, LocationIndex.CV_LOC_SPONSON_RIGHT);
+            Owner.SetChanged( true );
+        } else
+            throw new Exception(p.ActualName() + " cannot be allocated to the Sponson Turret.");
+    }
+
     public ArrayList<abPlaceable> GetFrontItems() {
         return FrontItems;
     }
@@ -496,6 +536,14 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
         return Turret2Items;
     }
 
+    public ArrayList<abPlaceable> GetSponsonTurretLeftItems() {
+        return SponsonTurretLeftItems;
+    }
+
+    public ArrayList<abPlaceable> GetSponsonTurretRightItems() {
+        return SponsonTurretRightItems;
+    }
+
     public abPlaceable[] GetItems(int Loc) {
         switch(Loc) {
             case LocationIndex.CV_LOC_BODY:
@@ -512,6 +560,10 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
                 return (abPlaceable[]) Turret1Items.toArray();
             case LocationIndex.CV_LOC_TURRET2:
                 return (abPlaceable[]) Turret2Items.toArray();
+            case LocationIndex.CV_LOC_SPONSON_LEFT:
+                return (abPlaceable[]) SponsonTurretLeftItems.toArray();
+            case LocationIndex.CV_LOC_SPONSON_RIGHT:
+                return (abPlaceable[]) SponsonTurretRightItems.toArray();
         }
         return null;
     }
@@ -529,6 +581,10 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
             return LocationIndex.CV_LOC_TURRET1;
         if ( Turret2Items.contains(p) )
             return LocationIndex.CV_LOC_TURRET2;
+        if ( SponsonTurretLeftItems.contains(p) )
+            return LocationIndex.CV_LOC_SPONSON_LEFT;
+        if ( SponsonTurretRightItems.contains(p) )
+            return LocationIndex.CV_LOC_SPONSON_RIGHT;
         if ( BodyItems.contains(p) )
             return LocationIndex.CV_LOC_BODY;
         return 11;
@@ -542,6 +598,8 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
         if ( Turret1Items.contains(p)) return new LocationIndex(0, LocationIndex.CV_LOC_TURRET1, p.NumCVSpaces());
         if ( RearItems.contains(p)) return new LocationIndex(0, LocationIndex.CV_LOC_REAR, p.NumCVSpaces());
         if ( Turret2Items.contains(p)) return new LocationIndex(0, LocationIndex.CV_LOC_TURRET2, p.NumCVSpaces());
+        if ( SponsonTurretLeftItems.contains(p)) return new LocationIndex(0, LocationIndex.CV_LOC_SPONSON_LEFT, p.NumCVSpaces());
+        if ( SponsonTurretRightItems.contains(p)) return new LocationIndex(0, LocationIndex.CV_LOC_SPONSON_RIGHT, p.NumCVSpaces());
         return null;
     }
 
@@ -598,6 +656,8 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
         Turret1Items.remove(p);
         RotorItems.remove(p);
         Turret2Items.remove(p);
+        SponsonTurretLeftItems.remove(p);
+        SponsonTurretRightItems.remove(p);
         NonCore.remove(p);
         TCList.remove(p);
         Owner.SetChanged( true );
@@ -635,6 +695,10 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
                 Turret1Items.remove(p);
             if ( Turret2Items.contains(p))
                 Turret2Items.remove(p);
+            if ( SponsonTurretLeftItems.contains(p))
+                SponsonTurretLeftItems.remove(p);
+            if ( SponsonTurretRightItems.contains(p))
+                SponsonTurretRightItems.remove(p);
         //}
 
         GetHeatSinks().SetNumHS(GetTotalHeat());
@@ -674,6 +738,8 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
         Items.add(BodyItems);
         Items.add(Turret1Items);
         Items.add(Turret2Items);
+        Items.add(SponsonTurretLeftItems);
+        Items.add(SponsonTurretRightItems);
         
         for ( ArrayList<abPlaceable> list : Items ) {
             for ( abPlaceable a : list ) {
@@ -691,6 +757,8 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
         Items.add(BodyItems);
         Items.add(Turret1Items);
         Items.add(Turret2Items);
+        Items.add(SponsonTurretLeftItems);
+        Items.add(SponsonTurretRightItems);
         
         for ( ArrayList<abPlaceable> list : Items ) {
             for ( abPlaceable a : list ) {
@@ -723,6 +791,8 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
         clone.SetRearItems( (ArrayList<abPlaceable>)RearItems.clone() );
         clone.SetTurret1( (ArrayList<abPlaceable>)Turret1Items.clone() );
         clone.SetTurret2( (ArrayList<abPlaceable>)Turret2Items.clone() );
+        clone.SetSponsonTurretLeftItems((ArrayList<abPlaceable>) SponsonTurretLeftItems.clone());
+        clone.SetSponsonTurretRightItems((ArrayList<abPlaceable>) SponsonTurretRightItems.clone());
         
         if( TCList.size() > 0 ) {
             clone.SetTCList( (ArrayList) TCList.clone() );
@@ -738,6 +808,7 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
         }
         clone.SetTurret(Turret1);
         clone.SetRearTurret(Turret2);
+        clone.SetSponsonTurretLeft(SponsonTurretLeft);
 
         return clone;
     }
@@ -778,6 +849,10 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
     public void SetTurret2(ArrayList<abPlaceable> c) {
         Turret2Items =  c;
     }
+
+    public void SetSponsonTurretLeftItems(ArrayList<abPlaceable> c) { SponsonTurretLeftItems = c; }
+
+    public void SetSponsonTurretRightItems(ArrayList<abPlaceable> c) { SponsonTurretRightItems = c; }
 
     public void SetNonCore(ArrayList v) {
         NonCore = v;
@@ -1070,6 +1145,24 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
         Turret2 = t;
     }
 
+    public SponsonTurret GetSponsonTurretLeft() {
+        SponsonTurretLeft.SetItems(SponsonTurretLeftItems);
+        return SponsonTurretLeft;
+    }
+
+    public void SetSponsonTurretLeft(SponsonTurret t) {
+        SponsonTurretLeft = t;
+    }
+
+    public SponsonTurret GetSponsonTurretRight() {
+        SponsonTurretRight.SetItems(SponsonTurretRightItems);
+        return SponsonTurretRight;
+    }
+
+    public void SetSponsonTurretRight(SponsonTurret t) {
+        SponsonTurretRight = t;
+    }
+
     public void MoveToQueue( int loc ) {
         /*
         switch (loc) {
@@ -1099,5 +1192,14 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
         Turret2.SetItems(Turret2Items);
         return Turret2.GetTonnage();
     }
-    
+
+    public double GetSponsonTurretTonnage() {
+        SponsonTurretLeft.SetItems(SponsonTurretLeftItems);
+        SponsonTurretRight.SetItems(SponsonTurretRightItems);
+        return CommonTools.RoundHalfUp((SponsonTurretLeft.GetTonnage() + SponsonTurretRight.GetTonnage()) * 0.10);
+    }
+
+    public double GetSponsonTurretCost() {
+        return GetSponsonTurretTonnage() * 4000.0;
+    }
 }

--- a/sswlib/src/main/java/components/CombatVehicle.java
+++ b/sswlib/src/main/java/components/CombatVehicle.java
@@ -106,7 +106,7 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
     private static AvailableCode OmniAvailable = new AvailableCode( AvailableCode.TECH_BOTH ),
                                  DualTurretAC = new AvailableCode( AvailableCode.TECH_BOTH ),
                                  ChinTurretAC = new AvailableCode( AvailableCode.TECH_BOTH ),
-                                 SponsoonAC = new AvailableCode( AvailableCode.TECH_BOTH );
+                                 SponsonAC = new AvailableCode( AvailableCode.TECH_BOTH );
     private Preferences Prefs;
     private BattleForceData BFData;
     private MultiSlotSystem BlueShield,
@@ -134,11 +134,11 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
         ChinTurretAC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
         ChinTurretAC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
 
-        SponsoonAC.SetCodes( 'B', 'F', 'F', 'F', 'D', 'B', 'F', 'F', 'F', 'D' );
-        SponsoonAC.SetFactions( "", "", "PS", "", "", "", "PS", "" );
-        SponsoonAC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
-        SponsoonAC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
-        SponsoonAC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
+        SponsonAC.SetCodes( 'B', 'F', 'F', 'F', 'D', 'B', 'F', 'F', 'F', 'D' );
+        SponsonAC.SetFactions( "", "", "PS", "", "", "", "PS", "" );
+        SponsonAC.SetISDates( 0, 0, false, 1950, 0, 0, false, false );
+        SponsonAC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
+        SponsonAC.SetRulesLevels( AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
 
         AvailableCode AC = new AvailableCode( AvailableCode.TECH_INNER_SPHERE );
         AC.SetISCodes( 'E', 'X', 'X', 'F', 'F' );
@@ -328,8 +328,8 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
         return false;
     }
 
-    public boolean CanUseSponsoon() {
-        if( CommonTools.IsAllowed( SponsoonAC,this) ) { return true; }
+    public boolean CanUseSponson() {
+        if( CommonTools.IsAllowed( SponsonAC,this) ) { return true; }
         return false;
     }
 

--- a/sswlib/src/main/java/components/CombatVehicle.java
+++ b/sswlib/src/main/java/components/CombatVehicle.java
@@ -76,6 +76,7 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
                     HasBlueShield = false,
                     HasTurret1 = false,
                     HasTurret2 = false,
+                    HasSponsonTurret = false,
                     HasPowerAmplifier = false,
                     UsingFlotationHull = false,
                     UsingLimitedAmphibious = false,
@@ -414,6 +415,7 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
         result += CurLoadout.GetPowerAmplifier().GetTonnage();
         if ( isHasTurret1() ) result += CurLoadout.GetTurretTonnage();
         if ( isHasTurret2() ) result += CurLoadout.GetRearTurretTonnage();
+        if ( isHasSponsonTurret() ) result += CurLoadout.GetSponsonTurretTonnage();
         result += GetLimitedAmphibiousTonnage();
         result += GetFullAmphibiousTonnage();
         result += GetEnvironmentalSealingTonnage();
@@ -1395,6 +1397,20 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
         }
     }
 
+    public boolean isHasSponsonTurret() {
+        return HasSponsonTurret;
+    }
+
+    public void setHasSponsonTurret(boolean HasSponsonTurret) {
+        this.HasSponsonTurret = HasSponsonTurret;
+        //Move any weapons/equipment that was in the turret to another location
+        if (!HasSponsonTurret) {
+            GetLoadout().SetSponsonTurretLeftItems(new ArrayList<abPlaceable>());
+            GetLoadout().SetSponsonTurretRightItems(new ArrayList<abPlaceable>());
+            GetLoadout().RefreshHeatSinks();
+        }
+    }
+
     public Engine getCurEngine() {
         return CurEngine;
     }
@@ -2174,6 +2190,8 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
         Locations.add(CurLoadout.GetRightItems());
         Locations.add(CurLoadout.GetTurret1Items());
         Locations.add(CurLoadout.GetTurret2Items());
+        Locations.add(CurLoadout.GetSponsonTurretLeftItems());
+        Locations.add(CurLoadout.GetSponsonTurretRightItems());
         
         // is it even worth performing all this?
         if( CurLoadout.GetNonCore().size() <= 0 ) {

--- a/sswlib/src/main/java/components/LocationIndex.java
+++ b/sswlib/src/main/java/components/LocationIndex.java
@@ -28,8 +28,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package components;
 
-import java.util.ArrayList;
-
 public class LocationIndex {
     // this is a convenience method for the XML saving and loading routine
     // it provides a location index for any given item.
@@ -56,12 +54,14 @@ public class LocationIndex {
                             CV_LOC_REAR = 3,
                             CV_LOC_TURRET1 = 4,
                             CV_LOC_TURRET2 = 5,
-                            CV_LOC_ROTOR = 6,
-                            CV_LOC_BODY = 7;
+                            CV_LOC_SPONSON_LEFT = 6,
+                            CV_LOC_SPONSON_RIGHT = 7,
+                            CV_LOC_ROTOR = 8,
+                            CV_LOC_BODY = 9;
     public final static String[] MechLocs = { "Head", "Center Torso", "Left Torso",
         "Right Torso", "Left Arm", "Right Arm", "Left Leg", "Right Leg", "Center Leg" },
                                  CVLocs = { "Front", "Left", "Right", "Rear",
-        "Turret", "Rear Turret", "Rotor", "Body" };
+        "Turret", "Rear Turret", "Left Sponson Turret", "Right Sponson Turret", "Rotor", "Body" };
 
     public LocationIndex() {}
 
@@ -89,6 +89,8 @@ public class LocationIndex {
         if ( location.equals("Rear")) return CV_LOC_REAR;
         if ( location.equals("Turret")) return CV_LOC_TURRET1;
         if ( location.equals("Rear Turret")) return CV_LOC_TURRET2;
+        if ( location.equals("Left Sponson Turret")) return CV_LOC_SPONSON_LEFT;
+        if ( location.equals("Right Sponson Turret")) return CV_LOC_SPONSON_RIGHT;
         if ( location.equals("Body")) return CV_LOC_BODY;
         return 11;
     }

--- a/sswlib/src/main/java/components/SponsonTurret.java
+++ b/sswlib/src/main/java/components/SponsonTurret.java
@@ -1,0 +1,212 @@
+/*
+Copyright (c) 2008~2009, Justin R. Bengtson (poopshotgun@yahoo.com)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+        this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+    * Neither the name of Justin R. Bengtson nor the names of contributors may
+        be used to endorse or promote products derived from this software
+        without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package components;
+
+import common.CommonTools;
+import java.util.ArrayList;
+
+public class SponsonTurret extends abPlaceable {
+    private ifCVLoadout Owner;
+    private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
+    private boolean Clan,
+            isTonnageSet;
+    private ArrayList Items = new ArrayList();
+    private double MaxTonnage = 0;
+
+    public SponsonTurret( ifCVLoadout l, boolean clan) {
+        AC.SetISCodes( 'B', 'F', 'F', 'F', 'D' );
+        AC.SetISDates( 0, 0, false, 3079, 0, 0, false, false );
+        AC.SetISFactions( "", "", "PS", "" );
+        AC.SetCLCodes( 'B', 'F', 'F', 'F', 'D' );
+        AC.SetCLDates( 0, 0, false, 3079, 0, 0, false, false );
+        AC.SetCLFactions( "", "", "PS", "" );
+        AC.SetPBMAllowed( true );
+        AC.SetPIMAllowed( true );
+        AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
+        Owner = l;
+        Clan = clan;
+    }
+
+    public String ActualName() {
+        return "Sponson Turret";
+    }
+
+    public String CritName() {
+        return "Sponson Turret";
+    }
+
+    public String LookupName() {
+        return "Sponson Turret";
+    }
+
+    public String ChatName() {
+        return "SponsonTur";
+    }
+
+    public String MegaMekName( boolean UseRear ) {
+        return "Sponson Turret";
+    }
+
+    public String BookReference() {
+        return "Tactical Operations";
+    }
+
+    public void SetClan( boolean b ) {
+        Clan = b;
+    }
+
+    public boolean IsClan() {
+        return Clan;
+    }
+
+    @Override
+    public int NumCrits() {
+        return 0;
+    }
+
+    public int NumCVSpaces() {
+        return 0;
+    }
+
+    @Override
+    public double GetTonnage() {
+        if ( isTonnageSet )
+            return MaxTonnage;
+        else
+            return GetSize();
+    }
+
+    @Override
+    public double GetCost() {
+        return GetSize() * 4000.0;
+    }
+
+    public double GetOffensiveBV() {
+        // we can't really control this one, so we should always call the TC
+        // with UseCurOffensiveBV().  Since almost all of the time a 'Mech will
+        // mount it's weapons forward, we'll call it without using rear.
+        return GetCurOffensiveBV( false, false, false );
+    }
+
+    public double GetCurOffensiveBV( boolean UseRear, boolean UseTC, boolean UseAES ) {
+        // BV calculations for the targeting computer are based on modified
+        // weapon BV, which we won't know until later.
+        return 0.0;
+    }
+
+    public double GetCurOffensiveBV( boolean UseRear, boolean UseTC, boolean UseAES, boolean UseRobotic ) {
+        // BV will not change for this item, so just return the normal value
+        return GetOffensiveBV();
+    }
+
+    public double GetDefensiveBV() {
+        double retval = 0.0;
+        if( IsArmored() ) {
+            retval = 5.0 * NumCrits();
+        }
+        return retval;
+    }
+
+    @Override
+    public AvailableCode GetAvailability() {
+        AvailableCode retval = AC.Clone();
+        if( IsArmored() ) {
+            retval.Combine( ArmoredAC );
+        }
+        return retval;
+    }
+
+    private double GetSize() {
+        double Build = 0.0;
+
+        if ( isTonnageSet )
+            return MaxTonnage;
+
+        if( Items.isEmpty() ) {
+            return 0;
+        }
+
+        for( int i = 0; i < Items.size(); i++ ) {
+            abPlaceable a = (abPlaceable)Items.get(i);
+            if( a instanceof RangedWeapon ) {
+                if( ((RangedWeapon) a).IsUsingCapacitor() ) {
+                    Build += a.GetTonnage() - ((RangedWeapon) a).GetCapacitor().GetTonnage();
+                } else if( ((RangedWeapon) a).IsUsingInsulator() ) {
+                    Build += a.GetTonnage() - ((RangedWeapon) a).GetInsulator().GetTonnage();
+                } else if( ((RangedWeapon) a).IsUsingPulseModule() ) {
+                    Build += a.GetTonnage() - ((RangedWeapon) a).GetPulseModule().GetTonnage();
+                }else {
+                    Build += a.GetTonnage();
+                }
+            } else if ( !(a instanceof Ammunition) ) {
+                Build += a.GetTonnage();
+            }
+            if( a.IsArmored() ) {
+                Build -= a.NumCrits() * 0.5;
+            }
+        }
+
+        return Build;
+    }
+
+    @Override
+    public boolean CoreComponent() {
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return CritName();
+    }
+
+    public void SetItems( ArrayList a ) {
+        Items = a;
+    }
+
+    public ArrayList GetItems() {
+        return Items;
+    }
+
+    public void TonnageSet( boolean i ) {
+        isTonnageSet = i;
+        if (!i)
+            MaxTonnage = 0;
+    }
+    public void SetTonnage( double t ) {
+        MaxTonnage = t;
+        isTonnageSet = true;
+    }
+    public boolean isTonnageSet() {
+        return isTonnageSet;
+    }
+
+    public double GetMaxTonnage() {
+        return MaxTonnage;
+    }
+}

--- a/sswlib/src/main/java/components/ifCVLoadout.java
+++ b/sswlib/src/main/java/components/ifCVLoadout.java
@@ -76,6 +76,8 @@ public interface ifCVLoadout {
     public void AddToBody( abPlaceable p ) throws Exception;
     public void AddToTurret1( abPlaceable p ) throws Exception;
     public void AddToTurret2( abPlaceable p ) throws Exception;
+    public void AddToSponsonTurretLeft(abPlaceable p ) throws Exception;
+    public void AddToSponsonTurretRight(abPlaceable p ) throws Exception;
     public ArrayList<abPlaceable> GetFrontItems();
     public ArrayList<abPlaceable> GetLeftItems();
     public ArrayList<abPlaceable> GetRightItems();
@@ -83,8 +85,12 @@ public interface ifCVLoadout {
     public ArrayList<abPlaceable> GetBodyItems();
     public ArrayList<abPlaceable> GetTurret1Items();
     public ArrayList<abPlaceable> GetTurret2Items();
+    public ArrayList<abPlaceable> GetSponsonTurretLeftItems();
+    public ArrayList<abPlaceable> GetSponsonTurretRightItems();
     public Turret GetTurret();
     public Turret GetRearTurret();
+    public SponsonTurret GetSponsonTurretLeft();
+    public SponsonTurret GetSponsonTurretRight();
     public abPlaceable[] GetItems( int Loc );
     public int Find( abPlaceable p );
     public LocationIndex FindIndex( abPlaceable p );
@@ -112,11 +118,15 @@ public interface ifCVLoadout {
     public void SetBodyItems( ArrayList<abPlaceable> c );
     public void SetTurret1( ArrayList<abPlaceable> c );
     public void SetTurret2( ArrayList<abPlaceable> c );
+    public void SetSponsonTurretLeftItems(ArrayList<abPlaceable> c);
+    public void SetSponsonTurretRightItems(ArrayList<abPlaceable> c);
     public void SetNonCore( ArrayList v );
     public void SetTCList( ArrayList v );
     public void SetEquipment( ArrayList v );
     public void SetTurret( Turret t );
     public void SetRearTurret( Turret t );
+    public void SetSponsonTurretLeft(SponsonTurret t);
+    public void SetSponsonTurretRight(SponsonTurret t);
     public ArrayList GetMechMods();
     public boolean CanUseClanCASE();
     public boolean IsUsingClanCASE();
@@ -143,6 +153,8 @@ public interface ifCVLoadout {
     public void MoveToQueue(int loc);
     public double GetTurretTonnage();
     public double GetRearTurretTonnage();
+    public double GetSponsonTurretTonnage();
+    public double GetSponsonTurretCost();
     public void ResetHeatSinks();
 /*
     public void AddMechModifier( MechModifier m );

--- a/sswlib/src/main/java/filehandlers/CVReader.java
+++ b/sswlib/src/main/java/filehandlers/CVReader.java
@@ -521,6 +521,9 @@ public class CVReader {
                         eType = nl.item( j ).getTextContent();
                     } else if( nl.item( j ).getNodeName().equals( "location" ) ) {
                         l = DecodeLocation( nl.item( j ) );
+                        if (l.Location == LocationIndex.CV_LOC_SPONSON_LEFT|| l.Location == LocationIndex.CV_LOC_SPONSON_RIGHT) {
+                            m.setHasSponsonTurret(true);
+                        }
                     } else if( nl.item( j ).getNodeName().equals( "splitlocation" ) ) {
                         splitLoc.add( DecodeLocation( nl.item( j ) ) );
                     } else if( nl.item( j ).getNodeName().equals( "vglarc" ) ) {

--- a/sswlib/src/main/java/filehandlers/CVTXTWriter.java
+++ b/sswlib/src/main/java/filehandlers/CVTXTWriter.java
@@ -232,6 +232,9 @@ public class CVTXTWriter {
             retval += String.format( "Turret:             %1$-28s %2$-8s                %3" + tformat, "", "", CurVee.GetLoadout().GetTurret().GetTonnage() ) + NL;
         if ( CurVee.isHasTurret2() ) 
             retval += String.format( "Rear Turret:        %1$-28s %2$-8s                %3" + tformat, "", "", CurVee.GetLoadout().GetRearTurret().GetTonnage() ) + NL;
+        if ( CurVee.isHasSponsonTurret() ) {
+            retval += String.format( "Sponson Turret:        %1$-28s %2$-8s                %3" + tformat, "", "", CurVee.GetLoadout().GetSponsonTurretTonnage() ) + NL;
+        }
         if( CurVee.GetArmor().GetBAR() < 10 ) {
             retval += String.format( "Armor:              %1$-28s AV - %2$3s                %3" + tformat, CurVee.GetArmor().CritName() + " (BAR: " + CurVee.GetArmor().GetBAR() +")", CurVee.GetArmor().GetArmorValue(), CurVee.GetArmor().GetTonnage() ) + NL;
         } else {

--- a/sswlib/src/main/java/filehandlers/FileCommon.java
+++ b/sswlib/src/main/java/filehandlers/FileCommon.java
@@ -1075,6 +1075,10 @@ public class FileCommon {
             return LocationIndex.CV_LOC_TURRET2;
         } else if( s.equals( "Rotor" ) ) {
             return LocationIndex.CV_LOC_ROTOR;
+        } else if( s.equals( "Left Sponson Turret" ) ) {
+            return LocationIndex.CV_LOC_SPONSON_LEFT;
+        } else if( s.equals( "Right Sponson Turret" ) ) {
+            return LocationIndex.CV_LOC_SPONSON_RIGHT;
         } else {
             return -1;
         }

--- a/sswlib/src/main/java/filehandlers/FileCommon.java
+++ b/sswlib/src/main/java/filehandlers/FileCommon.java
@@ -710,6 +710,10 @@ public class FileCommon {
                     return "Turret";
                 case LocationIndex.CV_LOC_TURRET2:
                     return "Rear Turret";
+                case LocationIndex.CV_LOC_SPONSON_LEFT:
+                    return "Left Sponson Turret";
+                case LocationIndex.CV_LOC_SPONSON_RIGHT:
+                    return "Right Sponson Turret";
                 default:
                     return "??";
             }
@@ -778,6 +782,10 @@ public class FileCommon {
                         return "T";
                     case LocationIndex.CV_LOC_TURRET2:
                         return "RT";
+                    case LocationIndex.CV_LOC_SPONSON_LEFT:
+                        return "LS-S";
+                    case LocationIndex.CV_LOC_SPONSON_RIGHT:
+                        return "RS-S";
                     default:
                         return "??";
                 }

--- a/sswlib/src/main/java/utilities/CVCostBVBreakdown.java
+++ b/sswlib/src/main/java/utilities/CVCostBVBreakdown.java
@@ -69,6 +69,9 @@ public class CVCostBVBreakdown {
             retval += String.format( "%1$-43s %2$,6.0f    %3$,6.0f    %4$,16.2f", "Turret", CurUnit.GetLoadout().GetTurret().GetDefensiveBV(), CurUnit.GetLoadout().GetTurret().GetOffensiveBV(), CurUnit.GetLoadout().GetTurret().GetCost() ) + NL;
         if ( CurUnit.isHasTurret2() )
             retval += String.format( "%1$-43s %2$,6.0f    %3$,6.0f    %4$,16.2f", "Rear Turret", CurUnit.GetLoadout().GetRearTurret().GetDefensiveBV(), CurUnit.GetLoadout().GetRearTurret().GetOffensiveBV(), CurUnit.GetLoadout().GetRearTurret().GetCost() ) + NL;
+        if ( CurUnit.isHasSponsonTurret() ) {
+            retval += String.format( "%1$-43s %2$,6.0f    %3$,6.0f    %4$,16.2f", "Sponson Turret", CurUnit.GetLoadout().GetSponsonTurretLeft().GetDefensiveBV(), CurUnit.GetLoadout().GetSponsonTurretLeft().GetOffensiveBV(), CurUnit.GetLoadout().GetSponsonTurretCost() ) + NL;
+        }
         retval += NL;
         retval += GetEquipmentCostLines();
         retval += NL;
@@ -173,6 +176,8 @@ public class CVCostBVBreakdown {
         Locations.add(CurUnit.GetLoadout().GetRightItems());
         Locations.add(CurUnit.GetLoadout().GetTurret1Items());
         Locations.add(CurUnit.GetLoadout().GetTurret2Items());
+        Locations.add(CurUnit.GetLoadout().GetSponsonTurretLeftItems());
+        Locations.add(CurUnit.GetLoadout().GetSponsonTurretRightItems());
         
         // is it even worth performing all this?
         if( CurUnit.GetLoadout().GetNonCore().size() <= 0 ) {

--- a/sswlib/src/main/java/utilities/CVCostBVBreakdown.java
+++ b/sswlib/src/main/java/utilities/CVCostBVBreakdown.java
@@ -70,7 +70,7 @@ public class CVCostBVBreakdown {
         if ( CurUnit.isHasTurret2() )
             retval += String.format( "%1$-43s %2$,6.0f    %3$,6.0f    %4$,16.2f", "Rear Turret", CurUnit.GetLoadout().GetRearTurret().GetDefensiveBV(), CurUnit.GetLoadout().GetRearTurret().GetOffensiveBV(), CurUnit.GetLoadout().GetRearTurret().GetCost() ) + NL;
         if ( CurUnit.isHasSponsonTurret() ) {
-            retval += String.format( "%1$-43s %2$,6.0f    %3$,6.0f    %4$,16.2f", "Sponson Turret", CurUnit.GetLoadout().GetSponsonTurretLeft().GetDefensiveBV(), CurUnit.GetLoadout().GetSponsonTurretLeft().GetOffensiveBV(), CurUnit.GetLoadout().GetSponsonTurretCost() ) + NL;
+            retval += String.format( "%1$-43s %2$,6.0f    %3$,6.0f    %4$,16.2f", "Sponson Turret", 0.0, 0.0, CurUnit.GetLoadout().GetSponsonTurretCost() ) + NL; // Sponsons don't directly contribute to BV
         }
         retval += NL;
         retval += GetEquipmentCostLines();


### PR DESCRIPTION
This PR implements sponson turrets in SAW and sswlib. They were only superficially added before--they were being treated as a regular turret and didn't really follow any of the rules for sponsons. 

Tested by myself, CampaignAnon, and Maelwys (thanks guys!) and is believed to be working to the best of our knowledge. Closes #39 