### PR TITLE
Fix #138 - reduce heat multiplier on SLRMs and iATMs

### DIFF
--- a/sswlib/src/main/java/components/RangedWeapon.java
+++ b/sswlib/src/main/java/components/RangedWeapon.java
@@ -584,7 +584,10 @@ public class RangedWeapon extends abPlaceable implements ifWeapon {
         if( Rotary ) { retval *= 6; }
         if( Ultra ) { retval *= 2; }
         if( OneShot ) { retval *= 0.25; }
-        if( Streak && this.ChatName.contains( "SRM" )) { retval *= 0.5; }
+        if( Streak && ( this.ChatName.contains( "SRM" )
+                || this.ChatName.contains( "LRM" )
+                || this.ChatName.contains( "iATM" ) )
+            ) { retval *= 0.5; }
         if( retval < 0 ) { retval = 0; }
         return retval;
     }


### PR DESCRIPTION
@WEKarnesky ping me if this is incorrect, but my understanding of #138 was that Streak LRMs and iATMs should be treated exactly like streak SRMs when calculating heat for offensive BV. We adjusted it for Streak SRMs [in this PR](https://github.com/WEKarnesky/sswlib/pull/8) but it looks like we needed to apply it to iATMs and LRMs as well, which this PR addresses.