### PR TITLE
Add task to publish sswlib to local maven repo

### DIFF
--- a/sswlib/build.gradle
+++ b/sswlib/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'maven-publish'
 }
 
 java {
@@ -12,6 +13,19 @@ dependencies {
     implementation 'org.apache.commons:commons-csv:1.8'
     
     testCompile group: 'junit', name: 'junit', version: '4.12'
+}
+
+publishing {
+    publications {
+        sswlib(MavenPublication) {
+            artifactId = 'sswlib'
+            from components.java
+        }
+    }
+
+    repositories {
+        mavenLocal()
+    }
 }
 
 jar {


### PR DESCRIPTION
This adds a gradle plugin to allow publishing sswlib to a local maven repository. To run it, you can use your IDE or run `./gradlew run sswlib:publish` from the command line, which will compile sswlib and push it to a local repository on your machine (`~/.m2` on Linux). Once published, if you want to use sswlib in another project, you simply add the following to your new project's `build.gradle`:

```
repositories {
    mavenCentral()
    mavenLocal()
}

dependencies {
    compile 'com.solarisskunkwerks:sswlib:0.7.5'
}
```

This will pull sswlib and all of it's dependencies from your local repo (or maven central if they arent published locally) and automatically add them to your build.

Future work could involve publishing sswlib to Maven Central so that anyone can pull it without publishing it locally first, but it needs cleaned up quite a bit before I'd want to do that.