### PR TITLE
sswlib: Fission engine shielding weight

### DIFF
--- a/sswlib/src/main/java/components/Engine.java
+++ b/sswlib/src/main/java/components/Engine.java
@@ -160,7 +160,7 @@ public class Engine extends abPlaceable {
         if( IsArmored() ) {
             return CurConfig.GetTonnage( EngineRating, Owner.UsingFractionalAccounting() ) + ReportCrits() * 0.5;
         } else {
-            if( Owner.GetUnitType() == AvailableCode.UNIT_COMBATVEHICLE && IsFusion() ) {
+            if( Owner.GetUnitType() == AvailableCode.UNIT_COMBATVEHICLE && (IsFusion() || IsFission())) {
                 double retval = CurConfig.GetTonnage( EngineRating, Owner.UsingFractionalAccounting() );
                 if( Owner.UsingFractionalAccounting() ) {
                     return retval * 1.5;
@@ -440,6 +440,8 @@ public class Engine extends abPlaceable {
     public boolean IsFusion() {
         return CurConfig.IsFusion();
     }
+
+    public boolean IsFission() { return CurConfig.IsFission(); }
 
     public boolean IsNuclear() {
         return CurConfig.IsNuclear();

--- a/sswlib/src/main/java/states/ifEngine.java
+++ b/sswlib/src/main/java/states/ifEngine.java
@@ -41,6 +41,7 @@ public interface ifEngine {
     public String BookReference();
     public int GetFullCrits();
     public boolean IsFusion();
+    public boolean IsFission();
     public boolean IsNuclear();
     public double GetTonnage( int Rating, boolean fractional );
     public int GetBFStructure( int tonnage );

--- a/sswlib/src/main/java/states/stEngineCLXL.java
+++ b/sswlib/src/main/java/states/stEngineCLXL.java
@@ -164,6 +164,8 @@ public class stEngineCLXL implements ifEngine, ifState {
         return true;
     }
 
+    public boolean IsFission() { return false; }
+
     public int GetFullCrits() {
         return 10;
     }

--- a/sswlib/src/main/java/states/stEngineCLXXL.java
+++ b/sswlib/src/main/java/states/stEngineCLXXL.java
@@ -164,6 +164,8 @@ public class stEngineCLXXL implements ifEngine, ifState {
         return true;
     }
 
+    public boolean IsFission() { return false; }
+
     public int GetFullCrits() {
         return 14;
     }

--- a/sswlib/src/main/java/states/stEngineFission.java
+++ b/sswlib/src/main/java/states/stEngineFission.java
@@ -147,6 +147,8 @@ public class stEngineFission implements ifEngine, ifState {
         return true;
     }
 
+    public boolean IsFission() { return true; }
+
     public int GetFullCrits() {
         return 6;
     }

--- a/sswlib/src/main/java/states/stEngineFuelCell.java
+++ b/sswlib/src/main/java/states/stEngineFuelCell.java
@@ -145,6 +145,8 @@ public class stEngineFuelCell implements ifEngine, ifState {
         return false;
     }
 
+    public boolean IsFission() { return false; }
+
     public int GetFullCrits() {
         return 6;
     }

--- a/sswlib/src/main/java/states/stEngineFusion.java
+++ b/sswlib/src/main/java/states/stEngineFusion.java
@@ -164,6 +164,8 @@ public class stEngineFusion implements ifEngine, ifState {
         return true;
     }
 
+    public boolean IsFission() { return false; }
+
     public int GetFullCrits() {
         return 6;
     }

--- a/sswlib/src/main/java/states/stEngineICE.java
+++ b/sswlib/src/main/java/states/stEngineICE.java
@@ -165,6 +165,8 @@ public class stEngineICE implements ifEngine, ifState {
         return false;
     }
 
+    public boolean IsFission() { return false; }
+
     public int GetFullCrits() {
         return 6;
     }

--- a/sswlib/src/main/java/states/stEngineISCF.java
+++ b/sswlib/src/main/java/states/stEngineISCF.java
@@ -141,6 +141,8 @@ public class stEngineISCF implements ifEngine, ifState {
         return true;
     }
 
+    public boolean IsFission() { return false; }
+
     public int GetFullCrits() {
         return 3;
     }

--- a/sswlib/src/main/java/states/stEngineISLF.java
+++ b/sswlib/src/main/java/states/stEngineISLF.java
@@ -164,6 +164,8 @@ public class stEngineISLF implements ifEngine, ifState {
         return true;
     }
 
+    public boolean IsFission() { return false; }
+
     public int GetFullCrits() {
         return 10;
     }

--- a/sswlib/src/main/java/states/stEngineISXL.java
+++ b/sswlib/src/main/java/states/stEngineISXL.java
@@ -164,6 +164,8 @@ public class stEngineISXL implements ifEngine, ifState {
         return true;
     }
 
+    public boolean IsFission() { return false; }
+
     public int GetFullCrits() {
         return 12;
     }

--- a/sswlib/src/main/java/states/stEngineISXXL.java
+++ b/sswlib/src/main/java/states/stEngineISXXL.java
@@ -164,6 +164,8 @@ public class stEngineISXXL implements ifEngine, ifState {
         return true;
     }
 
+    public boolean IsFission() { return false; }
+
     public int GetFullCrits() {
         return 18;
     }

--- a/sswlib/src/main/java/states/stEngineNone.java
+++ b/sswlib/src/main/java/states/stEngineNone.java
@@ -139,6 +139,8 @@ public class stEngineNone implements ifEngine, ifState {
         return false;
     }
 
+    public boolean IsFission() { return false; }
+
     public int GetFullCrits() {
         return 0;
     }

--- a/sswlib/src/main/java/states/stEnginePrimitiveFission.java
+++ b/sswlib/src/main/java/states/stEnginePrimitiveFission.java
@@ -150,6 +150,8 @@ public class stEnginePrimitiveFission implements ifEngine, ifState {
         return true;
     }
 
+    public boolean IsFission() { return true; }
+
     public int GetFullCrits() {
         return 6;
     }

--- a/sswlib/src/main/java/states/stEnginePrimitiveFuelCell.java
+++ b/sswlib/src/main/java/states/stEnginePrimitiveFuelCell.java
@@ -148,6 +148,8 @@ public class stEnginePrimitiveFuelCell implements ifEngine, ifState {
         return false;
     }
 
+    public boolean IsFission() { return false; }
+
     public int GetFullCrits() {
         return 6;
     }

--- a/sswlib/src/main/java/states/stEnginePrimitiveFusion.java
+++ b/sswlib/src/main/java/states/stEnginePrimitiveFusion.java
@@ -143,6 +143,8 @@ public class stEnginePrimitiveFusion implements ifEngine, ifState {
         return true;
     }
 
+    public boolean IsFission() { return false; }
+
     public int GetFullCrits() {
         return 6;
     }

--- a/sswlib/src/main/java/states/stEnginePrimitiveICE.java
+++ b/sswlib/src/main/java/states/stEnginePrimitiveICE.java
@@ -142,6 +142,8 @@ public class stEnginePrimitiveICE implements ifEngine, ifState {
         return false;
     }
 
+    public boolean IsFission() { return false; }
+
     public int GetFullCrits() {
         return 6;
     }


### PR DESCRIPTION
Closes #94. Previously, sswlib was only accounting for shielding weight on fusion engines, although it should have been doing this for fission engines as well. This required adding an `IsFission()` method on the engine states and interface, which returns false for everything except the two fission engine types.