### PR TITLE
Add commit hash to non-Stable builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     # Resolve version name for release archive
     #
     - name: Generate name for archive
-      run: echo "SSW_VERSION=$(ls ./build/release)" >> $GITHUB_ENV
+      run: echo "SSW_VERSION=$(ls ./build/release)-$(git rev-parse --short=10 HEAD)" >> $GITHUB_ENV
 
     #
     # Upload release distribution zipfile

--- a/BFB/build.gradle
+++ b/BFB/build.gradle
@@ -52,6 +52,7 @@ task writeProperties(type: WriteProperties) {
     outputFile "${buildDir}/resources/main/BFB/build.properties"
     property 'version', version
     property 'release', release
+    property 'rev', rev
 }
 
 compileJava.finalizedBy(writeProperties)

--- a/BFB/src/main/java/BFB/Common/Constants.java
+++ b/BFB/src/main/java/BFB/Common/Constants.java
@@ -71,7 +71,11 @@ public class Constants {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        return props.getProperty("version");
+        String ver = props.getProperty("version");
+        if (!props.getProperty("release").equals("Stable")) {
+            ver += "-" + props.getProperty("rev");
+        }
+        return ver;
     }
 
     public static String GetRelease() {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,3 @@
-//apply plugin: 'java'
-//apply plugin: 'com.palantir.git-version version 0.12.3'
-
 plugins {
     id 'java'
     id 'com.palantir.git-version' version '0.12.3'

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,16 @@
-apply plugin: 'java'
+//apply plugin: 'java'
+//apply plugin: 'com.palantir.git-version version 0.12.3'
+
+plugins {
+    id 'java'
+    id 'com.palantir.git-version' version '0.12.3'
+}
 
 allprojects {
     version '0.7.5'
     ext {
         release='SNAPSHOT'
+        rev=versionDetails().gitHash
     }
     jar {
         onlyIf { !sourceSets.main.allSource.files.isEmpty() }

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ task zipRelease(type: Zip, dependsOn: releaseBuild) {
     from "${buildDir}/release"
         include "**/"
     if ("$release" != "Stable") {
-        archiveName "SSW_${version}-${release}.zip"
+        archiveName "SSW_${version}-${release}-${rev}.zip"
     } else {
         archiveName "SSW_${version}.zip"
     }

--- a/saw/build.gradle
+++ b/saw/build.gradle
@@ -45,6 +45,7 @@ task writeProperties(type: WriteProperties) {
     outputFile "${buildDir}/resources/main/saw/build.properties"
     property 'version', version
     property 'release', release
+    property 'rev', rev
 }
 
 task copyDependencies {

--- a/saw/src/main/java/saw/Constants.java
+++ b/saw/src/main/java/saw/Constants.java
@@ -57,7 +57,11 @@ public class Constants {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        return props.getProperty("version");
+        String ver = props.getProperty("version");
+        if (!props.getProperty("release").equals("Stable")) {
+            ver += "-" + props.getProperty("rev");
+        }
+        return ver;
     }
 
     public static String GetRelease() {

--- a/ssw/build.gradle
+++ b/ssw/build.gradle
@@ -46,6 +46,7 @@ task writeProperties(type: WriteProperties) {
     outputFile "${buildDir}/resources/main/ssw/build.properties"
     property 'version', version
     property 'release', release
+    property 'rev', rev
 }
 
 task copyDependencies {

--- a/ssw/src/main/java/ssw/constants/SSWConstants.java
+++ b/ssw/src/main/java/ssw/constants/SSWConstants.java
@@ -60,7 +60,11 @@ public class SSWConstants {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        return props.getProperty("version");
+        String ver = props.getProperty("version");
+        if (!props.getProperty("release").equals("Stable")) {
+            ver += "-" + props.getProperty("rev");
+        }
+        return ver;
     }
 
     public static String GetRelease() {


### PR DESCRIPTION
This updates the gradle build system and Github CI to append the commit hash to version numbers both in the program and in the release archives. The hash will be displayed in the titlebar and about dialog in any **non-Stable** release. Therefore, I recommend changing the `release` variable in the root build.gradle to `RC` going forward and only using `Stable` for full stable releases.

Github CI will append the hash in all actions because there isn't a good way to resolve the release type from there. I figure that won't be a problem since tagged stable release binaries will still probably be uploaded manually.