### PR TITLE
Remove sponsons from armor locations

### DIFF
--- a/sswlib/src/main/java/components/CVArmor.java
+++ b/sswlib/src/main/java/components/CVArmor.java
@@ -41,8 +41,8 @@ public class CVArmor extends abPlaceable {
 
     // Declares
     private CombatVehicle Owner;
-    private int[] ArmorPoints = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-    private int[] MaxArmor = { 390, 390, 390, 390, 390, 390, 0, 0, 2, 390 };
+    private int[] ArmorPoints = { 0, 0, 0, 0, 0, 0, 0, 0 };
+    private int[] MaxArmor = { 390, 390, 390, 390, 390, 390, 2, 390 };
     private ifArmor Industrial = new stArmorIN(),
                     Standard = new stArmorMS(),
                     ISFF = new stArmorISFF(),

--- a/sswlib/src/main/java/components/LocationIndex.java
+++ b/sswlib/src/main/java/components/LocationIndex.java
@@ -54,10 +54,10 @@ public class LocationIndex {
                             CV_LOC_REAR = 3,
                             CV_LOC_TURRET1 = 4,
                             CV_LOC_TURRET2 = 5,
-                            CV_LOC_SPONSON_LEFT = 6,
-                            CV_LOC_SPONSON_RIGHT = 7,
-                            CV_LOC_ROTOR = 8,
-                            CV_LOC_BODY = 9;
+                            CV_LOC_ROTOR = 6,
+                            CV_LOC_BODY = 7,
+                            CV_LOC_SPONSON_LEFT = 8,
+                            CV_LOC_SPONSON_RIGHT = 9;
     public final static String[] MechLocs = { "Head", "Center Torso", "Left Torso",
         "Right Torso", "Left Arm", "Right Arm", "Left Leg", "Right Leg", "Center Leg" },
                                  CVLocs = { "Front", "Left", "Right", "Rear",


### PR DESCRIPTION
Fixes #156 by removing sponson turrets from the Armor locations array defined in CVArmor.java. Per Maelwys, Sponson Turrets can't be armored, but they still needed to be referenced as a location to be able to equip items to them.

Note that this required moving the sponsons to the end of the Locations list in LocationIndex.java because each integer is used to index into the armor location array. 