### PR TITLE
Fix off by one error when equipping partial wing

### DIFF
--- a/sswlib/src/main/java/components/PartialWing.java
+++ b/sswlib/src/main/java/components/PartialWing.java
@@ -156,8 +156,8 @@ public class PartialWing extends abPlaceable {
     @Override
     public boolean Place( ifMechLoadout l ) {
         //Check how many crits are available in the torsos, if they are less then we need, stop!
-        if ( ((ifMechLoadout) l).FreeCrits( ((ifMechLoadout) l).GetLTCrits() ) <= this.NumCrits() ) return false;
-        if ( ((ifMechLoadout) l).FreeCrits( ((ifMechLoadout) l).GetRTCrits() ) <= this.NumCrits() ) return false;
+        if ( ((ifMechLoadout) l).FreeCrits( ((ifMechLoadout) l).GetLTCrits() ) < this.NumCrits() ) return false;
+        if ( ((ifMechLoadout) l).FreeCrits( ((ifMechLoadout) l).GetRTCrits() ) < this.NumCrits() ) return false;
 
         try {
             ((ifMechLoadout) l).AddToLT( this );
@@ -181,8 +181,8 @@ public class PartialWing extends abPlaceable {
         if( locs.length != 2 ) { return false; }
 
         //Check how many crits are available in the torsos, if they are less then we need, stop!
-        if ( ((ifMechLoadout) l).FreeCrits( ((ifMechLoadout) l).GetLTCrits() ) <= this.NumCrits() ) return false;
-        if ( ((ifMechLoadout) l).FreeCrits( ((ifMechLoadout) l).GetRTCrits() ) <= this.NumCrits() ) return false;
+        if ( ((ifMechLoadout) l).FreeCrits( ((ifMechLoadout) l).GetLTCrits() ) < this.NumCrits() ) return false;
+        if ( ((ifMechLoadout) l).FreeCrits( ((ifMechLoadout) l).GetRTCrits() ) < this.NumCrits() ) return false;
 
         try {
             l.AddTo( this, locs[0].Location, locs[0].Index );


### PR DESCRIPTION
Partial Wings seem to have been affected by an off-by-one error when checking the available critical slots on the torsos, resulting in a failure to load the Ostscout IIC, which had exactly enough critical slots left on the right torso. 

After this fix all mechs appear to have loaded successfully using the magic wand from the "Open" dialog.