### PR TITLE
Poweramps and Fractional Accounting

### DIFF
--- a/Data/Equipment/equipment.json
+++ b/Data/Equipment/equipment.json
@@ -606,6 +606,9 @@
     "Explosive": false,
     "VariableSize": false,
     "RequiresQuad": false,
+	"RequiresFusion": false,
+    "RequiresNuclear": false,
+    "RequiresPowerAmps": true,
     "Availability": {
       "IS_SL": "X",
       "IS_SW": "X",
@@ -700,6 +703,9 @@
     "Explosive": false,
     "VariableSize": false,
     "RequiresQuad": false,
+	"RequiresFusion": false,
+    "RequiresNuclear": false,
+    "RequiresPowerAmps": true,
     "Availability": {
       "IS_SL": "X",
       "IS_SW": "X",
@@ -794,6 +800,9 @@
     "Explosive": false,
     "VariableSize": false,
     "RequiresQuad": false,
+	"RequiresFusion": false,
+    "RequiresNuclear": false,
+    "RequiresPowerAmps": true,
     "Availability": {
       "IS_SL": "E",
       "IS_SW": "F",
@@ -2300,7 +2309,7 @@
     "CritName": "Ground Mobile HPG",
     "Type": "PE",
     "LookupName": "Ground Mobile HPG",
-    "MegaMekName": "GroundMobileHPG",
+    "MegaMekName": "ISMobileHPG",
     "BookReference": "Tactical Operations",
     "ChatName": "HPG",
     "Specials": "-",
@@ -2338,6 +2347,9 @@
     "Explosive": false,
     "VariableSize": false,
     "RequiresQuad": false,
+	"RequiresFusion": true,
+    "RequiresNuclear": false,
+    "RequiresPowerAmps": true,
     "Availability": {
       "IS_SL": "F",
       "IS_SW": "X",

--- a/sswlib/src/main/java/components/CVPowerAmplifier.java
+++ b/sswlib/src/main/java/components/CVPowerAmplifier.java
@@ -64,6 +64,9 @@ public class CVPowerAmplifier {
             if( v.get( i ) instanceof RangedWeapon ) {
                 if ( ((ifWeapon)v.get( i ) ).RequiresPowerAmps() )
                     tons += ((abPlaceable) v.get( i )).GetTonnage();
+            } else if (v.get(i) instanceof Equipment) {
+                if (((Equipment)v.get(i)).RequiresPowerAmps())
+                    tons += ((Equipment) v.get( i )).GetTonnage();
             }
         }
         if( tons <= 0.0 ) {
@@ -71,7 +74,7 @@ public class CVPowerAmplifier {
         } else {
             double result = 0.0;
             if( CurLoadout.GetUnit().UsingFractionalAccounting() ) {
-                result = Math.ceil( tons * 200 ) * 0.001;
+                result = Math.ceil( tons * 100 ) * 0.001;
             } else {
                 result = (double) Math.ceil( tons * 0.2 ) * 0.5;
             }

--- a/sswlib/src/main/java/components/PowerAmplifier.java
+++ b/sswlib/src/main/java/components/PowerAmplifier.java
@@ -59,6 +59,9 @@ public class PowerAmplifier {
             if( v.get( i ) instanceof ifWeapon ) {
                 if ( ((ifWeapon)v.get( i ) ).RequiresPowerAmps() )
                     tons += ((abPlaceable) v.get( i )).GetTonnage();
+            } else if (v.get(i) instanceof Equipment) {
+                if (((Equipment)v.get(i)).RequiresPowerAmps())
+                    tons += ((Equipment) v.get( i )).GetTonnage();
             }
         }
         if( tons <= 0.0 ) {
@@ -66,7 +69,7 @@ public class PowerAmplifier {
         } else {
             double result = 0.0;
             if( CurLoadout.GetUnit().UsingFractionalAccounting() ) {
-                result = Math.ceil( tons * 200 ) * 0.001;
+                result = Math.ceil( tons * 100 ) * 0.001;
             } else {
                 result = (double) Math.ceil( tons * 0.2 ) * 0.5;
             }


### PR DESCRIPTION
This updates SSW and SAW to correctly handle power amps in Equipment, when it previously only considered them for weapons. It also fixes a bug where fractional accounting on power amps was being multipled by the wrong coefficient, resulting in tonnage values that were 2x the correct value.

This is a work in progress until we have a chance to update and test other fields.