### PR TITLE
Allow primitive battlemechs to use all primitive engines

### DIFF
--- a/sswlib/src/main/java/states/stEnginePrimitiveFission.java
+++ b/sswlib/src/main/java/states/stEnginePrimitiveFission.java
@@ -53,6 +53,7 @@ public class stEnginePrimitiveFission implements ifEngine, ifState {
         AC.SetCLCodes( 'D', 'X', 'F', 'E', 'F' );
         AC.SetCLDates( 0, 0, false, 1960, 0, 0, false, false );
         AC.SetCLFactions( "", "", "ES", "" );
+        AC.SetPBMAllowed(true);
         AC.SetPIMAllowed( true );
         AC.SetPrimitiveOnly( true );
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_ADVANCED );

--- a/sswlib/src/main/java/states/stEnginePrimitiveFuelCell.java
+++ b/sswlib/src/main/java/states/stEnginePrimitiveFuelCell.java
@@ -53,6 +53,7 @@ public class stEnginePrimitiveFuelCell implements ifEngine, ifState {
         AC.SetCLCodes( 'D', 'X', 'F', 'E', 'F' );
         AC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetCLFactions( "", "", "PS", "" );
+        AC.SetPBMAllowed(true);
         AC.SetPIMAllowed( true );
         AC.SetPrimitiveOnly( true );
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );

--- a/sswlib/src/main/java/states/stEnginePrimitiveICE.java
+++ b/sswlib/src/main/java/states/stEnginePrimitiveICE.java
@@ -52,6 +52,7 @@ public class stEnginePrimitiveICE implements ifEngine, ifState {
         AC.SetCLCodes( 'D', 'X', 'F', 'E', 'F' );
         AC.SetCLDates( 0, 0, false, 1950, 0, 0, false, false );
         AC.SetCLFactions( "", "", "PS", "" );
+        AC.SetPBMAllowed(true);
         AC.SetPIMAllowed( true );
         AC.SetPrimitiveOnly( true );
         AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_TOURNAMENT );


### PR DESCRIPTION
This fixes #151 by allowing primitive battlemechs to use all 4 primitive engine types