### PR TITLE
Dynamically resolve classpath in jar tasks

### DIFF
--- a/BFB/build.gradle
+++ b/BFB/build.gradle
@@ -19,7 +19,8 @@ application {
 jar {
     manifest.attributes (
             'Main-Class' : 'BFB.Main',
-            'Class-Path' : 'lib/sswlib.jar',
+            'Class-Path' : configurations.runtimeClasspath.files
+                    .findAll { it.name.endsWith(".jar") }.collect { "lib/${it.name}" }.join(' '),
             'SplashScreen-Image' : 'Images/BFB_Load.png'
     )
     archiveName = "BFB.jar"

--- a/binconvert/build.gradle
+++ b/binconvert/build.gradle
@@ -20,7 +20,8 @@ application {
 jar {
     manifest.attributes (
             'Main-Class' : 'binaryconverter.Main',
-            'Class-Path' : 'lib/sswlib.jar lib/AbsoluteLayout-RELEASE110.jar lib/gson-2.8.6.jar'
+            'Class-Path' : configurations.runtimeClasspath.files
+                    .findAll { it.name.endsWith(".jar") }.collect { "lib/${it.name}" }.join(' '),
     )
     jar.archiveName = "binconvert.jar"
 }

--- a/saw/build.gradle
+++ b/saw/build.gradle
@@ -20,7 +20,8 @@ application {
 jar {
     manifest.attributes (
             'Main-Class' : 'saw.Main',
-            'Class-Path' : 'lib/sswlib.jar lib/AbsoluteLayout-RELEASE110.jar lib/gson-2.8.6.jar'
+            'Class-Path' : configurations.runtimeClasspath.files
+                    .findAll { it.name.endsWith(".jar") }.collect { "lib/${it.name}" }.join(' '),
     )
     jar.archiveName = "SAW.jar"
 }

--- a/ssw/build.gradle
+++ b/ssw/build.gradle
@@ -20,7 +20,8 @@ application {
 jar {
     manifest.attributes (
             'Main-Class' : 'ssw.Main',
-            'Class-Path' : 'lib/sswlib.jar lib/AbsoluteLayout-RELEASE110.jar lib/gson-2.8.6.jar',
+            'Class-Path' : configurations.runtimeClasspath.files
+                    .findAll { it.name.endsWith(".jar") }.collect { "lib/${it.name}" }.join(' '),
             'SplashScreen-Image' : 'ssw/Images/splash.png'
     )
     archiveName = "SSW.jar"


### PR DESCRIPTION
This dynamically populates the classpath when executing the jar task, so all dependencies will automatically be added rather than us having to remember to hardcode them when new libs are added.