### PR TITLE
Stop ignoring "Choose TRO Pic" image in print preview

### DIFF
--- a/sswlib/src/main/java/Print/PrintMech.java
+++ b/sswlib/src/main/java/Print/PrintMech.java
@@ -273,7 +273,8 @@ public class PrintMech implements Printable {
         start.x -= 3;
         start.y -= 6;
         if ( printMech ) {
-            MechImage = imageTracker.media.GetImage(imageTracker.media.DetermineMatchingImage(CurMech.GetName(), CurMech.GetModel(), CurMech.GetSSWImage()));
+            if (MechImage == null) // fallback to fluff image if user didn't explicitly choose a TRO pic in the print dialog
+                MechImage = imageTracker.media.GetImage(imageTracker.media.DetermineMatchingImage(CurMech.GetName(), CurMech.GetModel(), CurMech.GetSSWImage()));
             if( MechImage != null ) {
                 //graphics.drawRect(start.x, start.y, 150, 210);
                 Dimension d = imageTracker.media.reSize(getMechImage(), 150, 210);


### PR DESCRIPTION
The print preview dialog was previously ignoring the image specified by the user after clicking "Choose TRO Pic", and instead was only loading the image saved in the Fluff tab of SSW. This change addresses that by first checking to see if a user explicitly chose a TRO pic in the print preview screen before falling back to the fluff image.

Fixes #42 