### PR TITLE
Build system improvements

### DIFF
--- a/BFB/build.gradle
+++ b/BFB/build.gradle
@@ -47,13 +47,11 @@ task copyDependencies {
     }
 }
 
-//distributions {
-//    main {
-//        contents {
-//            from ('../') {
-//                include 'Data/**'
-//                into 'bin'
-//            }
-//        }
-//    }
-//}
+task writeProperties(type: WriteProperties) {
+    outputFile "${buildDir}/resources/main/BFB/build.properties"
+    property 'version', version
+    property 'releaseType', releaseType
+    property 'date', date
+}
+
+compileJava.finalizedBy(writeProperties)

--- a/BFB/src/main/java/BFB/Common/Constants.java
+++ b/BFB/src/main/java/BFB/Common/Constants.java
@@ -27,11 +27,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package BFB.Common;
 
+import java.util.Properties;
+
 public class Constants {
     public final static String AppName = "Battletech Force Balancer",
                         AppDescription = "Battletech Force Balancer",
-                        Version = "0.7.4.1",
-                        AppRelease = "Stable",
                         Author = "George Blouin",
                         EMail = "george.blouin@gmail.com",
                         Print_ForceList = "Print.ForceList",
@@ -63,4 +63,24 @@ public class Constants {
                                  "Support Vehicle", "Mobile Structure" };
     public final static String NL = System.getProperty( "line.separator" );
     public final static String Tab = "\t";
+
+    public static String GetVersion() {
+        Properties props = new Properties();
+        try {
+            props.load(Constants.class.getResourceAsStream("/BFB/build.properties"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return props.getProperty("version");
+    }
+
+    public static String GetReleaseType() {
+        Properties props = new Properties();
+        try {
+            props.load(Constants.class.getResourceAsStream("/BFB/build.properties"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return props.getProperty("releaseType");
+    }
 }

--- a/BFB/src/main/java/BFB/Common/Constants.java
+++ b/BFB/src/main/java/BFB/Common/Constants.java
@@ -71,7 +71,11 @@ public class Constants {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        return props.getProperty("version");
+        if (props.getProperty("releaseType").equals("Nightly")) {
+            return props.getProperty("version") + "." + props.getProperty("date");
+        } else {
+            return props.getProperty("version");
+        }
     }
 
     public static String GetReleaseType() {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,10 @@ apply plugin: 'java'
 
 allprojects {
     version '0.7.4.1'
+    ext {
+        releaseType='Nightly'
+        date=getDate()
+    }
     jar {
         onlyIf { !sourceSets.main.allSource.files.isEmpty() }
     }
@@ -14,115 +18,39 @@ subprojects {
     }
 }
 
+static def getDate() {
+    def date = new Date()
+    def formattedDate = date.format('yyyyMMdd')
+    return formattedDate.toString()
+}
+
 evaluationDependsOnChildren()
 
-task releaseBuild(dependsOn: subprojects.build) {
-    doLast {
-        copy {
-            from 'Data'
-            into "${buildDir}/release/SSW_${version}/Data"
-        }
-        copy {
-            from "./ssw/build/libs"
-            into "${buildDir}/release/SSW_${version}"
-        }
-        copy {
-            from "./ssw/build/deps"
-            into "${buildDir}/release/SSW_${version}/lib"
-        }
-        copy {
-            from "./BFB/build/libs"
-            into "${buildDir}/release/SSW_${version}"
-        }
-        copy {
-            from "./BFB/build/deps"
-            into "${buildDir}/release//SSW_${version}/lib"
-        }
-        copy {
-            from "./saw/build/libs"
-            into "${buildDir}/release/SSW_${version}"
-        }
-        copy {
-            from "./saw/build/deps"
-            into "${buildDir}/release/SSW_${version}/lib"
-        }
-        copy {
-            from "./sswlib/build/libs"
-            into "${buildDir}/release/SSW_${version}/lib"
-        }
-        copy {
-            from "./binconvert/build/libs"
-            into "${buildDir}/release/SSW_${version}"
-        }
-        copy {
-            from "./binconvert/build/deps"
-            into "${buildDir}/release/SSW_${version}/lib"
-        }
-    }
+task copyDocs(dependsOn: subprojects.build, type: Copy) {
+    from 'Docs'
+    into "${buildDir}/release/SSW_${version}/Docs"
 }
 
-task copyDocs (dependsOn: subprojects.build) {
-    copy {
-        from 'Docs'
-        into "${buildDir}/release/SSW_${version}/Docs"
-    }
+task copyData(dependsOn: subprojects.build, type: Copy) {
+    from 'Data'
+    into "${buildDir}/release/SSW_${version}/Data"
 }
 
-task zipRelease(type: Zip, dependsOn: ['releaseBuild', 'copyDocs']) {
+task copyDeps(dependsOn: subprojects.build, type: Copy) {
+    from subprojects.collect { it.configurations.runtime }
+    into "$buildDir/release/SSW_${version}/lib"
+}
+
+task copyJars(dependsOn: subprojects.build, type: Copy) {
+    from subprojects.collect { it.tasks.withType(Jar) }
+    exclude "**/sswlib.jar"
+    into "$buildDir/release/SSW_${version}"
+}
+
+task releaseBuild(dependsOn: [copyDocs, copyData, copyDeps, copyJars]) { }
+
+task zipRelease(type: Zip, dependsOn: releaseBuild) {
         from "${buildDir}/release"
         include "**/"
         archiveName "SSW_${version}.zip"
 }
-
-//apply plugin: 'java-library-distribution'
-//distributions {
-//    main {
-//        baseName = "SSW"
-//        contents {
-//            exclude "dist-${version}.jar"
-//            from ('.') {
-//                include 'Data/**'
-//                into '.'
-//            }
-//            from ("./ssw/build/libs") {
-//                include "*.jar"
-//                into "."
-//            }
-//            from ("./BFB/build/libs") {
-//                include "*.jar"
-//                into "."
-//
-//            }
-//            from ("./saw/build/libs") {
-//                include "*.jar"
-//                into "."
-//            }
-//        }
-//    }
-//}
-
-
-//task copyResources {
-//    copy {
-//        from 'Data'
-//        into 'build/libs/Data'
-//        include '**/'
-//    }
-//}
-
-//task copyJars(type: Copy) {
-//    //dependsOn subprojects.build
-//    from subprojects.collect { it.tasks.withType(Jar) }
-//    into project.rootProject.buildDir.toString() + "/libs"
-//}
-////
-//task copyDependencies(type: Copy) {
-//    from subprojects.collect { it.artifacts }
-//    into project.rootProject.buildDir.toString() + "/libs/lib"
-//}
-//
-//task copyStartScripts(type: Copy) {
-//    dependsOn copyJars
-//    from subprojects.collect { it.tasks.withType(CreateStartScripts) }
-//    into project.rootProject.buildDir.toString() + "/scripts"
-//}

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'java'
 
 allprojects {
-    version '0.7.4.1'
+    version '0.7.4.2'
     ext {
-        releaseType='Stable'
+        releaseType='Nightly'
         date=getDate()
     }
     jar {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'java'
 allprojects {
     version '0.7.4.1'
     ext {
-        releaseType='Nightly'
+        releaseType='Stable'
         date=getDate()
     }
     jar {
@@ -50,7 +50,11 @@ task copyJars(dependsOn: subprojects.build, type: Copy) {
 task releaseBuild(dependsOn: [copyDocs, copyData, copyDeps, copyJars]) { }
 
 task zipRelease(type: Zip, dependsOn: releaseBuild) {
-        from "${buildDir}/release"
+    from "${buildDir}/release"
         include "**/"
+    if ("$releaseType" == "Nightly") {
+        archiveName "SSW_${version}.${date}"
+    } else {
         archiveName "SSW_${version}.zip"
+    }
 }

--- a/saw/build.gradle
+++ b/saw/build.gradle
@@ -40,6 +40,13 @@ task copyAssets (dependsOn: deleteAssets) {
     }
 }
 
+task writeProperties(type: WriteProperties) {
+    outputFile "${buildDir}/resources/main/saw/build.properties"
+    property 'version', version
+    property 'releaseType', releaseType
+    property 'date', date
+}
+
 task copyDependencies {
     copy {
         into "${buildDir}/deps"
@@ -47,13 +54,4 @@ task copyDependencies {
     }
 }
 
-//distributions {
-//    main {
-//        contents {
-//            from ('../') {
-//                include 'Data/**'
-//                into 'lib'
-//            }
-//        }
-//    }
-//}
+compileJava.finalizedBy(writeProperties)

--- a/saw/src/main/java/saw/Constants.java
+++ b/saw/src/main/java/saw/Constants.java
@@ -28,14 +28,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package saw;
 
+import java.util.Properties;
+
 public class Constants {
     // Constants for the program
 
     // here is the versioning and program name
     public final static String AppName = "SAW",
                         AppDescription = "Solaris Armor Werks",
-                        Version = "0.7.4.1",
-                        AppRelease = "Stable",
                         ImageListFileName = "S7Images",
                         LogFileName = "Logs/SAW_Log.txt",
                         HTMLTemplateName = "Data/Templates/Vee_HTML.html",
@@ -49,4 +49,24 @@ public class Constants {
                      ART4_APOLLO = 3;
     public final static int SCREEN_SIZE_NORMAL = 0,
                             SCREEN_SIZE_WIDE_1280 = 1;
+
+    public static String GetVersion() {
+        Properties props = new Properties();
+        try {
+            props.load(Constants.class.getResourceAsStream("/saw/build.properties"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return props.getProperty("version");
+    }
+
+    public static String GetReleaseType() {
+        Properties props = new Properties();
+        try {
+            props.load(Constants.class.getResourceAsStream("/saw/build.properties"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return props.getProperty("releaseType");
+    }
 }

--- a/saw/src/main/java/saw/Constants.java
+++ b/saw/src/main/java/saw/Constants.java
@@ -57,7 +57,11 @@ public class Constants {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        return props.getProperty("version");
+        if (props.getProperty("releaseType").equals("Nightly")) {
+            return props.getProperty("version") + "." + props.getProperty("date");
+        } else {
+            return props.getProperty("version");
+        }
     }
 
     public static String GetReleaseType() {

--- a/saw/src/main/java/saw/Main.java
+++ b/saw/src/main/java/saw/Main.java
@@ -134,7 +134,7 @@ public class Main {
                     System.out.println("Error loading Icon image...\n" + e.getMessage());
                 }
                 
-                MainFrame.setTitle( Constants.AppDescription + " " + Constants.Version );
+                MainFrame.setTitle( Constants.AppDescription + " " + Constants.GetVersion() );
                 MainFrame.setLocationRelativeTo( null );
                 //MainFrame.setResizable( true );
                 MainFrame.setDefaultCloseOperation( javax.swing.JFrame.DISPOSE_ON_CLOSE );

--- a/saw/src/main/java/saw/gui/dlgAboutBox.java
+++ b/saw/src/main/java/saw/gui/dlgAboutBox.java
@@ -43,8 +43,8 @@ public class dlgAboutBox extends javax.swing.JDialog {
         setResizable( false );
         setTitle( "About " + saw.Constants.AppDescription );
         lblAppName.setText(saw.Constants.AppDescription);
-        lblVersion.setText(saw.Constants.Version);
-        lblRelease.setText(saw.Constants.AppRelease);
+        lblVersion.setText(saw.Constants.GetVersion());
+        lblRelease.setText(saw.Constants.GetReleaseType());
     }
 
     /** This method is called from within the constructor to

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -157,7 +157,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         cmbMotiveTypeActionPerformed(null);
         spnTonnageStateChanged(null);
 
-        setTitle( saw.Constants.AppDescription + " " + saw.Constants.Version );
+        setTitle( saw.Constants.AppDescription + " " + saw.Constants.GetVersion() );
 
         // added for easy checking
         PPCCapAC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
@@ -6511,7 +6511,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         }
 
         setCursor( NormalCursor );
-        setTitle( saw.Constants.AppName + " " + saw.Constants.Version + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
+        setTitle( saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
         CurVee.SetChanged( false );
     }//GEN-LAST:event_btnSaveActionPerformed
     private void SaveOmniFluffInfo() {
@@ -6994,7 +6994,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             chkYearRestrict.setEnabled( true );
         }
         CurVee.SetChanged( false );
-        setTitle( saw.Constants.AppDescription + " " + saw.Constants.Version );
+        setTitle( saw.Constants.AppDescription + " " + saw.Constants.GetVersion() );
     }
 
     private void CheckOmni() {
@@ -7789,7 +7789,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             //cmbOmniVariant.setSelectedItem( CurLoadout );
             //cmbOmniVariantActionPerformed( evt );
         }
-        setTitle( saw.Constants.AppName + " " + saw.Constants.Version + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
+        setTitle( saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
 }//GEN-LAST:event_btnExportTXTActionPerformed
 
     private void btnExportHTMLActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnExportHTMLActionPerformed
@@ -7826,7 +7826,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             //cmbOmniVariant.setSelectedItem( CurLoadout );
             //cmbOmniVariantActionPerformed( evt );
         }
-        setTitle( saw.Constants.AppName + " " + saw.Constants.Version + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
+        setTitle( saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
 }//GEN-LAST:event_btnExportHTMLActionPerformed
 
     private void btnExportMTFActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnExportMTFActionPerformed
@@ -7853,7 +7853,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
 
         // if there were no problems, let the user know how it went
         Media.Messager( this, "Vehicle saved successfully to MTF:\n" + filename );
-        setTitle( saw.Constants.AppName + " " + saw.Constants.Version + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
+        setTitle( saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
 }//GEN-LAST:event_btnExportMTFActionPerformed
 
     private void btnAddQuirkActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnAddQuirkActionPerformed
@@ -8942,7 +8942,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         txtCommSystem.setText( CurVee.GetCommSystem() );
         txtTNTSystem.setText( CurVee.GetTandTSystem() );
 
-        setTitle( saw.Constants.AppName + " " + saw.Constants.Version + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
+        setTitle( saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
         CurVee.SetChanged(false);
     }
 
@@ -9096,7 +9096,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         }
 
         setCursor(NormalCursor);
-        setTitle(saw.Constants.AppName + " " + saw.Constants.Version + " - " + CurVee.GetName() + " " + CurVee.GetModel());
+        setTitle(saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel());
         CurVee.SetChanged(false);
     }//GEN-LAST:event_mnuSaveActionPerformed
 
@@ -9154,7 +9154,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             cmbOmniVariant.setSelectedItem(CurLoadout);
             cmbOmniVariantActionPerformed(evt);
         }
-        setTitle(saw.Constants.AppName + " " + saw.Constants.Version + " - " + CurVee.GetName() + " " + CurVee.GetModel());
+        setTitle(saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel());
         CurVee.SetChanged(false);
         setCursor(NormalCursor);
     }//GEN-LAST:event_mnuSaveAsActionPerformed
@@ -9638,7 +9638,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             cmbOmniVariant.setSelectedItem( CurLoadout );
             cmbOmniVariantActionPerformed( evt );
         }
-        setTitle( saw.Constants.AppName + " " + saw.Constants.Version + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
+        setTitle( saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
         SetSource = true;
     }//GEN-LAST:event_btnExportHTMLIconActionPerformed
 

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -155,7 +155,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         cmbMotiveTypeActionPerformed(null);
         spnTonnageStateChanged(null);
 
-        setTitle( saw.Constants.AppDescription + " " + saw.Constants.Version );
+        setTitle( saw.Constants.AppDescription + " " + saw.Constants.GetVersion() );
 
         // added for easy checking
         PPCCapAC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
@@ -5903,7 +5903,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         }
 
         setCursor( NormalCursor );
-        setTitle( saw.Constants.AppName + " " + saw.Constants.Version + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
+        setTitle( saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
         CurVee.SetChanged( false );
     }//GEN-LAST:event_btnSaveActionPerformed
     private void SaveOmniFluffInfo() {
@@ -6327,7 +6327,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             chkYearRestrict.setEnabled( true );
         }
         CurVee.SetChanged( false );
-        setTitle( saw.Constants.AppDescription + " " + saw.Constants.Version );
+        setTitle( saw.Constants.AppDescription + " " + saw.Constants.GetVersion() );
     }
 
     private void CheckOmni() {
@@ -7152,7 +7152,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         txtCommSystem.setText( CurVee.GetCommSystem() );
         txtTNTSystem.setText( CurVee.GetTandTSystem() );
 
-        setTitle( saw.Constants.AppName + " " + saw.Constants.Version + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
+        setTitle( saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
         CurVee.SetChanged(false);
     }
 
@@ -7306,7 +7306,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         }
 
         setCursor(NormalCursor);
-        setTitle(saw.Constants.AppName + " " + saw.Constants.Version + " - " + CurVee.GetName() + " " + CurVee.GetModel());
+        setTitle(saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel());
         CurVee.SetChanged(false);
     }//GEN-LAST:event_mnuSaveActionPerformed
 
@@ -7364,7 +7364,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             cmbOmniVariant.setSelectedItem(CurLoadout);
             cmbOmniVariantActionPerformed(evt);
         }
-        setTitle(saw.Constants.AppName + " " + saw.Constants.Version + " - " + CurVee.GetName() + " " + CurVee.GetModel());
+        setTitle(saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel());
         CurVee.SetChanged(false);
         setCursor(NormalCursor);
     }//GEN-LAST:event_mnuSaveAsActionPerformed
@@ -7718,7 +7718,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             cmbOmniVariant.setSelectedItem( CurLoadout );
             cmbOmniVariantActionPerformed( evt );
         }
-        setTitle( saw.Constants.AppName + " " + saw.Constants.Version + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
+        setTitle( saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
         SetSource = true;
     }//GEN-LAST:event_btnExportHTMLIconActionPerformed
 
@@ -7767,7 +7767,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
 
         // if there were no problems, let the user know how it went
         Media.Messager(this, "Vehicle saved successfully to MTF:\n" + filename);
-        setTitle(saw.Constants.AppName + " " + saw.Constants.Version + " - " + CurVee.GetName() + " " + CurVee.GetModel());
+        setTitle(saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel());
     }//GEN-LAST:event_btnExportMTFActionPerformed
 
     private void btnExportHTMLActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnExportHTMLActionPerformed
@@ -7804,7 +7804,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             //cmbOmniVariant.setSelectedItem( CurLoadout );
             //cmbOmniVariantActionPerformed( evt );
         }
-        setTitle(saw.Constants.AppName + " " + saw.Constants.Version + " - " + CurVee.GetName() + " " + CurVee.GetModel());
+        setTitle(saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel());
     }//GEN-LAST:event_btnExportHTMLActionPerformed
 
     private void btnExportTXTActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnExportTXTActionPerformed
@@ -7841,7 +7841,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             //cmbOmniVariant.setSelectedItem( CurLoadout );
             //cmbOmniVariantActionPerformed( evt );
         }
-        setTitle(saw.Constants.AppName + " " + saw.Constants.Version + " - " + CurVee.GetName() + " " + CurVee.GetModel());
+        setTitle(saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel());
     }//GEN-LAST:event_btnExportTXTActionPerformed
 
     private void btnClearImageActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnClearImageActionPerformed

--- a/ssw/build.gradle
+++ b/ssw/build.gradle
@@ -41,6 +41,13 @@ task copyAssets (dependsOn: deleteAssets) {
     }
 }
 
+task writeProperties(type: WriteProperties) {
+    outputFile "${buildDir}/resources/main/ssw/build.properties"
+    property 'version', version
+    property 'releaseType', releaseType
+    property 'date', date
+}
+
 task copyDependencies {
     copy {
         into "${buildDir}/deps"
@@ -48,3 +55,4 @@ task copyDependencies {
     }
 }
 
+compileJava.finalizedBy(writeProperties)

--- a/ssw/src/main/java/ssw/constants/SSWConstants.java
+++ b/ssw/src/main/java/ssw/constants/SSWConstants.java
@@ -58,7 +58,7 @@ public class SSWConstants {
     public static String GetVersion() {
         Properties props = new Properties();
         try {
-            props.load(dlgAboutBox.class.getResourceAsStream("/ssw/build.properties"));
+            props.load(SSWConstants.class.getResourceAsStream("/ssw/build.properties"));
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -68,7 +68,7 @@ public class SSWConstants {
     public static String GetReleaseType() {
         Properties props = new Properties();
         try {
-            props.load(dlgAboutBox.class.getResourceAsStream("/ssw/build.properties"));
+            props.load(SSWConstants.class.getResourceAsStream("/ssw/build.properties"));
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/ssw/src/main/java/ssw/constants/SSWConstants.java
+++ b/ssw/src/main/java/ssw/constants/SSWConstants.java
@@ -28,14 +28,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package ssw.constants;
 
+import ssw.gui.dlgAboutBox;
+
+import java.util.Properties;
+
 public class SSWConstants {
     // SSWConstants for the program
 
     // here is the versioning and program name
     public final static String AppName = "SSW",
                         AppDescription = "Solaris Skunk Werks",
-                        Version = "0.7.4.1",
-                        AppRelease = "Stable",
                         ImageListFileName = "Data/Solaris7/S7Images",
                         LogDirectoryName = "Logs",
                         LogFileName = "SSW_Log.txt",
@@ -52,4 +54,24 @@ public class SSWConstants {
                         PrefsNodeName = "/com/sswsuite/ssw";
     public final static int SCREEN_SIZE_NORMAL = 0,
                             SCREEN_SIZE_WIDE_1280 = 1;
+
+    public static String GetVersion() {
+        Properties props = new Properties();
+        try {
+            props.load(dlgAboutBox.class.getResourceAsStream("/ssw/build.properties"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return props.getProperty("version");
+    }
+
+    public static String GetReleaseType() {
+        Properties props = new Properties();
+        try {
+            props.load(dlgAboutBox.class.getResourceAsStream("/ssw/build.properties"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return props.getProperty("releaseType");
+    }
 }

--- a/ssw/src/main/java/ssw/constants/SSWConstants.java
+++ b/ssw/src/main/java/ssw/constants/SSWConstants.java
@@ -62,7 +62,11 @@ public class SSWConstants {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        return props.getProperty("version");
+        if (props.getProperty("releaseType").equals("Nightly")) {
+            return props.getProperty("version") + "." + props.getProperty("date");
+        } else {
+            return props.getProperty("version");
+        }
     }
 
     public static String GetReleaseType() {

--- a/ssw/src/main/java/ssw/gui/dlgAboutBox.java
+++ b/ssw/src/main/java/ssw/gui/dlgAboutBox.java
@@ -28,14 +28,22 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package ssw.gui;
 
+import filehandlers.Media;
 import ssw.constants.SSWConstants;
 
 import java.awt.Point;
+import java.util.Arrays;
+import java.util.Properties;
 
 public class dlgAboutBox extends javax.swing.JDialog {
 
     ifMechForm Parent;
 
+//    public class GetVersion {
+//        public static String GetVersion() {
+//
+//        }
+//    }
     /** Creates new form dlgAboutBox */
     public dlgAboutBox(java.awt.Frame parent, boolean modal) {
         super(parent, modal);
@@ -44,8 +52,8 @@ public class dlgAboutBox extends javax.swing.JDialog {
         setResizable( false );
         setTitle( "About " + SSWConstants.AppDescription );
         lblAppName.setText(SSWConstants.AppDescription);
-        lblVersion.setText(SSWConstants.Version);
-        lblRelease.setText(SSWConstants.AppRelease);
+        lblRelease.setText(SSWConstants.GetReleaseType());
+        lblVersion.setText(SSWConstants.GetVersion());
     }
 
     /** This method is called from within the constructor to

--- a/ssw/src/main/java/ssw/gui/frmMain.java
+++ b/ssw/src/main/java/ssw/gui/frmMain.java
@@ -212,7 +212,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         pnlVariants.add( Variants );
         pnlNotables.add( Notables );
         setViewToolbar( Prefs.getBoolean( "ViewToolbar", true ) );
-        setTitle( SSWConstants.AppDescription + " " + SSWConstants.Version );
+        setTitle( SSWConstants.AppDescription + " " + SSWConstants.GetVersion() );
         pack();
 
         mnuDetails.addActionListener( new java.awt.event.ActionListener() {
@@ -2816,7 +2816,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
             chkYearRestrict.setEnabled( true );
         }
         CurMech.SetChanged( false );
-        setTitle( SSWConstants.AppDescription + " " + SSWConstants.Version );
+        setTitle( SSWConstants.AppDescription + " " + SSWConstants.GetVersion() );
     }
 
     private void GetInfoOn() {
@@ -12533,7 +12533,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
 
         // if there were no problems, let the user know how it went
         Media.Messager( this, "Mech saved successfully to MTF:\n" + filename );
-        setTitle( SSWConstants.AppName + " " + SSWConstants.Version + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
+        setTitle( SSWConstants.AppName + " " + SSWConstants.GetVersion() + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
     }//GEN-LAST:event_btnExportMTFActionPerformed
 
     private void lstChoosePhysicalValueChanged(javax.swing.event.ListSelectionEvent evt) {//GEN-FIRST:event_lstChoosePhysicalValueChanged
@@ -12577,7 +12577,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
             cmbOmniVariant.setSelectedItem( CurLoadout );
             cmbOmniVariantActionPerformed( evt );
         }
-        setTitle( SSWConstants.AppName + " " + SSWConstants.Version + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
+        setTitle( SSWConstants.AppName + " " + SSWConstants.GetVersion() + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
     }//GEN-LAST:event_btnExportTXTActionPerformed
 
     private void btnExportHTMLActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnExportHTMLActionPerformed
@@ -12614,7 +12614,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
             cmbOmniVariant.setSelectedItem( CurLoadout );
             cmbOmniVariantActionPerformed( evt );
         }
-        setTitle( SSWConstants.AppName + " " + SSWConstants.Version + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
+        setTitle( SSWConstants.AppName + " " + SSWConstants.GetVersion() + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
     }//GEN-LAST:event_btnExportHTMLActionPerformed
 
     private void mnuAboutSSWActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_mnuAboutSSWActionPerformed
@@ -13160,7 +13160,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         }
 
         setCursor( NormalCursor );
-        setTitle( SSWConstants.AppName + " " + SSWConstants.Version + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
+        setTitle( SSWConstants.AppName + " " + SSWConstants.GetVersion() + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
         CurMech.SetChanged( false );
 	}//GEN-LAST:event_mnuSaveActionPerformed
 
@@ -13234,7 +13234,7 @@ private void mnuSaveAsActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIR
         cmbOmniVariant.setSelectedItem( CurLoadout );
         cmbOmniVariantActionPerformed( evt );
     }
-    setTitle( SSWConstants.AppName + " " + SSWConstants.Version + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
+    setTitle( SSWConstants.AppName + " " + SSWConstants.GetVersion() + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
     CurMech.SetChanged( false );
     setCursor( NormalCursor );
 }//GEN-LAST:event_mnuSaveAsActionPerformed
@@ -13771,7 +13771,7 @@ public void LoadMechIntoGUI() {
         txtSumPAmpsACode.setVisible( true );
     }
 
-    setTitle( SSWConstants.AppName + " " + SSWConstants.Version + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
+    setTitle( SSWConstants.AppName + " " + SSWConstants.GetVersion() + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
 }
 
 private void mnuExportClipboardActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_mnuExportClipboardActionPerformed

--- a/ssw/src/main/java/ssw/gui/frmMainWide.java
+++ b/ssw/src/main/java/ssw/gui/frmMainWide.java
@@ -198,7 +198,7 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
         pnlVariants.add( Variants );
         pnlNotables.add( Notables );
         setViewToolbar( Prefs.getBoolean( "ViewToolbar", true ) );
-        setTitle( SSWConstants.AppDescription + " " + SSWConstants.Version );
+        setTitle( SSWConstants.AppDescription + " " + SSWConstants.GetVersion() );
         pack();
 
         mnuDetails.addActionListener( new java.awt.event.ActionListener() {
@@ -2728,7 +2728,7 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
             chkYearRestrict.setEnabled( true );
         }
         CurMech.SetChanged( false );
-        setTitle( SSWConstants.AppDescription + " " + SSWConstants.Version );
+        setTitle( SSWConstants.AppDescription + " " + SSWConstants.GetVersion() );
     }
 
     private void GetInfoOn() {
@@ -10688,7 +10688,7 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
         }
 
         setCursor( NormalCursor );
-        setTitle( SSWConstants.AppName + " " + SSWConstants.Version + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
+        setTitle( SSWConstants.AppName + " " + SSWConstants.GetVersion() + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
         CurMech.SetChanged( false );
 	}//GEN-LAST:event_mnuSaveActionPerformed
 
@@ -10762,7 +10762,7 @@ private void mnuSaveAsActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIR
         cmbOmniVariant.setSelectedItem( CurLoadout );
         cmbOmniVariantActionPerformed( evt );
     }
-    setTitle( SSWConstants.AppName + " " + SSWConstants.Version + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
+    setTitle( SSWConstants.AppName + " " + SSWConstants.GetVersion() + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
     CurMech.SetChanged( false );
     setCursor( NormalCursor );
 }//GEN-LAST:event_mnuSaveAsActionPerformed
@@ -11048,7 +11048,7 @@ public void LoadMechIntoGUI() {
         txtSumPAmpsACode.setVisible( true );
     }
 
-    setTitle( SSWConstants.AppName + " " + SSWConstants.Version + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
+    setTitle( SSWConstants.AppName + " " + SSWConstants.GetVersion() + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
 }
 
 private void mnuExportClipboardActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_mnuExportClipboardActionPerformed
@@ -11379,7 +11379,7 @@ private void btnExportMTFActionPerformed(java.awt.event.ActionEvent evt) {//GEN-
 
     // if there were no problems, let the user know how it went
     Media.Messager( this, "Mech saved successfully to MTF:\n" + filename );
-    setTitle( SSWConstants.AppName + " " + SSWConstants.Version + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
+    setTitle( SSWConstants.AppName + " " + SSWConstants.GetVersion() + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
 }//GEN-LAST:event_btnExportMTFActionPerformed
 
 private void btnExportHTMLActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnExportHTMLActionPerformed
@@ -11416,7 +11416,7 @@ private void btnExportHTMLActionPerformed(java.awt.event.ActionEvent evt) {//GEN
         cmbOmniVariant.setSelectedItem( CurLoadout );
         cmbOmniVariantActionPerformed( evt );
     }
-    setTitle( SSWConstants.AppName + " " + SSWConstants.Version + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
+    setTitle( SSWConstants.AppName + " " + SSWConstants.GetVersion() + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
 }//GEN-LAST:event_btnExportHTMLActionPerformed
 
 private void btnExportTXTActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnExportTXTActionPerformed
@@ -11453,7 +11453,7 @@ private void btnExportTXTActionPerformed(java.awt.event.ActionEvent evt) {//GEN-
         cmbOmniVariant.setSelectedItem( CurLoadout );
         cmbOmniVariantActionPerformed( evt );
     }
-    setTitle( SSWConstants.AppName + " " + SSWConstants.Version + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
+    setTitle( SSWConstants.AppName + " " + SSWConstants.GetVersion() + " - " + CurMech.GetName() + " " + CurMech.GetModel() );
 }//GEN-LAST:event_btnExportTXTActionPerformed
 
 private void btnClearImageActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnClearImageActionPerformed

--- a/sswlib/src/main/java/common/Constants.java
+++ b/sswlib/src/main/java/common/Constants.java
@@ -29,8 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package common;
 
 public class Constants {
-    public final static String LibVersion = "0.7.4.1",
-                               BASELOADOUT_NAME = "Base Loadout",
+    public final static String BASELOADOUT_NAME = "Base Loadout",
                                WEAPONSFILE = "Data/Equipment/weapons.dat",
                                PHYSICALSFILE = "Data/Equipment/physicals.dat",
                                EQUIPMENTFILE = "Data/Equipment/equipment.dat",


### PR DESCRIPTION
This cleans up our gradle build system substantially by removing unneeded code, comments, and correcting the task order so that the `releaseBuild` task actually runs how it's supposed to. 

We now only have to update the version number and release type in a single place (the root `build.gradle`), and the build system will generate a `build.properties` file for each project during compilation and include them as a resource to be read from the Java. The date is resolved dynamically, and is appended to the archive name and version info in the apps when it's set to "Nightly". The properties files are written to directories under each project's `build/` rather than `src/main/resources`, so they will be automatically cleaned up when gradle `clean` tasks are ran.

Each app has had new methods `GetVersion()` and `GetReleaseType()` added to their respective `Constants` classes, and all references to the original hardcoded strings have been replaced with these. 