### PR TITLE
Serialize exclusions and mechmodifiers in equipment JSON; fix some exclusion errors

### DIFF
--- a/Data/Equipment/equipment.json
+++ b/Data/Equipment/equipment.json
@@ -1224,7 +1224,15 @@
     "BattleForceAbilities": [
       "C3M",
       "TAG"
-    ]
+    ],
+    "Exclusions": {
+      "Exclusions": [
+        "Improved C3 Computer",
+        "Null Signature System",
+        "Void Signature System"
+      ],
+      "Excluder": "C3 Computer (Master)"
+    }
   },
   "C3 Computer (Slave)": {
     "ActualName": "Command/Control/Communication Computer (Slave)",
@@ -1318,7 +1326,15 @@
     },
     "BattleForceAbilities": [
       "C3S"
-    ]
+    ],
+    "Exclusions": {
+      "Exclusions": [
+        "Improved C3 Computer",
+        "Null Signature System",
+        "Void Signature System"
+      ],
+      "Excluder": "C3 Computer (Slave)"
+    }
   },
   "Improved C3 Computer": {
     "ActualName": "Improved Command/Control/Communication Computer",
@@ -1412,7 +1428,16 @@
     },
     "BattleForceAbilities": [
       "C3I"
-    ]
+    ],
+    "Exclusions": {
+      "Exclusions": [
+        "C3 Computer (Master)",
+        "C3 Computer (Slave)",
+        "Null Signature System",
+        "Void Signature System"
+      ],
+      "Excluder": "Improved C3 Computer"
+    }
   },
   "C3 Boosted Computer (Master)": {
     "ActualName": "Command/Control/Communication Boosted Computer (Master)",
@@ -1507,7 +1532,15 @@
     "BattleForceAbilities": [
       "C3BSM",
       "TAG"
-    ]
+    ],
+    "Exclusions": {
+      "Exclusions": [
+        "Improved C3 Computer",
+        "Null Signature System",
+        "Void Signature System"
+      ],
+      "Excluder": "C3 Boosted Computer (Master)"
+    }
   },
   "C3 Boosted Computer (Slave)": {
     "ActualName": "Command/Control/Communication Boosted Computer (Slave)",
@@ -1601,7 +1634,15 @@
     },
     "BattleForceAbilities": [
       "C3BSS"
-    ]
+    ],
+    "Exclusions": {
+      "Exclusions": [
+        "Improved C3 Computer",
+        "Null Signature System",
+        "Void Signature System"
+      ],
+      "Excluder": "C3 Boosted Computer (Slave)"
+    }
   },
   "C3 Emergency Master": {
     "ActualName": "Command/Control/Communication Emergency Master",
@@ -1695,7 +1736,15 @@
     },
     "BattleForceAbilities": [
       "C3EM"
-    ]
+    ],
+    "Exclusions": {
+      "Exclusions": [
+        "Improved C3 Computer",
+        "Null Signature System",
+        "Void Signature System"
+      ],
+      "Excluder": "C3 Emergency Master"
+    }
   },
   "C3 Remote Sensor Launcher": {
     "ActualName": "Command/Control/Communication Remote Sensor Launcher",
@@ -2165,7 +2214,13 @@
     },
     "BattleForceAbilities": [
       "-"
-    ]
+    ],
+    "Exclusions": {
+      "Exclusions": [
+        "Radical Heat Sink"
+      ],
+      "Excluder": "Coolant Pod"
+    }
   },
   "Electronic Warfare Equipment": {
     "ActualName": "Electronic Warfare Equipment",
@@ -2729,7 +2784,13 @@
     },
     "BattleForceAbilities": [
       ""
-    ]
+    ],
+    "Exclusions": {
+      "Exclusions": [
+        "HarJel III"
+      ],
+      "Excluder": "HarJel II"
+    }
   },
   "HarJel III": {
     "ActualName": "HarJel III Self-Repair System",
@@ -2823,7 +2884,13 @@
     },
     "BattleForceAbilities": [
       ""
-    ]
+    ],
+    "Exclusions": {
+      "Exclusions": [
+        "HarJel II"
+      ],
+      "Excluder": "HarJel III"
+    }
   },
   "TAG": {
     "ActualName": "Target Acquisition Gear",
@@ -3481,7 +3548,20 @@
     },
     "BattleForceAbilities": [
       "ENG"
-    ]
+    ],
+    "Exclusions": {
+      "Exclusions": [
+        "Backhoe",
+        "Chainsaw",
+        "Combine",
+        "Dual Saw",
+        "Heavy Duty Pile-Driver",
+        "Mining Drill",
+        "Rock Cutter",
+        "Wrecking Ball"
+      ],
+      "Excluder": "Bulldozer"
+    }
   },
   "Fluid Suction System, Standard": {
     "ActualName": "Fluid Suction System, Standard",
@@ -7053,6 +7133,12 @@
     },
     "BattleForceAbilities": [
       "-"
-    ]
+    ],
+    "Exclusions": {
+      "Exclusions": [
+        "Coolant Pod"
+      ],
+      "Excluder": "Radical Heat Sink"
+    }
   }
 }

