### PR TITLE
QoL Change: 'Set Armor Tonnage' now is pre-filled with the current tonnage.

### DIFF
--- a/ssw/src/main/java/ssw/gui/dlgArmorTonnage.java
+++ b/ssw/src/main/java/ssw/gui/dlgArmorTonnage.java
@@ -45,6 +45,8 @@ public class dlgArmorTonnage extends javax.swing.JDialog {
         setDefaultCloseOperation( javax.swing.JDialog.HIDE_ON_CLOSE );
         double max = ((ifMechForm) parent).GetMech().GetArmor().GetMaxTonnage();
         lblMaxArmor.setText( "Max Armor Tonnage: " + max );
+        double currentTonnage = ((ifMechForm) parent).GetMech().GetArmor().GetTonnage();
+        txtArmorTons.setText("" + currentTonnage);
     }
 
     public double GetResult() {


### PR DESCRIPTION
Just a 2 line change to enhance quality of life.

When I was farting around SSW a few days ago I like messing around with armor tonnage/weapon loadouts, it made no sense to me why the "Set Armor Tonnage" didn't default its text box to the current tonnage but it DOES show the max tonnage. Turns out it's super easy to do.

Before (with a Trebuchet TBT-9K):
![image](https://user-images.githubusercontent.com/411932/101430575-41e95e00-38d3-11eb-9cd4-403b6b811b67.png)

After:
![image](https://user-images.githubusercontent.com/411932/101430586-4746a880-38d3-11eb-9db2-b354af5c0d6c.png)
