### PR TITLE
Sort weapons by BV (highest first) then heat (lowest first)

### DIFF
--- a/Data/Equipment/physicals.json
+++ b/Data/Equipment/physicals.json
@@ -283,7 +283,7 @@
     "ToHitShort": -2,
     "ToHitMedium": -2,
     "ToHitLong": -2,
-    "DamageAdd": 1,
+    "DamageAdd": 3,
     "CritAdd": 2,
     "PWClass": 0,
     "TonMult": 0.0,

--- a/sswlib/src/main/java/components/Mech.java
+++ b/sswlib/src/main/java/components/Mech.java
@@ -4570,7 +4570,18 @@ public class Mech implements ifUnit, ifBattleforce {
             // get the two items we'll be comparing
             boolean AES1 = UseAESModifier( ((abPlaceable) v.get( i - 1 )) );
             boolean AES2 = UseAESModifier( ((abPlaceable) v.get( i )) );
-            if( ((abPlaceable) v.get( i - 1 )).GetCurOffensiveBV( rear, TC, AES1 ) >= ((abPlaceable) v.get( i )).GetCurOffensiveBV( rear, TC, AES2 ) ) {
+            /***
+             * 2020-10-06:
+             * This should be improved but the problem is it needs to be sorted by BV,
+             * then by heat, lowest to highest.  To that end we just get the heat and
+             * compare them as a second step if the BV is the same.  If the BV is higher
+             * then we don't need to look.
+             */
+            double offensiveBV1 = ((abPlaceable) v.get( i - 1 )).GetCurOffensiveBV( rear, TC, AES1 );
+            double offensiveBV2 = ((abPlaceable) v.get( i )).GetCurOffensiveBV( rear, TC, AES2 );
+            double heat1 = ((ifWeapon) v.get( i - 1 )).GetHeat();
+            double heat2 = ((ifWeapon) v.get( i )).GetHeat();
+            if( offensiveBV1 > offensiveBV2 || ( offensiveBV1 == offensiveBV2 && heat1 <= heat2 ) ) {
                 i = j;
                 j += 1;
             } else {


### PR DESCRIPTION
This changes how weapons are sorted for BV purposes.  Originally it was sorted by BV only (highest first) now it sorts by BV (highest first), then by heat (lowest first) when BV is equal.