--- a/Data/Equipment/physicals.json
+++ b/Data/Equipment/physicals.json
@@ -1260,7 +1260,22 @@
     "BattleForceAbilities": [
       "MEL",
       "SHLD"
-    ]
+    ],
+    "Modifier": {
+      "WalkAdd": -1,
+      "RunAdd": 0,
+      "JumpAdd": 0,
+      "RunMult": 0,
+      "PilotMod": 0,
+      "GunneryMod": 0,
+      "HeatAdd": 0,
+      "DefBonus": 0,
+      "MinDefBonus": 0,
+      "ArmorMult": 0,
+      "IntMult": 0,
+      "BVMovement": true,
+      "BVHeatMod": false
+    }
   },
   "Large Shield": {
     "ActualName": "Large Shield",
@@ -1351,7 +1366,22 @@
     "BattleForceAbilities": [
       "MEL",
       "SHLD"
-    ]
+    ],
+    "Modifier": {
+      "WalkAdd": -1,
+      "RunAdd": 0,
+      "JumpAdd": 0,
+      "RunMult": 0,
+      "PilotMod": 0,
+      "GunneryMod": 0,
+      "HeatAdd": 0,
+      "DefBonus": 0,
+      "MinDefBonus": 0,
+      "ArmorMult": 0,
+      "IntMult": 0,
+      "BVMovement": true,
+      "BVHeatMod": false
+    }
   },
   "Backhoe": {
     "ActualName": "Backhoe",

--- a/sswlib/src/main/java/components/BipedLoadout.java
+++ b/sswlib/src/main/java/components/BipedLoadout.java
@@ -4944,57 +4944,57 @@ public boolean IsTripod(){
                 } else {
                     test = (abPlaceable) Queue.get( j );
                 }
-                if( test.CritName().contains( exclude[i] ) ) {
+                if( test.CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + ((abPlaceable) Queue.get( j )).CritName() );
                 }
             }
             // check the loadout proper
             for( int j = 0; j < 6; j++ ) {
-                if( HDCrits[j].CritName().contains( exclude[i] ) ) {
+                if( HDCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + HDCrits[j].CritName() );
                 }
-                if( CTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( CTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + CTCrits[j].CritName() );
                 }
-                if( LTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( LTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + LTCrits[j].CritName() );
                 }
-                if( RTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( RTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + RTCrits[j].CritName() );
                 }
-                if( LACrits[j].CritName().contains( exclude[i] ) ) {
+                if( LACrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + LACrits[j].CritName() );
                 }
-                if( RACrits[j].CritName().contains( exclude[i] ) ) {
+                if( RACrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + RACrits[j].CritName() );
                 }
-                if( LLCrits[j].CritName().contains( exclude[i] ) ) {
+                if( LLCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + LLCrits[j].CritName() );
                 }
-                if( RLCrits[j].CritName().contains( exclude[i] ) ) {
+                if( RLCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + RLCrits[j].CritName() );
                 }
             }
             for( int j = 6; j < 12; j++ ) {
-                if( CTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( CTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + CTCrits[j].CritName() );
                 }
-                if( LTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( LTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + LTCrits[j].CritName() );
                 }
-                if( RTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( RTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + RTCrits[j].CritName() );
                 }
-                if( LACrits[j].CritName().contains( exclude[i] ) ) {
+                if( LACrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + LACrits[j].CritName() );
                 }
-                if( RACrits[j].CritName().contains( exclude[i] ) ) {
+                if( RACrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + RACrits[j].CritName() );
                 }
             }
             // special addition for a targeting computer that is not in the loadout yet
             if( Use_TC ) {
-                if( CurTC.CritName().contains( exclude[i] ) ) {
+                if( CurTC.CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + CurTC.CritName() );
                 }
             }

--- a/sswlib/src/main/java/components/BipedLoadout.java
+++ b/sswlib/src/main/java/components/BipedLoadout.java
@@ -4945,7 +4945,7 @@ public boolean IsTripod(){
                     test = (abPlaceable) Queue.get( j );
                 }
                 if( test.CritName().equals( exclude[i] ) ) {
-                    throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + ((abPlaceable) Queue.get( j )).CritName() );
+                    throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + test.CritName() );
                 }
             }
             // check the loadout proper

