### PR TITLE
Add fields to equipment for saw to calculate heatsinks properly

### DIFF
--- a/sswlib/src/main/java/components/Equipment.java
+++ b/sswlib/src/main/java/components/Equipment.java
@@ -75,7 +75,10 @@ public class Equipment extends abPlaceable {
                     CanMountRear = false,
                     Explosive = false,
                     VariableSize = false,
-                    RequiresQuad = false;
+                    RequiresQuad = false,
+                    RequiresFusion = false,
+                    RequiresNuclear = false,
+                    RequiresPowerAmps = false;
     private transient boolean Rear = false;
     @SerializedName("Availability") private AvailableCode AC;
 
@@ -459,6 +462,18 @@ public class Equipment extends abPlaceable {
 
     public boolean RequiresQuad() {
         return RequiresQuad;
+    }
+
+    public boolean RequiresFusion() {
+        return RequiresFusion;
+    }
+
+    public boolean RequiresNuclear() {
+        return RequiresNuclear;
+    }
+
+    public boolean RequiresPowerAmps() {
+        return RequiresPowerAmps;
     }
 
     public int MaxAllowed() {


### PR DESCRIPTION
This starts to address #163 by adding some fields SAW needs to properly calculate the number of heatsinks when adding equipment. We will still need to add some logic to SAW to use this information, as well as update the equipment JSON where appropriate.