### PR TITLE
Check for requiresnuclear and requiresfusion on equipment

### DIFF
--- a/sswlib/src/main/java/components/BipedLoadout.java
+++ b/sswlib/src/main/java/components/BipedLoadout.java
@@ -5001,6 +5001,14 @@ public boolean IsTripod(){
                 throw new Exception( p.CritName() + " may not be mounted as it requires a fusion engine." );
             }
         }
+        if( p instanceof Equipment ) {
+            if( ((Equipment) p).RequiresNuclear() &! Owner.GetEngine().IsNuclear() ) {
+                throw new Exception( p.CritName() + " may not be mounted as it requires a nuclear engine." );
+            }
+            if( ((Equipment) p).RequiresFusion() &! Owner.GetEngine().IsFusion() ) {
+                throw new Exception( p.CritName() + " may not be mounted as it requires a fusion engine." );
+            }
+        }
         if( p instanceof Talons ) {
             for( int i = 0; i < NonCore.size(); i++ ) {
                 if( NonCore.get( i ) instanceof Talons ) {

--- a/sswlib/src/main/java/components/QuadLoadout.java
+++ b/sswlib/src/main/java/components/QuadLoadout.java
@@ -4717,6 +4717,14 @@ public void SetBoobyTrap( boolean b ) throws Exception{
                 throw new Exception( p.CritName() + " may not be mounted as it requires a fusion engine." );
             }
         }
+        if( p instanceof Equipment ) {
+            if( ((Equipment) p).RequiresNuclear() &! Owner.GetEngine().IsNuclear() ) {
+                throw new Exception( p.CritName() + " may not be mounted as it requires a nuclear engine." );
+            }
+            if( ((Equipment) p).RequiresFusion() &! Owner.GetEngine().IsFusion() ) {
+                throw new Exception( p.CritName() + " may not be mounted as it requires a fusion engine." );
+            }
+        }
         if( p instanceof Talons ) {
             for( int i = 0; i < NonCore.size(); i++ ) {
                 if( NonCore.get( i ) instanceof Talons ) {

--- a/sswlib/src/main/java/components/TripodLoadout.java
+++ b/sswlib/src/main/java/components/TripodLoadout.java
@@ -5204,6 +5204,14 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
                 throw new Exception( p.CritName() + " may not be mounted as it requires a fusion engine." );
             }
         }
+        if( p instanceof Equipment ) {
+            if( ((Equipment) p).RequiresNuclear() &! Owner.GetEngine().IsNuclear() ) {
+                throw new Exception( p.CritName() + " may not be mounted as it requires a nuclear engine." );
+            }
+            if( ((Equipment) p).RequiresFusion() &! Owner.GetEngine().IsFusion() ) {
+                throw new Exception( p.CritName() + " may not be mounted as it requires a fusion engine." );
+            }
+        }
         if( p instanceof Talons ) {
             for( int i = 0; i < NonCore.size(); i++ ) {
                 if( NonCore.get( i ) instanceof Talons ) {


### PR DESCRIPTION
`RequiresNuclear` and `RequiresFusion` were added to equipment.json as they were needed for some exclusions and heatsink calculations. The logic in SAW has already been updated to check for these, but I forgot to update SSW as well.