### PR TITLE
Add function to check if a mech has an item equipped by name

### DIFF
--- a/sswlib/src/main/java/components/BipedLoadout.java
+++ b/sswlib/src/main/java/components/BipedLoadout.java
@@ -1713,7 +1713,7 @@ public boolean IsTripod(){
     }
 
     public boolean HasItem(String lookupName) {
-        List<abPlaceable> items = GetNonCore();
+        List<abPlaceable> items = NonCore;
         for (abPlaceable item : items) {
             if (item.LookupName().equals(lookupName)) {
                 return true;

--- a/sswlib/src/main/java/components/BipedLoadout.java
+++ b/sswlib/src/main/java/components/BipedLoadout.java
@@ -1712,6 +1712,16 @@ public boolean IsTripod(){
         return false;
     }
 
+    public boolean HasItem(String lookupName) {
+        List<abPlaceable> items = GetNonCore();
+        for (abPlaceable item : items) {
+            if (item.LookupName().equals(lookupName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public int[] FindHeatSinks() {
         // this routine is used mainly by the text and html writers to find the
         // locations of heat sinks specifically.  returns an int[] with the

--- a/sswlib/src/main/java/components/QuadLoadout.java
+++ b/sswlib/src/main/java/components/QuadLoadout.java
@@ -1509,7 +1509,7 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
     }
 
     public boolean HasItem(String lookupName) {
-        List<abPlaceable> items = GetNonCore();
+        List<abPlaceable> items = NonCore;
         for (abPlaceable item : items) {
             if (item.LookupName().equals(lookupName)) {
                 return true;

--- a/sswlib/src/main/java/components/QuadLoadout.java
+++ b/sswlib/src/main/java/components/QuadLoadout.java
@@ -1508,6 +1508,16 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
         return false;
     }
 
+    public boolean HasItem(String lookupName) {
+        List<abPlaceable> items = GetNonCore();
+        for (abPlaceable item : items) {
+            if (item.LookupName().equals(lookupName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public int[] FindHeatSinks() {
         // this routine is used mainly by the text and html writers to find the
         // locations of heat sinks specifically.  returns an int[] with the

--- a/sswlib/src/main/java/components/TripodLoadout.java
+++ b/sswlib/src/main/java/components/TripodLoadout.java
@@ -1817,6 +1817,16 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
         return false;
     }
 
+    public boolean HasItem(String lookupName) {
+        List<abPlaceable> items = GetNonCore();
+        for (abPlaceable item : items) {
+            if (item.LookupName().equals(lookupName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public int[] FindHeatSinks() {
         // this routine is used mainly by the text and html writers to find the
         // locations of heat sinks specifically.  returns an int[] with the

--- a/sswlib/src/main/java/components/TripodLoadout.java
+++ b/sswlib/src/main/java/components/TripodLoadout.java
@@ -1818,7 +1818,7 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
     }
 
     public boolean HasItem(String lookupName) {
-        List<abPlaceable> items = GetNonCore();
+        List<abPlaceable> items = NonCore;
         for (abPlaceable item : items) {
             if (item.LookupName().equals(lookupName)) {
                 return true;

--- a/sswlib/src/main/java/components/ifMechLoadout.java
+++ b/sswlib/src/main/java/components/ifMechLoadout.java
@@ -239,4 +239,5 @@ public interface ifMechLoadout {
     public boolean HasBoobyTrap();
     public BoobyTrap GetBoobyTrap();
     public boolean LocationHasEquip(int index, String name);
+    public boolean HasItem(String lookupName);
 }


### PR DESCRIPTION
This adds a `HasItem(String lookupName)` to the various mech loadouts to check if a piece of equipment is equipped anywhere on the mech. The other versions currently require an actual instance of `abPlaceable`, which is harder to create from other parts of the code.