### PR TITLE
Fix rounding error when determing coolant pod bonuses in bv breakdown

### DIFF
--- a/sswlib/src/main/java/utilities/CostBVBreakdown.java
+++ b/sswlib/src/main/java/utilities/CostBVBreakdown.java
@@ -599,7 +599,7 @@ public class CostBVBreakdown {
                 }
             }
             // get the heat sink bonus
-            BonusFromCP = (int) Math.ceil( (double) NumHS * ( (double) NumPods * 0.2f ) );
+            BonusFromCP = (int) Math.ceil( (double) NumHS * ( (double) NumPods * 0.2 ) );
             if( BonusFromCP > MaxHSBonus ) { BonusFromCP = MaxHSBonus; }
             retval += BonusFromCP;
         }


### PR DESCRIPTION
Apparently `0.2f` rounds to 3, which led to a rounding error when displaying the coolant pod bonus in the cost/bv breakdown pane.