### PR TITLE
Fix issue saving quirks on new mechs

### DIFF
--- a/ssw/src/main/java/ssw/gui/frmMain.java
+++ b/ssw/src/main/java/ssw/gui/frmMain.java
@@ -129,7 +129,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
     private Cursor NormalCursor = new Cursor( Cursor.DEFAULT_CURSOR );
     // ImageIcon FluffImage = Utils.createImageIcon( SSWConstants.NO_IMAGE );
     public DataFactory data;
-    public ArrayList<Quirk> quirks = new ArrayList<Quirk>();
+    public ArrayList<Quirk> quirks;
 
     private dlgPrintBatchMechs BatchWindow = null;
     private ImageTracker imageTracker = new ImageTracker();
@@ -157,6 +157,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         CurMech = new Mech( Prefs );
         ArmorTons = new VSetArmorTonnage( Prefs );
         Mechrender = new MechLoadoutRenderer( this );
+        quirks = CurMech.GetQuirks();
 
         // added for easy checking
         PPCCapAC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
@@ -452,7 +453,6 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         RefreshInternalPoints();
         SetLoadoutArrays();
         SetWeaponChoosers();
-        quirks = CurMech.GetQuirks();
         cmbInternalType.setSelectedItem( SSWConstants.DEFAULT_CHASSIS );
         cmbEngineType.setSelectedItem( SSWConstants.DEFAULT_ENGINE );
         cmbGyroType.setSelectedItem( SSWConstants.DEFAULT_GYRO );

--- a/ssw/src/main/java/ssw/gui/frmMain.java
+++ b/ssw/src/main/java/ssw/gui/frmMain.java
@@ -452,6 +452,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         RefreshInternalPoints();
         SetLoadoutArrays();
         SetWeaponChoosers();
+        quirks = CurMech.GetQuirks();
         cmbInternalType.setSelectedItem( SSWConstants.DEFAULT_CHASSIS );
         cmbEngineType.setSelectedItem( SSWConstants.DEFAULT_ENGINE );
         cmbGyroType.setSelectedItem( SSWConstants.DEFAULT_GYRO );

--- a/ssw/src/main/java/ssw/gui/frmMainWide.java
+++ b/ssw/src/main/java/ssw/gui/frmMainWide.java
@@ -432,6 +432,7 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
         RefreshInternalPoints();
         SetLoadoutArrays();
         SetWeaponChoosers();
+        quirks = CurMech.GetQuirks();
         cmbInternalType.setSelectedItem( SSWConstants.DEFAULT_CHASSIS );
         cmbEngineType.setSelectedItem( SSWConstants.DEFAULT_ENGINE );
         cmbGyroType.setSelectedItem( SSWConstants.DEFAULT_GYRO );

--- a/ssw/src/main/java/ssw/gui/frmMainWide.java
+++ b/ssw/src/main/java/ssw/gui/frmMainWide.java
@@ -114,7 +114,7 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
     private Cursor NormalCursor = new Cursor( Cursor.DEFAULT_CURSOR );
     // ImageIcon FluffImage = Utils.createImageIcon( SSWConstants.NO_IMAGE );
     public DataFactory data;
-    public ArrayList<Quirk> quirks = new ArrayList<Quirk>();
+    public ArrayList<Quirk> quirks;
 
     private dlgPrintBatchMechs BatchWindow = null;
     private ImageTracker imageTracker = new ImageTracker();
@@ -143,6 +143,7 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
         CurMech = new Mech( Prefs );
         ArmorTons = new VSetArmorTonnage( Prefs );
         Mechrender = new MechLoadoutRenderer( this );
+        quirks = CurMech.GetQuirks();
 
         // added for easy checking
         PPCCapAC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
@@ -432,7 +433,6 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
         RefreshInternalPoints();
         SetLoadoutArrays();
         SetWeaponChoosers();
-        quirks = CurMech.GetQuirks();
         cmbInternalType.setSelectedItem( SSWConstants.DEFAULT_CHASSIS );
         cmbEngineType.setSelectedItem( SSWConstants.DEFAULT_ENGINE );
         cmbGyroType.setSelectedItem( SSWConstants.DEFAULT_GYRO );


### PR DESCRIPTION
This fixes #222 by assigning a valid reference to the Mech's quirk list in the view without loading it into the program first. The dialog's quirk list model was only being set by `LoadMechIntoGUI()`, but this method isn't called when designing a new mech, so the new Mech's table never got updated when new quirks were added.