### PR TITLE
Fix #137 - allocate space for ammo bins on CVs

### DIFF
--- a/sswlib/src/main/java/components/CVLoadout.java
+++ b/sswlib/src/main/java/components/CVLoadout.java
@@ -31,6 +31,8 @@ package components;
 import common.CommonTools;
 import common.Constants;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
+
 import visitors.VFCSApolloLoader;
 import visitors.VFCSArtemisIVLoader;
 import visitors.VFCSArtemisVLoader;
@@ -1201,5 +1203,15 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
 
     public double GetSponsonTurretCost() {
         return GetSponsonTurretTonnage() * 4000.0;
+    }
+
+    public int NumCVAmmoSpaces() {
+        LinkedHashSet<String> set = new LinkedHashSet<>();
+        for (abPlaceable a: (ArrayList<abPlaceable>)GetNonCore()) {
+            if (a instanceof Ammunition) {
+                set.add(a.toString());
+            }
+        }
+        return set.size();
     }
 }

--- a/sswlib/src/main/java/components/CombatVehicle.java
+++ b/sswlib/src/main/java/components/CombatVehicle.java
@@ -2349,6 +2349,7 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
         int retval = getMaxItems();
         retval -= CurEngine.NumCVSpaces();
         retval -= CurArmor.NumCVSpaces();
+        retval -= GetLoadout().NumCVAmmoSpaces();
         for ( abPlaceable a : (ArrayList<abPlaceable>)GetLoadout().GetNonCore() ) {
             retval -= a.NumCVSpaces();
         }

--- a/sswlib/src/main/java/components/ifCVLoadout.java
+++ b/sswlib/src/main/java/components/ifCVLoadout.java
@@ -156,6 +156,7 @@ public interface ifCVLoadout {
     public double GetSponsonTurretTonnage();
     public double GetSponsonTurretCost();
     public void ResetHeatSinks();
+    public int NumCVAmmoSpaces();
 /*
     public void AddMechModifier( MechModifier m );
     public void RemoveMechMod( MechModifier m );


### PR DESCRIPTION
This PR implements the ammo bin space rules mentioned in #137. It looks like the original developers intended to create a bigger CVAmmunitionHandler class that was never used, but implementing it would be complicated and possibly break how ammo is currently being handled as regular equipment (which I like). Instead, this PR simply dedupes grabs the ammo strings from the loadout, dedupes it with a LinkedHashSet and returns the length, thereby allocating spaces once per ammo type.