### PR TITLE
Quad Leg Ammo BV fix

### DIFF
--- a/sswlib/src/main/java/components/Mech.java
+++ b/sswlib/src/main/java/components/Mech.java
@@ -2560,12 +2560,18 @@ public class Mech implements ifUnit, ifBattleforce {
                             }
                             break;
                         case 4:
-                            if( ! CurLoadout.HasLACASEII() &! CurLoadout.HasLTCASEII() &! CurLoadout.IsUsingClanCASE() ) {
+                            if (CurLoadout instanceof QuadLoadout && (! CurLoadout.HasLACASEII() )){
+                                result -= 15.0 * p.NumCrits();
+                            }
+                            else if( ! CurLoadout.HasLACASEII() &! CurLoadout.HasLTCASEII() &! CurLoadout.IsUsingClanCASE() ) {
                                 result -= 15.0 * p.NumCrits();
                             }
                             break;
                         case 5:
-                            if( ! CurLoadout.HasRACASEII() &! CurLoadout.HasRTCASEII() &! CurLoadout.IsUsingClanCASE() ) {
+                            if (CurLoadout instanceof QuadLoadout && (! CurLoadout.HasRACASEII() )){
+                                result -= 15.0 * p.NumCrits();
+                            }
+                            else if( ! CurLoadout.HasRACASEII() &! CurLoadout.HasRTCASEII() &! CurLoadout.IsUsingClanCASE() ) {
                                 result -= 15.0 * p.NumCrits();
                             }
                             break;


### PR DESCRIPTION
If the mech is an instance of a Quad, then the LA and RA are actually legs and we shouldn't look to the Torso for the ammo explosion penalty.