### PR TITLE
Trigger builds on pushes to develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      - develop
   pull_request:
     branches:
       - master


### PR DESCRIPTION
This will trigger build actions when PRs get merged into develop so that Maelwys and other testers can have comprehensive dev snapshots instead of just individual bugfix/feature branches.