### PR TITLE
Prevent making an Omnimech with Hardened Armor

### DIFF
--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -8390,6 +8390,13 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         SaveOmniFluffInfo();
         String VariantName = "";
 
+        // 2020-11-13 Omnis can't have Hardened Armor, but we wrote this generic
+        // in case later other armor types come along
+        if (!CurVee.GetArmor().AllowOmni()){
+            Media.Messager( this, "Omnivees are not allowed to have " + CurVee.GetArmor().ActualName());
+            return;
+        }
+        
         int choice = javax.swing.JOptionPane.showConfirmDialog(this,
                 "Are you sure you want to lock the chassis?\nAll items in the base "
                 + "loadout will be locked in location\nand most chassis specifications "

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -8837,6 +8837,13 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         // currently testing right now.
         SaveOmniFluffInfo();
         String VariantName = "";
+        
+        // 2020-11-13 Omnis can't have Hardened Armor, but we wrote this generic
+        // in case later other armor types come along
+        if (!CurVee.GetArmor().AllowOmni()){
+            Media.Messager( this, "Omnivees are not allowed to have " + CurVee.GetArmor().ActualName());
+            return;
+        }
 
         int choice = javax.swing.JOptionPane.showConfirmDialog(this,
                 "Are you sure you want to lock the chassis?\nAll items in the base "

--- a/ssw/src/main/java/ssw/gui/frmMain.java
+++ b/ssw/src/main/java/ssw/gui/frmMain.java
@@ -12867,6 +12867,13 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
             tbpMainTabPane.setSelectedComponent( pnlCriticals );
             return;
         }
+        
+        // 2020-10-19 Omnis can't have Hardened Armor, but we wrote this generic
+        // in case later other armor types com along
+        if (!CurMech.GetArmor().AllowOmni()){
+            Media.Messager( this, "Omnimechs are not allowed to have " + CurMech.GetArmor().ActualName());
+            return;
+        }
 
         int choice = javax.swing.JOptionPane.showConfirmDialog( this,
             "Are you sure you want to lock the chassis?\nAll items in the base " +

--- a/ssw/src/main/java/ssw/gui/frmMainWide.java
+++ b/ssw/src/main/java/ssw/gui/frmMainWide.java
@@ -13666,6 +13666,13 @@ private void btnLockChassisActionPerformed(java.awt.event.ActionEvent evt) {//GE
         tbpMainTabPane.setSelectedComponent( pnlEquipment );
         return;
     }
+    
+    // 2020-10-19 Omnis can't have Hardened Armor, but we wrote this generic
+    // in case later other armor types com along
+    if (!CurMech.GetArmor().AllowOmni()){
+        Media.Messager( this, "Omnimechs are not allowed to have " + CurMech.GetArmor().ActualName());
+        return;
+    }
 
     int choice = javax.swing.JOptionPane.showConfirmDialog( this,
             "Are you sure you want to lock the chassis?\nAll items in the base " +

--- a/sswlib/src/main/java/components/CVArmor.java
+++ b/sswlib/src/main/java/components/CVArmor.java
@@ -846,6 +846,11 @@ public class CVArmor extends abPlaceable {
         // armor is always roll again, so no armoring
         return false;
     }
+    
+    public boolean AllowOmni()
+    {
+        return Config.AllowOmni();
+    }
 
     public String ActualName() {
         return Config.ActualName();

--- a/sswlib/src/main/java/components/MechArmor.java
+++ b/sswlib/src/main/java/components/MechArmor.java
@@ -2570,6 +2570,15 @@ public class MechArmor  extends abPlaceable {
     {
         return Config.AllowHarJel();
     }
+    
+    public boolean AllowOmni()
+    {
+        return Config.AllowOmni();
+    }
+    
+    public boolean IsOmnimech(){
+        return Owner.IsOmnimech();
+    }
 
     public boolean HasHarjelMod() {
         List<LocationIndex> hj2 = Owner.GetLoadout().FindIndexesByName("HarJel II");

--- a/sswlib/src/main/java/states/ifArmor.java
+++ b/sswlib/src/main/java/states/ifArmor.java
@@ -59,4 +59,5 @@ public interface ifArmor {
     public MechModifier GetMechModifier();
     public AvailableCode GetAvailability();
     public boolean AllowHarJel();
+    public boolean AllowOmni();
 }

--- a/sswlib/src/main/java/states/stArmorCLFF.java
+++ b/sswlib/src/main/java/states/stArmorCLFF.java
@@ -160,4 +160,8 @@ public class stArmorCLFF implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return true;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorCLFL.java
+++ b/sswlib/src/main/java/states/stArmorCLFL.java
@@ -160,4 +160,8 @@ public class stArmorCLFL implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return false;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorCLLR.java
+++ b/sswlib/src/main/java/states/stArmorCLLR.java
@@ -160,4 +160,8 @@ public class stArmorCLLR implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return false;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorCLRE.java
+++ b/sswlib/src/main/java/states/stArmorCLRE.java
@@ -160,4 +160,8 @@ public class stArmorCLRE implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return false;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorCM.java
+++ b/sswlib/src/main/java/states/stArmorCM.java
@@ -151,4 +151,8 @@ public class stArmorCM implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return false;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorHA.java
+++ b/sswlib/src/main/java/states/stArmorHA.java
@@ -151,4 +151,8 @@ public class stArmorHA implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return false;
     }
+    
+    public boolean AllowOmni(){
+        return false;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorHD.java
+++ b/sswlib/src/main/java/states/stArmorHD.java
@@ -173,4 +173,8 @@ public class stArmorHD implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return false;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorIN.java
+++ b/sswlib/src/main/java/states/stArmorIN.java
@@ -150,4 +150,8 @@ public class stArmorIN implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return false;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorISAB.java
+++ b/sswlib/src/main/java/states/stArmorISAB.java
@@ -170,4 +170,8 @@ public class stArmorISAB implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return false;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorISBR.java
+++ b/sswlib/src/main/java/states/stArmorISBR.java
@@ -170,4 +170,8 @@ public class stArmorISBR implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return false;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorISFF.java
+++ b/sswlib/src/main/java/states/stArmorISFF.java
@@ -161,4 +161,8 @@ public class stArmorISFF implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return true;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorISHF.java
+++ b/sswlib/src/main/java/states/stArmorISHF.java
@@ -157,4 +157,8 @@ public class stArmorISHF implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return true;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorISIR.java
+++ b/sswlib/src/main/java/states/stArmorISIR.java
@@ -173,4 +173,8 @@ public class stArmorISIR implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return false;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorISLF.java
+++ b/sswlib/src/main/java/states/stArmorISLF.java
@@ -161,4 +161,8 @@ public class stArmorISLF implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return true;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorISLR.java
+++ b/sswlib/src/main/java/states/stArmorISLR.java
@@ -161,4 +161,8 @@ public class stArmorISLR implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return false;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorISRE.java
+++ b/sswlib/src/main/java/states/stArmorISRE.java
@@ -161,4 +161,8 @@ public class stArmorISRE implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return false;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorISST.java
+++ b/sswlib/src/main/java/states/stArmorISST.java
@@ -275,4 +275,8 @@ public class stArmorISST implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return false;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorISVST.java
+++ b/sswlib/src/main/java/states/stArmorISVST.java
@@ -270,4 +270,8 @@ public class stArmorISVST implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return false;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorMS.java
+++ b/sswlib/src/main/java/states/stArmorMS.java
@@ -150,4 +150,8 @@ public class stArmorMS implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return true;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorPBM.java
+++ b/sswlib/src/main/java/states/stArmorPBM.java
@@ -152,4 +152,8 @@ public class stArmorPBM implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return false;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }

--- a/sswlib/src/main/java/states/stArmorPatchwork.java
+++ b/sswlib/src/main/java/states/stArmorPatchwork.java
@@ -201,4 +201,8 @@ public class stArmorPatchwork implements ifArmor, ifState {
     public boolean AllowHarJel(){
         return false;
     }
+    
+    public boolean AllowOmni(){
+        return true;
+    }
 }


### PR DESCRIPTION
Armor now has an AllowOmni value, currently only Hardened prevents it. As armor is fixed when locking the Omni chassis, we check the armor at that time.