### PR TITLE
Fix SAW BV Issues

### DIFF
--- a/sswlib/src/main/java/components/CVArmor.java
+++ b/sswlib/src/main/java/components/CVArmor.java
@@ -1016,7 +1016,7 @@ public class CVArmor extends abPlaceable {
     }
 
     public double GetDefensiveBV() {
-        return ( GetArmorValue() + GetModularArmorValue() ) * 2.5;
+        return ( GetArmorValue() + GetModularArmorValue() ) * GetBVTypeMult() * 2.5;
     }
 
     public int GetBAR() {

--- a/sswlib/src/main/java/components/CombatVehicle.java
+++ b/sswlib/src/main/java/components/CombatVehicle.java
@@ -305,6 +305,10 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
     public boolean IsVTOL() {
         return getCurConfig().IsVTOL();
     }
+
+    public boolean IsWIGE() {
+        return getCurConfig().IsWIGE();
+    }
     
     public boolean IsNaval() {
         return ( (CurConfig instanceof stCVDisplacement) || 
@@ -2139,8 +2143,8 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
         // Get the defensive factors for jumping and running movement
         double ground = DefensiveFactor[RunMP];
         
-        //VTOL's get an extra .1
-        if ( IsVTOL() ) ground += .1;
+        //VTOL's and WiGEs get an extra .1
+        if ( IsVTOL() || IsWIGE() ) ground += .1;
         
         //Stealth Armor gets an extra .2
         if ( GetArmor().IsStealth() ) ground += .2;

--- a/sswlib/src/main/java/states/ifCombatVehicle.java
+++ b/sswlib/src/main/java/states/ifCombatVehicle.java
@@ -39,7 +39,8 @@ public interface ifCombatVehicle {
     public int GetCostMultiplier();
     public double GetDefensiveMultiplier();
     public boolean RequiresLiftEquipment();
-    public boolean IsVTOL();
+    default boolean IsVTOL() { return false; }
+    default boolean IsWIGE() { return false; }
     public boolean CanBeTrailer();
     public boolean CanBeDuneBuggy();
     public boolean CanUseJumpMP();

--- a/sswlib/src/main/java/states/stCVDisplacement.java
+++ b/sswlib/src/main/java/states/stCVDisplacement.java
@@ -68,10 +68,6 @@ public class stCVDisplacement implements ifCombatVehicle {
         return true;
     }
 
-    public boolean IsVTOL() {
-        return false;
-    }
-
     public boolean CanBeDuneBuggy() {
         return false;
     }

--- a/sswlib/src/main/java/states/stCVDisplacementSH.java
+++ b/sswlib/src/main/java/states/stCVDisplacementSH.java
@@ -70,10 +70,6 @@ public class stCVDisplacementSH implements ifCombatVehicle {
         return true;
     }
 
-    public boolean IsVTOL() {
-        return false;
-    }
-
     public boolean CanBeDuneBuggy() {
         return false;
     }

--- a/sswlib/src/main/java/states/stCVHover.java
+++ b/sswlib/src/main/java/states/stCVHover.java
@@ -78,10 +78,6 @@ public class stCVHover implements ifCombatVehicle {
         return true;
     }
 
-    public boolean IsVTOL() {
-        return false;
-    }
-
     public boolean CanBeDuneBuggy() {
         return false;
     }

--- a/sswlib/src/main/java/states/stCVHoverSH.java
+++ b/sswlib/src/main/java/states/stCVHoverSH.java
@@ -70,10 +70,6 @@ public class stCVHoverSH implements ifCombatVehicle {
         return true;
     }
 
-    public boolean IsVTOL() {
-        return false;
-    }
-
     public boolean CanBeDuneBuggy() {
         return false;
     }

--- a/sswlib/src/main/java/states/stCVHydrofoil.java
+++ b/sswlib/src/main/java/states/stCVHydrofoil.java
@@ -90,10 +90,6 @@ public class stCVHydrofoil implements ifCombatVehicle {
         return true;
     }
 
-    public boolean IsVTOL() {
-        return false;
-    }
-
     public boolean CanBeDuneBuggy() {
         return false;
     }

--- a/sswlib/src/main/java/states/stCVSubmarine.java
+++ b/sswlib/src/main/java/states/stCVSubmarine.java
@@ -70,10 +70,6 @@ public class stCVSubmarine implements ifCombatVehicle {
         return true;
     }
 
-    public boolean IsVTOL() {
-        return false;
-    }
-
     public boolean CanBeDuneBuggy() {
         return false;
     }

--- a/sswlib/src/main/java/states/stCVTracked.java
+++ b/sswlib/src/main/java/states/stCVTracked.java
@@ -70,10 +70,6 @@ public class stCVTracked implements ifCombatVehicle {
         return true;
     }
 
-    public boolean IsVTOL() {
-        return false;
-    }
-
     public boolean CanBeDuneBuggy() {
         return false;
     }

--- a/sswlib/src/main/java/states/stCVVTOL.java
+++ b/sswlib/src/main/java/states/stCVVTOL.java
@@ -76,6 +76,7 @@ public class stCVVTOL implements ifCombatVehicle {
         return false;
     }
 
+    @Override
     public boolean IsVTOL() {
         return true;
     }

--- a/sswlib/src/main/java/states/stCVWheeled.java
+++ b/sswlib/src/main/java/states/stCVWheeled.java
@@ -70,10 +70,6 @@ public class stCVWheeled implements ifCombatVehicle {
         return true;
     }
 
-    public boolean IsVTOL() {
-        return false;
-    }
-
     public boolean CanBeDuneBuggy() {
         return true;
     }

--- a/sswlib/src/main/java/states/stCVWiGE.java
+++ b/sswlib/src/main/java/states/stCVWiGE.java
@@ -78,9 +78,8 @@ public class stCVWiGE implements ifCombatVehicle {
         return true;
     }
 
-    public boolean IsVTOL() {
-        return false;
-    }
+    @Override
+    public boolean IsWIGE() { return true; }
 
     public boolean CanBeDuneBuggy() {
         return false;


### PR DESCRIPTION
This addresses #130 by adding the +1 TMM to WiGE's and adding an additional modifier to fix an error in the defensive BV calculation for combat vehicles. The IsVTOL and IsWIGE methods were refactored to default to false so that they don't have to be explicitly implemented in every class that uses the combat vehicle interface.