### PR TITLE
Upload release zip artifact on Pushes/PRs to develop and master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,14 @@
 #
 name: Java CI with Gradle
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+      - develop
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
 
       with:
         path: ./build/release/
-        name: ${{ env.SSW_VERSION }}.zip
+        name: ${{ env.SSW_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
 
       with:
         path: ./build/release/
-        name: "$SSW_VERSION.zip"
+        name: $SSW_VERSION.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
 
       with:
         path: ./build/release/
-        name: $SSW_VERSION.zip
+        name: ${{ env.SSW_VERSION }}.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     # Perform a Release Build
     #
     - name: Build with Gradle
-      run: ./gradlew zipRelease
+      run: ./gradlew releaseBuild
 
     #
     # Upload release distribution zipfile
@@ -41,4 +41,4 @@ jobs:
       uses: kittaakos/upload-artifact-as-is@v0
 
       with:
-        path: ./build/distributions/
+        path: ./build/release/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,7 @@
 #
 name: Java CI with Gradle
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   ci:
@@ -29,18 +25,13 @@ jobs:
     # Perform a Release Build
     #
     - name: Build with Gradle
-      run: ./gradlew releaseBuild
+      run: ./gradlew zipRelease
 
     #
-    # Put the releases up in a single zip file called:
-    #
-    #     releases.zip
-    #
-    # NB: Due to a GitHub Actions limitation we won't know
-    #     what the filename is in order to display it somewhere.
+    # Upload release distribution zipfile
     #
     - name: Upload Releases
-      uses: actions/upload-artifact@v2-preview
+      uses: kittaakos/upload-artifact-as-is@v0
+
       with:
-        name: releases
-        path: ./build/release
+        path: ./build/distributions/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,17 @@ jobs:
       run: ./gradlew releaseBuild
 
     #
+    # Resolve version name for release archive
+    #
+    - name: Generate name for archive
+      run: echo ::set-env name=SSW_VERSION::$(ls ./build/release)
+
+    #
     # Upload release distribution zipfile
     #
     - name: Upload Releases
-      uses: kittaakos/upload-artifact-as-is@v0
+      uses: actions/upload-artifact@v2-preview
 
       with:
         path: ./build/release/
+        name: "$SSW_VERSION.zip"


### PR DESCRIPTION
This uses the `upload-artifact-as-is` Github action to upload a properly named/versioned release zip on CI actions. I've also updated the action to build on every push/PR to develop as well as master to facilitate testing bugfixes/features (no more manually compiling and uploading binaries to PR/issue threads to link in Discord).