--- a/sswlib/src/main/java/components/CVLoadout.java
+++ b/sswlib/src/main/java/components/CVLoadout.java
@@ -1068,7 +1068,7 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
             for( int j = 0; j < GetNonCore().size(); j++ ) {
                 test = (abPlaceable) GetNonCore().get( j );
                 if( test.CritName().equals( exclude[i] ) ) {
-                    throw new Exception( "A Vehicle may not mount an " + p.CritName() + " if it\nalready mounts an " + ((abPlaceable) Queue.get( j )).CritName() );
+                    throw new Exception( "A Vehicle may not mount an " + p.CritName() + " if it\nalready mounts an " + test.CritName() );
                 }
             }
             // special addition for a targeting computer that is not in the loadout yet

--- a/sswlib/src/main/java/components/CVLoadout.java
+++ b/sswlib/src/main/java/components/CVLoadout.java
@@ -1067,13 +1067,13 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
             abPlaceable test;
             for( int j = 0; j < GetNonCore().size(); j++ ) {
                 test = (abPlaceable) GetNonCore().get( j );
-                if( test.CritName().contains( exclude[i] ) ) {
+                if( test.CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A Vehicle may not mount an " + p.CritName() + " if it\nalready mounts an " + ((abPlaceable) Queue.get( j )).CritName() );
                 }
             }
             // special addition for a targeting computer that is not in the loadout yet
             if( Use_TC ) {
-                if( CurTC.CritName().contains( exclude[i] ) ) {
+                if( CurTC.CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A Vehicle may not mount an " + p.CritName() + " if it\nalready mounts an " + CurTC.CritName() );
                 }
             }

--- a/sswlib/src/main/java/components/QuadLoadout.java
+++ b/sswlib/src/main/java/components/QuadLoadout.java
@@ -4660,7 +4660,7 @@ public void SetBoobyTrap( boolean b ) throws Exception{
                     test = (abPlaceable) Queue.get( j );
                 }
                 if( test.CritName().equals( exclude[i] ) ) {
-                    throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + ((abPlaceable) Queue.get( j )).CritName() );
+                    throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + test.CritName() );
                 }
             }
             // check the loadout proper

--- a/sswlib/src/main/java/components/QuadLoadout.java
+++ b/sswlib/src/main/java/components/QuadLoadout.java
@@ -4659,51 +4659,51 @@ public void SetBoobyTrap( boolean b ) throws Exception{
                 } else {
                     test = (abPlaceable) Queue.get( j );
                 }
-                if( test.CritName().contains( exclude[i] ) ) {
+                if( test.CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + ((abPlaceable) Queue.get( j )).CritName() );
                 }
             }
             // check the loadout proper
             for( int j = 0; j < 6; j++ ) {
-                if( HDCrits[j].CritName().contains( exclude[i] ) ) {
+                if( HDCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + HDCrits[j].CritName() );
                 }
-                if( CTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( CTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + CTCrits[j].CritName() );
                 }
-                if( LTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( LTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + LTCrits[j].CritName() );
                 }
-                if( RTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( RTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + RTCrits[j].CritName() );
                 }
-                if( LACrits[j].CritName().contains( exclude[i] ) ) {
+                if( LACrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + LACrits[j].CritName() );
                 }
-                if( RACrits[j].CritName().contains( exclude[i] ) ) {
+                if( RACrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + RACrits[j].CritName() );
                 }
-                if( LLCrits[j].CritName().contains( exclude[i] ) ) {
+                if( LLCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + LLCrits[j].CritName() );
                 }
-                if( RLCrits[j].CritName().contains( exclude[i] ) ) {
+                if( RLCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + RLCrits[j].CritName() );
                 }
             }
             for( int j = 6; j < 12; j++ ) {
-                if( CTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( CTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + CTCrits[j].CritName() );
                 }
-                if( LTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( LTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + LTCrits[j].CritName() );
                 }
-                if( RTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( RTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + RTCrits[j].CritName() );
                 }
             }
             // special addition for a targeting computer that is not in the loadout yet
             if( Use_TC ) {
-                if( CurTC.CritName().contains( exclude[i] ) ) {
+                if( CurTC.CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + CurTC.CritName() );
                 }
             }

--- a/sswlib/src/main/java/components/TripodLoadout.java
+++ b/sswlib/src/main/java/components/TripodLoadout.java
@@ -5138,7 +5138,7 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
                     test = (abPlaceable) Queue.get( j );
                 }
                 if( test.CritName().equals( exclude[i] ) ) {
-                    throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + ((abPlaceable) Queue.get( j )).CritName() );
+                    throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + test.CritName() );
                 }
             }
             // check the loadout proper

--- a/sswlib/src/main/java/components/TripodLoadout.java
+++ b/sswlib/src/main/java/components/TripodLoadout.java
@@ -5137,60 +5137,60 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
                 } else {
                     test = (abPlaceable) Queue.get( j );
                 }
