### PR TITLE
Use csv library to read and write unit list cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ task zipRelease(type: Zip, dependsOn: releaseBuild) {
     from "${buildDir}/release"
         include "**/"
     if ("$releaseType" == "Nightly") {
-        archiveName "SSW_${version}.${date}"
+        archiveName "SSW_${version}.${date}.zip"
     } else {
         archiveName "SSW_${version}.zip"
     }

--- a/sswlib/build.gradle
+++ b/sswlib/build.gradle
@@ -9,6 +9,7 @@ java {
 
 dependencies {
     implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'org.apache.commons:commons-csv:1.8'
     
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/sswlib/src/main/java/filehandlers/MechReader.java
+++ b/sswlib/src/main/java/filehandlers/MechReader.java
@@ -200,7 +200,10 @@ public class MechReader {
                     if (node.getNodeName().equals("source")) {Config.setSource( node.getTextContent() );}
                     if (node.getNodeName().equals("info")) {Config.setInfo( node.getTextContent() );}
                     try {
-                        if (node.getNodeName().equals("battleforce")) {Config.setBattleForceStats( new BattleForceStats( node ) );}
+                        if (node.getNodeName().equals("battleforce")) {
+                            Config.setBattleForceStats( new BattleForceStats( node ) );
+                            Config.getBattleForceStats().setElement(Config.getFullName());
+                        }
                     } catch ( Exception e ) {
                         System.out.println(e.getMessage());
                     }
@@ -288,7 +291,10 @@ public class MechReader {
                     if (node.getNodeName().equals("source")) {Config.setSource( node.getTextContent() );}
                     if (node.getNodeName().equals("info")) {Config.setInfo( node.getTextContent() );}
                     try {
-                        if (node.getNodeName().equals("battleforce")) {Config.setBattleForceStats( new BattleForceStats( node ) );}
+                        if (node.getNodeName().equals("battleforce")) {
+                            Config.setBattleForceStats( new BattleForceStats( node ) );
+                            Config.getBattleForceStats().setElement(Config.getFullName());
+                        }
                     } catch ( Exception e ) {
                         System.out.println(e.getMessage());
                     }

--- a/sswlib/src/main/java/filehandlers/UnitCacheParser.java
+++ b/sswlib/src/main/java/filehandlers/UnitCacheParser.java
@@ -1,0 +1,38 @@
+package filehandlers;
+
+import list.UnitListData;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.CSVRecord;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class UnitCacheParser {
+    public static ArrayList<UnitListData> LoadUnitCache(BufferedReader br) throws IOException {
+        ArrayList<UnitListData> units = new ArrayList<>();
+        CSVParser parser = CSVParser.parse(br, CSVFormat.DEFAULT);
+        for (CSVRecord record : parser) {
+            List<String> values = new ArrayList<>();
+            for (int i = 0; i < record.size(); i++) {
+                values.add(record.get(i));
+            }
+            units.add(new UnitListData(values));
+        }
+        return units;
+    }
+
+    public static int WriteUnitCache(ArrayList<UnitListData> unitList, BufferedWriter bw) throws IOException {
+        int unitsWritten = 0;
+        CSVPrinter printer = new CSVPrinter(bw, CSVFormat.DEFAULT);
+        for (UnitListData unit : unitList) {
+            printer.printRecord(unit.toCsvIndex());
+            unitsWritten++;
+        }
+        return unitsWritten;
+    }
+}

--- a/sswlib/src/main/java/list/UnitList.java
+++ b/sswlib/src/main/java/list/UnitList.java
@@ -28,19 +28,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package list;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.ArrayList;
-import javax.swing.table.AbstractTableModel;
-
-import filehandlers.Media;
 import filehandlers.UnitCacheParser;
 import list.view.abView;
 import list.view.tbTotalWarfareView;
+
+import javax.swing.table.AbstractTableModel;
+import java.io.*;
+import java.util.ArrayList;
 
 
 public class UnitList extends AbstractTableModel {

--- a/sswlib/src/main/java/list/UnitListData.java
+++ b/sswlib/src/main/java/list/UnitListData.java
@@ -33,6 +33,9 @@ import battleforce.BattleForceStats;
 import common.CommonTools;
 import filehandlers.MechReader;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class UnitListData extends abUnitData {
     public UnitListData(String Name, String Model, String Configuration, String Level, String Era, String Tech, String Source, String Type, String Motive, String Info, int Tonnage, int Year, int BV, double Cost, String filename, BattleForceStats bfStats){
         this.Name = Name;
@@ -95,27 +98,29 @@ public class UnitListData extends abUnitData {
         }
     }
 
-    public UnitListData( String[] Items ) {
-        this.Name = Items[name];
-        this.Model = Items[model];
-        this.Configuration = Items[configuration];
+    public UnitListData(List<String> Items) {
+        this.Name = Items.get(name);
+        this.Model = Items.get(model);
+        this.Configuration = Items.get(configuration);
         this.TypeModel = this.getFullName();
-        this.Level = Items[level];
-        this.Era = Items[era];
-        this.Tech = Items[tech];
-        this.Source = Items[source];
-        this.Tonnage = Integer.parseInt(Items[tonnage]);
-        this.Year = Integer.parseInt(Items[year]);
-        this.BV = Integer.parseInt(Items[bv]);
-        this.Cost = Double.parseDouble(Items[cost]);
-        this.filename = Items[Filename];
-        this.Type = Items[type];
-        this.Motive = Items[motive];
-        this.Info = Items[info];
-        this.Config = Items[config];
+        this.Level = Items.get(level);
+        this.Era = Items.get(era);
+        this.Tech = Items.get(tech);
+        this.Source = Items.get(source);
+        this.Tonnage = Integer.parseInt(Items.get(tonnage));
+        this.Year = Integer.parseInt(Items.get(year));
+        this.BV = Integer.parseInt(Items.get(bv));
+        this.Cost = Double.parseDouble(Items.get(cost));
+        this.filename = Items.get(Filename);
+        this.Type = Items.get(type);
+        this.Motive = Items.get(motive);
+        this.Info = Items.get(info);
+        this.Config = Items.get(config);
         if ( !Config.isEmpty() ) { this.Omni = true; }
 
-        this.bfstat = new BattleForceStats( new String[]{this.getFullName(), Items[pv], Items[wt], Items[mv], Items[s], Items[m], Items[l], Items[e], Items[ov], Items[armor], Items[internal], Items[abilities]} );
+        this.bfstat = new BattleForceStats( new String[]{this.getFullName(), Items.get(pv), Items.get(wt), Items.get(mv),
+                Items.get(s), Items.get(m), Items.get(l), Items.get(e), Items.get(ov), Items.get(armor), Items.get(internal),
+                Items.get(abilities)} );
         this.bfstat.setName(Name);
         this.bfstat.setModel(Model);
 
@@ -141,36 +146,35 @@ public class UnitListData extends abUnitData {
         return u;
     }
 
-    public String SerializeIndex() {
-        String data = "";
-
-        data += this.Name + ",";
-        data += this.Model + ",";
-        data += this.Configuration + ",";
-        data += this.Level + ",";
-        data += this.Era + ",";
-        data += this.Tech + ",";
-        data += this.Source + ",";
-        data += this.Tonnage + ",";
-        data += this.Year + ",";
-        data += this.BV + ",";
-        data += this.Cost + ",";
-        data += this.filename + ",";
-        data += this.Type + ",";
-        data += this.Motive + ",";
-        data += this.Info.replace(",", " ") + ",";
-        data += this.Config + ",";
-        data += this.bfstat.getPointValue() + ",";
-        data += this.bfstat.getWeight() + ",";
-        data += this.bfstat.getAbilitiesString().replace(",", "~") + ",";
-        data += this.bfstat.getMovement() + ",";
-        data += this.bfstat.getShort() + ",";
-        data += this.bfstat.getMedium() + ",";
-        data += this.bfstat.getLong() + ",";
-        data += this.bfstat.getExtreme() + ",";
-        data += this.bfstat.getOverheat() + ",";
-        data += this.bfstat.getArmor() + ",";
-        data += this.bfstat.getInternal();
+    public List<String> toCsvIndex() {
+        List<String> data = new ArrayList<>();
+        data.add(Name);
+        data.add(Model);
+        data.add(Configuration);
+        data.add(Level);
+        data.add(Era);
+        data.add(Tech);
+        data.add(Source);
+        data.add(String.valueOf(Tonnage));
+        data.add(String.valueOf(Year));
+        data.add(String.valueOf(BV));
+        data.add(String.valueOf(Cost));
+        data.add(filename);
+        data.add(Type);
+        data.add(Motive);
+        data.add(Info);
+        data.add(Config);
+        data.add(String.valueOf(bfstat.getPointValue()));
+        data.add(String.valueOf(bfstat.getWeight()));
+        data.add(bfstat.getAbilitiesString().replace(",", "~")); // check to make sure this is necessary
+        data.add(bfstat.getMovement());
+        data.add(String.valueOf(bfstat.getShort()));
+        data.add(String.valueOf(bfstat.getMedium()));
+        data.add(String.valueOf(bfstat.getLong()));
+        data.add(String.valueOf(bfstat.getExtreme()));
+        data.add(String.valueOf(bfstat.getOverheat()));
+        data.add(String.valueOf(bfstat.getArmor()));
+        data.add(String.valueOf(bfstat.getInternal()));
 
         return data;
     }

--- a/sswlib/src/main/java/list/ifUnitData.java
+++ b/sswlib/src/main/java/list/ifUnitData.java
@@ -28,8 +28,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package list;
 
+import java.util.List;
+
 public interface ifUnitData {
-    public String SerializeIndex();
+    public List<String> toCsvIndex();
     public String getName();
     public void setName(String Name);
     public String getFullName();


### PR DESCRIPTION
The SSW-Master `index.ssi` file was being parsed manually, with a simple `String.split(",")` to separate the fields. This led to some issues like commas in certain fields breaking the file. I looked at both JSON and raw objects via Kryo as alternative formats for storing the unit cache, but JSON would bloat the file to 2-3x the current size and Kryo added a few hundred extra lines of code due to the need to write custom serializers, and I wanted to avoid introducing that complexity.

This is more of a drop-in replacement for what we were doing before. The Commons CSV library properly quotes records when needed and is able to pass the appropriate fields back to the classes being deserialized, so they can use more or less the same constructors they were using before.

This also fixes a bug in `MechReader.java` where the bfstat unit name was not being set for Omnimech configurations other than the base loadout.

Fixes #155. 

Build for @Maelwys to test before we merge:
[SSW_0.7.4.2.20200921.zip](https://github.com/Solaris-Skunk-Werks/solarisskunkwerks/files/5258023/SSW_0.7.4.2.20200921.zip)
