### PR TITLE
Account for Sponson Turret Cost in GetDryCost

### DIFF
--- a/sswlib/src/main/java/components/CombatVehicle.java
+++ b/sswlib/src/main/java/components/CombatVehicle.java
@@ -395,7 +395,7 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
     
     public double GetDryCost() {
         // returns the total cost of the mech without ammunition
-        return (GetEquipCost() + GetChassisCost()) * GetCostMult() * GetConfigMultiplier();
+        return (GetEquipCost() + CurLoadout.GetSponsonTurretCost() + GetChassisCost()) * GetCostMult() * GetConfigMultiplier();
     }
     
     public double GetConfigMultiplier() {


### PR DESCRIPTION
GetDryCost() was not factoring in Sponson Turret costs when calculating the cost of a unit. This PR simply adds the final c-bill cost of the sponson to the calculation.