-                if( test.CritName().contains( exclude[i] ) ) {
+                if( test.CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + ((abPlaceable) Queue.get( j )).CritName() );
                 }
             }
             // check the loadout proper
             for( int j = 0; j < 6; j++ ) {
-                if( HDCrits[j].CritName().contains( exclude[i] ) ) {
+                if( HDCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + HDCrits[j].CritName() );
                 }
-                if( CTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( CTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + CTCrits[j].CritName() );
                 }
-                if( LTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( LTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + LTCrits[j].CritName() );
                 }
-                if( RTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( RTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + RTCrits[j].CritName() );
                 }
-                if( LACrits[j].CritName().contains( exclude[i] ) ) {
+                if( LACrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + LACrits[j].CritName() );
                 }
-                if( RACrits[j].CritName().contains( exclude[i] ) ) {
+                if( RACrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + RACrits[j].CritName() );
                 }
-                if( LLCrits[j].CritName().contains( exclude[i] ) ) {
+                if( LLCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + LLCrits[j].CritName() );
                 }
-                if( RLCrits[j].CritName().contains( exclude[i] ) ) {
+                if( RLCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + RLCrits[j].CritName() );
                 }
-                if( CLCrits[j].CritName().contains( exclude[i] ) ) {
+                if( CLCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + CLCrits[j].CritName() );
                 }
             }
             for( int j = 6; j < 12; j++ ) {
-                if( CTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( CTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + CTCrits[j].CritName() );
                 }
-                if( LTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( LTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + LTCrits[j].CritName() );
                 }
-                if( RTCrits[j].CritName().contains( exclude[i] ) ) {
+                if( RTCrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + RTCrits[j].CritName() );
                 }
-                if( LACrits[j].CritName().contains( exclude[i] ) ) {
+                if( LACrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + LACrits[j].CritName() );
                 }
-                if( RACrits[j].CritName().contains( exclude[i] ) ) {
+                if( RACrits[j].CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + RACrits[j].CritName() );
                 }
             }
             // special addition for a targeting computer that is not in the loadout yet
             if( Use_TC ) {
-                if( CurTC.CritName().contains( exclude[i] ) ) {
+                if( CurTC.CritName().equals( exclude[i] ) ) {
                     throw new Exception( "A mech may not mount an " + p.CritName() + " if it\nalready mounts an " + CurTC.CritName() );
                 }
             }

--- a/sswlib/src/main/java/components/abPlaceable.java
+++ b/sswlib/src/main/java/components/abPlaceable.java
@@ -34,9 +34,9 @@ import java.util.logging.Logger;
 public abstract class abPlaceable implements Comparable<abPlaceable> {
     // An abstract class for items that can be placed inside a loadout.
     protected transient boolean Locked = false,  Armored = false;
-    private transient Exclusion Exclusions = null;
     public final static AvailableCode ArmoredAC = new AvailableCode( AvailableCode.TECH_BOTH );
-    private transient MechModifier Modifier = null;
+    private Exclusion Exclusions = null;
+    private MechModifier Modifier = null;
     private String[] BattleForceAbilities = new String[]{};
 
     public abPlaceable() {

--- a/sswlib/src/main/java/filehandlers/JsonReader.java
+++ b/sswlib/src/main/java/filehandlers/JsonReader.java
@@ -17,7 +17,6 @@ import java.util.stream.Collectors;
 
 public class JsonReader {
     private Gson gson = new GsonBuilder()
-            .serializeNulls()
             .setPrettyPrinting()
             .disableHtmlEscaping()
             .registerTypeAdapter(Ammunition.class, new AmmunitionInstanceCreator())

--- a/sswlib/src/main/java/filehandlers/JsonWriter.java
+++ b/sswlib/src/main/java/filehandlers/JsonWriter.java
@@ -13,7 +13,6 @@ import java.util.Map;
 
 public class JsonWriter {
     private Gson gson = new GsonBuilder()
-            .serializeNulls()
             .setPrettyPrinting()
             .disableHtmlEscaping()
             .create();


### PR DESCRIPTION
I'd previously left out equipment exclusions and physical weapon mech modifiers when converting the equipment files from binary to JSON. This PR updates the JSON models to serialize and deserialize the relevant fields to populate these objects, as well as instructing gson not to serialize null values going forward. This means we won't need to update all the models when adding new fields.

While I was at it, I also looked at #107 and determined the root cause was `CheckExclusions()` was using `.contains()` rather than `.equals()` when comparing the item name to the exclusions, so if the exclusion was a substring of the item being checked, it would conflict and throw an exception. I changed all of these calls to `.contains()` because I can't think of a logical reason to use the substring.

Attaching a build to test below before we merge for RC2.

[SSW_0.7.4 RC1.zip](https://github.com/Solaris-Skunk-Werks/solarisskunkwerks/files/5176633/SSW_0.7.4.RC1.zip)
