### PR TITLE
Correctly set turret selector when loading CVs

### DIFF
--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -5637,7 +5637,6 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
     private void BuildTurretSelector()
     {
         ArrayList list = new ArrayList();
-        String curTurret = cmbTurret.getSelectedItem().toString();
 
         if ( !CurVee.IsOmni())
             cmbTurret.setEnabled(true);
@@ -5659,8 +5658,12 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
 
         // now set the turret chooser
         cmbTurret.setModel( new javax.swing.DefaultComboBoxModel( temp ) );
-
-        cmbTurret.setSelectedItem(curTurret);
+        if (CurVee.isHasTurret2())
+            cmbTurret.setSelectedItem("Dual Turret");
+        else if (CurVee.isHasTurret1())
+            cmbTurret.setSelectedItem("Single Turret");
+        else
+            cmbTurret.setSelectedItem("No Turret");
     }
 
     private void BuildChassisSelector()

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -5501,7 +5501,6 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
     private void BuildTurretSelector()
     {
         ArrayList list = new ArrayList();
-        String curTurret = cmbTurret.getSelectedItem().toString();
 
         if ( !CurVee.IsOmni())
             cmbTurret.setEnabled(true);
@@ -5523,8 +5522,12 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
 
         // now set the turret chooser
         cmbTurret.setModel( new javax.swing.DefaultComboBoxModel( temp ) );
-
-        cmbTurret.setSelectedItem(curTurret);
+        if (CurVee.isHasTurret2())
+            cmbTurret.setSelectedItem("Dual Turret");
+        else if (CurVee.isHasTurret1())
+            cmbTurret.setSelectedItem("Single Turret");
+        else
+            cmbTurret.setSelectedItem("No Turret");
     }
 
     private void BuildChassisSelector()


### PR DESCRIPTION
Closes #59 

When loading/opening vehicles, the turret selection menu was not refreshed based on whether the vee had a single, dual, or no turret, and instead just used whatever value it was previously set to. This commit simply checks the turret status of the vee before setting the menu item.