### PR TITLE
Fix ECM/Probe/C3 Requirements

### DIFF
--- a/BFB/src/main/java/BFB/Common/Constants.java
+++ b/BFB/src/main/java/BFB/Common/Constants.java
@@ -30,7 +30,7 @@ package BFB.Common;
 public class Constants {
     public final static String AppName = "Battletech Force Balancer",
                         AppDescription = "Battletech Force Balancer",
-                        Version = "0.7.4",
+                        Version = "0.7.4.1",
                         AppRelease = "Stable",
                         Author = "George Blouin",
                         EMail = "george.blouin@gmail.com",

--- a/Docs/0.7.4.1 Changes.txt
+++ b/Docs/0.7.4.1 Changes.txt
@@ -1,7 +1,8 @@
-This is a quick hotfix to address one known bug
+This is a quick hotfix to address two known bugs.
 
 You can download the newest version, and join our development discord through our Github page here.  We welcome all who want to help make SSW even better: https://github.com/Solaris-Skunk-Werks/solarisskunkwerks#solaris-skunk-werks
 
 **Main Features and fixes:**
 
 * Fixed a bug where equipped ECMs, Probes, and C3s could not be found by gear that required it (e.g.: Stealth Armor)
+* Fixed a separate related bug where the selected equipment list wasn't updated when ECMs are auto-added

--- a/Docs/0.7.4.1 Changes.txt
+++ b/Docs/0.7.4.1 Changes.txt
@@ -1,0 +1,7 @@
+This is a quick hotfix to address one known bug
+
+You can download the newest version, and join our development discord through our Github page here.  We welcome all who want to help make SSW even better: https://github.com/Solaris-Skunk-Werks/solarisskunkwerks#solaris-skunk-werks
+
+**Main Features and fixes:**
+
+* Fixed a bug where equipped ECMs, Probes, and C3s could not be found by gear that required it (e.g.: Stealth Armor)

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 allprojects {
-    version '0.7.4'
+    version '0.7.4.1'
     jar {
         onlyIf { !sourceSets.main.allSource.files.isEmpty() }
     }

--- a/saw/src/main/java/saw/Constants.java
+++ b/saw/src/main/java/saw/Constants.java
@@ -34,7 +34,7 @@ public class Constants {
     // here is the versioning and program name
     public final static String AppName = "SAW",
                         AppDescription = "Solaris Armor Werks",
-                        Version = "0.7.4",
+                        Version = "0.7.4.1",
                         AppRelease = "Stable",
                         ImageListFileName = "S7Images",
                         LogFileName = "Logs/SAW_Log.txt",

--- a/ssw/src/main/java/ssw/constants/SSWConstants.java
+++ b/ssw/src/main/java/ssw/constants/SSWConstants.java
@@ -34,7 +34,7 @@ public class SSWConstants {
     // here is the versioning and program name
     public final static String AppName = "SSW",
                         AppDescription = "Solaris Skunk Werks",
-                        Version = "0.7.4",
+                        Version = "0.7.4.1",
                         AppRelease = "Stable",
                         ImageListFileName = "Data/Solaris7/S7Images",
                         LogDirectoryName = "Logs",

--- a/ssw/src/main/java/ssw/gui/frmMain.java
+++ b/ssw/src/main/java/ssw/gui/frmMain.java
@@ -28,55 +28,35 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package ssw.gui;
 
-import ssw.filehandlers.HTMLWriter;
-import ssw.filehandlers.HMPReader;
-import ssw.gui.DamageChart;
+import Print.PrintConsts;
+import battleforce.BattleForceStats;
 import common.CommonTools;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Cursor;
-import java.awt.Image;
+import common.DataFactory;
+import components.*;
+import dialog.frmForce;
+import filehandlers.*;
+import gui.TextPane;
+import list.view.tbQuirks;
+import ssw.constants.SSWConstants;
+import ssw.filehandlers.HMPReader;
+import ssw.filehandlers.HTMLWriter;
+import ssw.print.Printer;
+import ssw.printpreview.dlgPreview;
+import states.ifState;
+import visitors.VArmorSetPatchworkLocation;
+import visitors.VMechFullRecalc;
+import visitors.VSetArmorTonnage;
+import visitors.ifVisitor;
+
+import javax.swing.*;
+import javax.swing.text.JTextComponent;
+import java.awt.*;
 import java.awt.datatransfer.DataFlavor;
-import java.awt.event.ActionEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.FocusAdapter;
-import java.awt.event.FocusEvent;
+import java.awt.event.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import javax.swing.DropMode;
-import javax.swing.ImageIcon;
-import javax.swing.JFileChooser;
-import javax.swing.JMenuItem;
-import javax.swing.JPopupMenu;
-import javax.swing.JSpinner;
-import javax.swing.SpinnerNumberModel;
-
-import components.*;
-import filehandlers.*;
-import ssw.print.Printer;
-import visitors.*;
-import states.ifState;
-import java.util.prefs.*;
-import javax.swing.JEditorPane;
-import javax.swing.JTextField;
-import javax.swing.text.JTextComponent;
-import battleforce.*;
-import common.DataFactory;
-import dialog.frmForce;
-import components.EquipmentCollection;
-import ssw.printpreview.dlgPreview;
-import Print.PrintConsts;
-import ssw.constants.SSWConstants;
-import gui.TextPane;
-import javax.swing.JFrame;
-import javax.swing.JOptionPane;
-
-import javax.swing.SwingUtilities;
-import list.view.tbQuirks;
+import java.util.prefs.Preferences;
 
 public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer.ClipboardOwner, common.DesignForm, ifMechForm {
     FocusAdapter spinners = new FocusAdapter() {
@@ -579,11 +559,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         Equipment[ARTILLERY] = data.GetEquipment().GetArtillery( CurMech );
         Equipment[EQUIPMENT] = data.GetEquipment().GetEquipment( CurMech );
         Equipment[AMMUNITION] = new Object[] { " " };
-        if( CurMech.GetLoadout().GetNonCore().toArray().length <= 0 ) {
-            Equipment[SELECTED] = new Object[] { " " };
-        } else {
-            Equipment[SELECTED] = CurMech.GetLoadout().GetNonCore().toArray();
-        }
+        RefreshSelectedEquipment();
 
         for( int i = 0; i < Equipment.length; i++ ) {
             if( Equipment[i] == null ) {
@@ -3163,12 +3139,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
             CurMech.GetLoadout().Remove( CurItem );
 
             // refresh the selected equipment listbox
-            if( CurMech.GetLoadout().GetNonCore().toArray().length <= 0 ) {
-                Equipment[SELECTED] = new Object[] { " " };
-            } else {
-                Equipment[SELECTED] = CurMech.GetLoadout().GetNonCore().toArray();
-            }
-            lstSelectedEquipment.setListData( Equipment[SELECTED] );
+            RefreshSelectedEquipment();
 
             // Check the targeting computer if needed
             if( CurMech.UsingTC() ) {
@@ -4744,12 +4715,22 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
                     }
                 }
                 CurMech.GetLoadout().AddToQueue( a );
+                RefreshSelectedEquipment();
             }
             return true;
         } else {
             Media.Messager( this, "Please add an appropriate ECM Suite to complement this\n system.  The 'Mech is not valid without an ECM Suite." );
             return true;
         }
+    }
+
+    private void RefreshSelectedEquipment() {
+        if(CurMech.GetLoadout().GetNonCore().toArray().length <= 0) {
+            Equipment[SELECTED] = new Object[] { " " };
+        } else {
+            Equipment[SELECTED] = CurMech.GetLoadout().GetNonCore().toArray();
+        }
+        lstSelectedEquipment.setListData(Equipment[SELECTED]);
     }
 
      /** This method is called from within the constructor to
@@ -11322,12 +11303,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         }
 
         // refresh the selected equipment listbox
-        if( CurMech.GetLoadout().GetNonCore().toArray().length <= 0 ) {
-            Equipment[SELECTED] = new Object[] { " " };
-        } else {
-            Equipment[SELECTED] = CurMech.GetLoadout().GetNonCore().toArray();
-        }
-        lstSelectedEquipment.setListData( Equipment[SELECTED] );
+        RefreshSelectedEquipment();
 
         // now refresh the information panes
         RefreshSummary();
@@ -12260,12 +12236,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
             }
         }
         // refresh the selected equipment listbox
-        if( CurMech.GetLoadout().GetNonCore().toArray().length <= 0 ) {
-            Equipment[SELECTED] = new Object[] { " " };
-        } else {
-            Equipment[SELECTED] = CurMech.GetLoadout().GetNonCore().toArray();
-        }
-        lstSelectedEquipment.setListData( Equipment[SELECTED] );
+        RefreshSelectedEquipment();
 
         // Check the targeting computer if needed
         if( CurMech.UsingTC() ) {
@@ -12418,12 +12389,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
                 }
 
                 // refresh the selected equipment listbox
-                if( CurMech.GetLoadout().GetNonCore().toArray().length <= 0 ) {
-                    Equipment[SELECTED] = new Object[] { " " };
-                } else {
-                    Equipment[SELECTED] = CurMech.GetLoadout().GetNonCore().toArray();
-                }
-                lstSelectedEquipment.setListData( Equipment[SELECTED] );
+                RefreshSelectedEquipment();
             }
 
             // now refresh the information panes
@@ -12437,12 +12403,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         CurMech.GetLoadout().SafeClearLoadout();
 
         // refresh the selected equipment listbox
-        if( CurMech.GetLoadout().GetNonCore().toArray().length <= 0 ) {
-            Equipment[SELECTED] = new Object[] { " " };
-        } else {
-            Equipment[SELECTED] = CurMech.GetLoadout().GetNonCore().toArray();
-        }
-        lstSelectedEquipment.setListData( Equipment[SELECTED] );
+        RefreshSelectedEquipment();
 
         // Check the targeting computer if needed
         if( CurMech.UsingTC() ) {

--- a/ssw/src/main/java/ssw/gui/frmMainWide.java
+++ b/ssw/src/main/java/ssw/gui/frmMainWide.java
@@ -28,49 +28,34 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package ssw.gui;
 
-import ssw.filehandlers.HTMLWriter;
-import ssw.filehandlers.HMPReader;
-import ssw.gui.DamageChart;
+import Print.PrintConsts;
+import battleforce.BattleForceStats;
 import common.CommonTools;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Cursor;
-import java.awt.Image;
+import common.DataFactory;
+import components.*;
+import dialog.frmForce;
+import filehandlers.*;
+import gui.TextPane;
+import list.view.tbQuirks;
+import ssw.constants.SSWConstants;
+import ssw.filehandlers.HMPReader;
+import ssw.filehandlers.HTMLWriter;
+import ssw.print.Printer;
+import ssw.printpreview.dlgPreview;
+import states.ifState;
+import visitors.VArmorSetPatchworkLocation;
+import visitors.VMechFullRecalc;
+import visitors.VSetArmorTonnage;
+import visitors.ifVisitor;
+
+import javax.swing.*;
+import java.awt.*;
 import java.awt.datatransfer.DataFlavor;
-import java.awt.event.ActionEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
-import java.awt.event.KeyEvent;
+import java.awt.event.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import javax.swing.DropMode;
-import javax.swing.ImageIcon;
-import javax.swing.JFileChooser;
-import javax.swing.JMenuItem;
-import javax.swing.JPopupMenu;
-import javax.swing.SpinnerNumberModel;
-
-import components.*;
-import filehandlers.*;
-import ssw.print.Printer;
-import visitors.*;
-import states.ifState;
-import java.util.prefs.*;
-import javax.swing.JEditorPane;
-import javax.swing.JTextField;
-import battleforce.*;
-import common.DataFactory;
-import dialog.frmForce;
-import components.EquipmentCollection;
-import ssw.printpreview.dlgPreview;
-import Print.PrintConsts;
-import ssw.constants.SSWConstants;
-import gui.TextPane;
-
-import javax.swing.SwingUtilities;
-import list.view.tbQuirks;
+import java.util.prefs.Preferences;
 
 public class frmMainWide extends javax.swing.JFrame implements java.awt.datatransfer.ClipboardOwner, common.DesignForm, ifMechForm {
 
@@ -4618,11 +4603,20 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
                     }
                 }
                 CurMech.GetLoadout().AddToQueue( a );
+                RefreshSelectedEquipment();
             }
             return true;
         } else {
             Media.Messager( this, "Please add an appropriate ECM Suite to complement this\n system.  The 'Mech is not valid without an ECM Suite." );
             return true;
+        }
+    }
+
+    private void RefreshSelectedEquipment() {
+        if(CurMech.GetLoadout().GetNonCore().toArray().length <= 0) {
+            Equipment[SELECTED] = new Object[] { " " };
+        } else {
+            Equipment[SELECTED] = CurMech.GetLoadout().GetNonCore().toArray();
         }
     }
 

--- a/sswlib/src/main/java/common/Constants.java
+++ b/sswlib/src/main/java/common/Constants.java
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package common;
 
 public class Constants {
-    public final static String LibVersion = "0.7.4",
+    public final static String LibVersion = "0.7.4.1",
                                BASELOADOUT_NAME = "Base Loadout",
                                WEAPONSFILE = "Data/Equipment/weapons.dat",
                                PHYSICALSFILE = "Data/Equipment/physicals.dat",

--- a/sswlib/src/main/java/components/BipedLoadout.java
+++ b/sswlib/src/main/java/components/BipedLoadout.java
@@ -28,11 +28,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package components;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Stream;
 
 import common.CommonTools;
 import visitors.VFCSApolloLoader;

--- a/sswlib/src/main/java/components/BipedLoadout.java
+++ b/sswlib/src/main/java/components/BipedLoadout.java
@@ -28,7 +28,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package components;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
 import common.CommonTools;
 import visitors.VFCSApolloLoader;
 import visitors.VFCSArtemisIVLoader;
@@ -1096,6 +1101,19 @@ public boolean IsTripod(){
         default:
             return null;
         }
+    }
+
+    public List<abPlaceable> GetCrits() {
+        List<abPlaceable> crits = new ArrayList<>();
+        crits.addAll(Arrays.asList(HDCrits));
+        crits.addAll(Arrays.asList(CTCrits));
+        crits.addAll(Arrays.asList(LTCrits));
+        crits.addAll(Arrays.asList(RTCrits));
+        crits.addAll(Arrays.asList(LACrits));
+        crits.addAll(Arrays.asList(RACrits));
+        crits.addAll(Arrays.asList(LLCrits));
+        crits.addAll(Arrays.asList(RLCrits));
+        return crits;
     }
 
     public int Find( abPlaceable p ) {

--- a/sswlib/src/main/java/components/Mech.java
+++ b/sswlib/src/main/java/components/Mech.java
@@ -34,7 +34,6 @@ import battleforce.*;
 import common.CommonTools;
 import java.util.Hashtable;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.prefs.Preferences;
 import visitors.*;
 

--- a/sswlib/src/main/java/components/Mech.java
+++ b/sswlib/src/main/java/components/Mech.java
@@ -28,14 +28,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package components;
 
-import java.util.Enumeration;
-import common.Constants;
 import battleforce.*;
 import common.CommonTools;
-import java.util.Hashtable;
-import java.util.ArrayList;
-import java.util.prefs.Preferences;
+import common.Constants;
 import visitors.*;
+
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.prefs.Preferences;
 
 public class Mech implements ifUnit, ifBattleforce {
     // A mech for the designer.  This is a large container class that will
@@ -4719,7 +4720,7 @@ public class Mech implements ifUnit, ifBattleforce {
     }
 
     public boolean HasC3() {
-        for (abPlaceable item : CurLoadout.GetCrits()) {
+        for (abPlaceable item : (ArrayList<abPlaceable>)CurLoadout.GetEquipment()) {
             if (item.LookupName().contains("C3")) {
                 return true;
             }
@@ -4728,7 +4729,7 @@ public class Mech implements ifUnit, ifBattleforce {
     }
 
     public boolean HasECM() {
-        for (abPlaceable item : CurLoadout.GetCrits()) {
+        for (abPlaceable item : (ArrayList<abPlaceable>)CurLoadout.GetEquipment()) {
             if (item.LookupName().contains("ECM") || item.LookupName().contains("Watchdog")) {
                 return true;
             }
@@ -4737,7 +4738,7 @@ public class Mech implements ifUnit, ifBattleforce {
     }
 
     public boolean HasProbe() {
-        for (abPlaceable item : CurLoadout.GetCrits()) {
+        for (abPlaceable item : (ArrayList<abPlaceable>)CurLoadout.GetEquipment()) {
             if (item.LookupName().contains("Probe")) {
                 return true;
             }

--- a/sswlib/src/main/java/components/Mech.java
+++ b/sswlib/src/main/java/components/Mech.java
@@ -34,6 +34,7 @@ import battleforce.*;
 import common.CommonTools;
 import java.util.Hashtable;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.prefs.Preferences;
 import visitors.*;
 
@@ -4719,37 +4720,28 @@ public class Mech implements ifUnit, ifBattleforce {
     }
 
     public boolean HasC3() {
-        // checks for C3 systems.
-        SimplePlaceable p = new SimplePlaceable( "C3Test", "C3Test", "C3Test", "C3Test", "none", 0, false, null );
-        p.SetExclusions( new Exclusion( new String[] { "C3" }, "C3Test" ) );
-        try {
-            CurLoadout.CheckExclusions( p );
-        } catch( Exception e ) {
-            return true;
+        for (abPlaceable item : CurLoadout.GetCrits()) {
+            if (item.LookupName().contains("C3")) {
+                return true;
+            }
         }
         return false;
     }
 
     public boolean HasECM() {
-        // ensures that, if the 'Mech needs ECM, it has it.
-        SimplePlaceable p = new SimplePlaceable( "ECMTest", "ECMTest", "ECMTest", "ECMTest", "none", 0, false, null );
-        p.SetExclusions( new Exclusion( new String[] { "ECM", "Watchdog" }, "ECMTest" ) );
-        try {
-            CurLoadout.CheckExclusions( p );
-        } catch( Exception e ) {
-            return true;
+        for (abPlaceable item : CurLoadout.GetCrits()) {
+            if (item.LookupName().contains("ECM") || item.LookupName().contains("Watchdog")) {
+                return true;
+            }
         }
         return false;
     }
 
     public boolean HasProbe() {
-        // ensures that, if the 'Mech needs Probe, it has it.
-        SimplePlaceable p = new SimplePlaceable( "ProbeTest", "ProbeTest", "ProbeTest", "ProbeTest", "none", 0, false, null );
-        p.SetExclusions( new Exclusion( new String[] { "Probe" }, "ProbeTest" ) );
-        try {
-            CurLoadout.CheckExclusions( p );
-        } catch( Exception e ) {
-            return true;
+        for (abPlaceable item : CurLoadout.GetCrits()) {
+            if (item.LookupName().contains("Probe")) {
+                return true;
+            }
         }
         return false;
     }

--- a/sswlib/src/main/java/components/QuadLoadout.java
+++ b/sswlib/src/main/java/components/QuadLoadout.java
@@ -30,6 +30,9 @@ package components;
 
 import common.CommonTools;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import visitors.VFCSArtemisIVLoader;
 import visitors.VFCSArtemisVLoader;
 import visitors.VFCSApolloLoader;
@@ -970,6 +973,19 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
         default:
             return null;
         }
+    }
+
+    public List<abPlaceable> GetCrits() {
+        List<abPlaceable> crits = new ArrayList<>();
+        crits.addAll(Arrays.asList(HDCrits));
+        crits.addAll(Arrays.asList(CTCrits));
+        crits.addAll(Arrays.asList(LTCrits));
+        crits.addAll(Arrays.asList(RTCrits));
+        crits.addAll(Arrays.asList(LACrits));
+        crits.addAll(Arrays.asList(RACrits));
+        crits.addAll(Arrays.asList(LLCrits));
+        crits.addAll(Arrays.asList(RLCrits));
+        return crits;
     }
 
     public int Find( abPlaceable p ) {

--- a/sswlib/src/main/java/components/TripodLoadout.java
+++ b/sswlib/src/main/java/components/TripodLoadout.java
@@ -29,6 +29,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package components;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import common.CommonTools;
 import visitors.VFCSApolloLoader;
 import visitors.VFCSArtemisIVLoader;
@@ -1162,6 +1165,20 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
         default:
             return null;
         }
+    }
+
+    public List<abPlaceable> GetCrits() {
+        List<abPlaceable> crits = new ArrayList<>();
+        crits.addAll(Arrays.asList(HDCrits));
+        crits.addAll(Arrays.asList(CTCrits));
+        crits.addAll(Arrays.asList(LTCrits));
+        crits.addAll(Arrays.asList(RTCrits));
+        crits.addAll(Arrays.asList(LACrits));
+        crits.addAll(Arrays.asList(RACrits));
+        crits.addAll(Arrays.asList(LLCrits));
+        crits.addAll(Arrays.asList(RLCrits));
+        crits.addAll(Arrays.asList(CLCrits));
+        return crits;
     }
 
     public int Find( abPlaceable p ) {

--- a/sswlib/src/main/java/components/ifMechLoadout.java
+++ b/sswlib/src/main/java/components/ifMechLoadout.java
@@ -29,6 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package components;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public interface ifMechLoadout {
     public void SetName( String s );
@@ -100,6 +101,7 @@ public interface ifMechLoadout {
     public abPlaceable[] GetLLCrits();
     public abPlaceable[] GetCLCrits();
     public abPlaceable[] GetCrits( int Loc );
+    public List<abPlaceable> GetCrits();
     public int Find( abPlaceable p );
     public LocationIndex FindIndex( abPlaceable p );
     public ArrayList FindSplitIndex( abPlaceable p );


### PR DESCRIPTION
7.4 contained a regression caused by refactoring the `CheckExclusions()` logic to fix a different bug with HarJels conflicting with themselves. Previously, `CheckExclusions()` only checked if equipped items contained a substring, rather than comparing the whole name. `HasECM()`, `HasProbe()`, and `HasC3()` relied on this behavior to act as a wildcard search for equipped items, causing them to not be found when the behavior changed, causing #167.

This hotfix corrects the issue by refactoring the `Has` functions to use their own conditions to conduct the search, keeping `CheckExclusions` working by matching only the exact name. Mech Loadouts now expose a new method that returns a single `List` of all equipped items, allowing callers to easily search the whole mech for equipment rather than having to check each location individually using static arrays.