### PR TITLE
Check for Armored Turrest in BV calcs

### DIFF
--- a/sswlib/src/main/java/components/Mech.java
+++ b/sswlib/src/main/java/components/Mech.java
@@ -2459,6 +2459,15 @@ public class Mech implements ifUnit, ifBattleforce {
             if( CurLoadout.HasSupercharger() ) {
                 result += CurLoadout.GetSupercharger().GetDefensiveBV();
             }
+            if( CurLoadout.HasLTTurret()){
+                result += CurLoadout.GetLTTurret().GetDefensiveBV();
+            }
+            if( CurLoadout.HasRTTurret()){
+                result += CurLoadout.GetRTTurret().GetDefensiveBV();
+            }
+            if( CurLoadout.HasHDTurret()){
+                result += CurLoadout.GetHDTurret().GetDefensiveBV();
+            }
         }
         return result;
     }


### PR DESCRIPTION
This fixed the Armored component Turret that was affecting the Uraeus UAE-7R.  I'm still working on how to fix the issue affecting the Quickdraw QKD-8X with the Rear firing. Not sure if we want to try to fix that first, or merge this in.