### PR TITLE
Change release types from nightly to alpha/beta/rc

### DIFF
--- a/BFB/build.gradle
+++ b/BFB/build.gradle
@@ -51,8 +51,7 @@ task copyDependencies {
 task writeProperties(type: WriteProperties) {
     outputFile "${buildDir}/resources/main/BFB/build.properties"
     property 'version', version
-    property 'releaseType', releaseType
-    property 'date', date
+    property 'release', release
 }
 
 compileJava.finalizedBy(writeProperties)

--- a/BFB/src/main/java/BFB/Common/Constants.java
+++ b/BFB/src/main/java/BFB/Common/Constants.java
@@ -71,20 +71,16 @@ public class Constants {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        if (props.getProperty("releaseType").equals("Nightly")) {
-            return props.getProperty("version") + "." + props.getProperty("date");
-        } else {
-            return props.getProperty("version");
-        }
+        return props.getProperty("version");
     }
 
-    public static String GetReleaseType() {
+    public static String GetRelease() {
         Properties props = new Properties();
         try {
             props.load(Constants.class.getResourceAsStream("/BFB/build.properties"));
         } catch (Exception e) {
             e.printStackTrace();
         }
-        return props.getProperty("releaseType");
+        return props.getProperty("release");
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'java'
 allprojects {
     version '0.7.5'
     ext {
-        release='Alpha 1'
+        release='SNAPSHOT'
     }
     jar {
         onlyIf { !sourceSets.main.allSource.files.isEmpty() }
@@ -46,7 +46,7 @@ task zipRelease(type: Zip, dependsOn: releaseBuild) {
     from "${buildDir}/release"
         include "**/"
     if ("$release" != "Stable") {
-        archiveName "SSW_${version}_${release}.zip"
+        archiveName "SSW_${version}-${release}.zip"
     } else {
         archiveName "SSW_${version}.zip"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,7 @@ apply plugin: 'java'
 allprojects {
     version '0.7.5'
     ext {
-        releaseType='Nightly'
-        date=getDate()
+        release='Alpha 1'
     }
     jar {
         onlyIf { !sourceSets.main.allSource.files.isEmpty() }
@@ -16,12 +15,6 @@ subprojects {
     repositories {
         mavenCentral()
     }
-}
-
-static def getDate() {
-    def date = new Date()
-    def formattedDate = date.format('yyyyMMdd')
-    return formattedDate.toString()
 }
 
 evaluationDependsOnChildren()
@@ -52,8 +45,8 @@ task releaseBuild(dependsOn: [copyDocs, copyData, copyDeps, copyJars]) { }
 task zipRelease(type: Zip, dependsOn: releaseBuild) {
     from "${buildDir}/release"
         include "**/"
-    if ("$releaseType" == "Nightly") {
-        archiveName "SSW_${version}.${date}.zip"
+    if ("$release" != "Stable") {
+        archiveName "SSW_${version}_${release}.zip"
     } else {
         archiveName "SSW_${version}.zip"
     }

--- a/saw/build.gradle
+++ b/saw/build.gradle
@@ -44,8 +44,7 @@ task copyAssets (dependsOn: deleteAssets) {
 task writeProperties(type: WriteProperties) {
     outputFile "${buildDir}/resources/main/saw/build.properties"
     property 'version', version
-    property 'releaseType', releaseType
-    property 'date', date
+    property 'release', release
 }
 
 task copyDependencies {

--- a/saw/src/main/java/saw/Constants.java
+++ b/saw/src/main/java/saw/Constants.java
@@ -57,20 +57,16 @@ public class Constants {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        if (props.getProperty("releaseType").equals("Nightly")) {
-            return props.getProperty("version") + "." + props.getProperty("date");
-        } else {
-            return props.getProperty("version");
-        }
+        return props.getProperty("version");
     }
 
-    public static String GetReleaseType() {
+    public static String GetRelease() {
         Properties props = new Properties();
         try {
             props.load(Constants.class.getResourceAsStream("/saw/build.properties"));
         } catch (Exception e) {
             e.printStackTrace();
         }
-        return props.getProperty("releaseType");
+        return props.getProperty("release");
     }
 }

--- a/saw/src/main/java/saw/gui/dlgAboutBox.java
+++ b/saw/src/main/java/saw/gui/dlgAboutBox.java
@@ -44,7 +44,7 @@ public class dlgAboutBox extends javax.swing.JDialog {
         setTitle( "About " + saw.Constants.AppDescription );
         lblAppName.setText(saw.Constants.AppDescription);
         lblVersion.setText(saw.Constants.GetVersion());
-        lblRelease.setText(saw.Constants.GetReleaseType());
+        lblRelease.setText(saw.Constants.GetRelease());
     }
 
     /** This method is called from within the constructor to

--- a/ssw/build.gradle
+++ b/ssw/build.gradle
@@ -45,8 +45,7 @@ task copyAssets (dependsOn: deleteAssets) {
 task writeProperties(type: WriteProperties) {
     outputFile "${buildDir}/resources/main/ssw/build.properties"
     property 'version', version
-    property 'releaseType', releaseType
-    property 'date', date
+    property 'release', release
 }
 
 task copyDependencies {

--- a/ssw/src/main/java/ssw/constants/SSWConstants.java
+++ b/ssw/src/main/java/ssw/constants/SSWConstants.java
@@ -28,8 +28,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package ssw.constants;
 
-import ssw.gui.dlgAboutBox;
-
 import java.util.Properties;
 
 public class SSWConstants {
@@ -62,20 +60,16 @@ public class SSWConstants {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        if (props.getProperty("releaseType").equals("Nightly")) {
-            return props.getProperty("version") + "." + props.getProperty("date");
-        } else {
-            return props.getProperty("version");
-        }
+        return props.getProperty("version");
     }
 
-    public static String GetReleaseType() {
+    public static String GetRelease() {
         Properties props = new Properties();
         try {
             props.load(SSWConstants.class.getResourceAsStream("/ssw/build.properties"));
         } catch (Exception e) {
             e.printStackTrace();
         }
-        return props.getProperty("releaseType");
+        return props.getProperty("release");
     }
 }

--- a/ssw/src/main/java/ssw/gui/dlgAboutBox.java
+++ b/ssw/src/main/java/ssw/gui/dlgAboutBox.java
@@ -28,22 +28,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package ssw.gui;
 
-import filehandlers.Media;
 import ssw.constants.SSWConstants;
 
 import java.awt.Point;
-import java.util.Arrays;
-import java.util.Properties;
 
 public class dlgAboutBox extends javax.swing.JDialog {
 
     ifMechForm Parent;
 
-//    public class GetVersion {
-//        public static String GetVersion() {
-//
-//        }
-//    }
     /** Creates new form dlgAboutBox */
     public dlgAboutBox(java.awt.Frame parent, boolean modal) {
         super(parent, modal);
@@ -52,7 +44,7 @@ public class dlgAboutBox extends javax.swing.JDialog {
         setResizable( false );
         setTitle( "About " + SSWConstants.AppDescription );
         lblAppName.setText(SSWConstants.AppDescription);
-        lblRelease.setText(SSWConstants.GetReleaseType());
+        lblRelease.setText(SSWConstants.GetRelease());
         lblVersion.setText(SSWConstants.GetVersion());
     }
 


### PR DESCRIPTION
This changes the build system to use semver release types instead of `Nightly` + `date()` for pre-release versions. Under this system, the major version (`version` in `build.gradle`) will be bumped to the next release after each stable, so it will be 0.7.5 in the develop branch until 0.7.5 stable is released, at which point it will be bumped to 0.7.6. The `release` variable under it will be set to `SNAPSHOT` until a new dev alpha/beta release is ready, at which point it will be changed to `Alpha`/`Beta` <number>. So the first 0.7.5 dev release would be as follows:

```
version '0.7.5'
ext {
    release='Alpha 1'
}
```
The `zipRelease` task appends the release type to the zip file name when it's anything other than stable.