### PR TITLE
Reset quirks when clicking new mech button

### DIFF
--- a/ssw/src/main/java/ssw/gui/frmMain.java
+++ b/ssw/src/main/java/ssw/gui/frmMain.java
@@ -2845,6 +2845,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
             new String [] {
                 "Cost", "Quirk"
             }));
+        CurMech.SetQuirks(quirks);
     }
 
     private void UnallocateAll() {

--- a/ssw/src/main/java/ssw/gui/frmMainWide.java
+++ b/ssw/src/main/java/ssw/gui/frmMainWide.java
@@ -2704,6 +2704,7 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
         RefreshInfoPane();
         SetWeaponChoosers();
         ResetAmmo();
+        ResetQuirks();
 
         Overview.StartNewDocument();
         Capabilities.StartNewDocument();
@@ -2743,6 +2744,21 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
             ItemInfo.setLocationRelativeTo( this );
             ItemInfo.setVisible( true );
         }
+    }
+    
+        private void ResetQuirks() {
+        quirks = new ArrayList<>();
+        tblQuirks.setModel(new javax.swing.table.DefaultTableModel(
+            new Object [][] {
+                {null, null},
+                {null, null},
+                {null, null},
+                {null, null}
+            },
+            new String [] {
+                "Cost", "Quirk"
+            }));
+        CurMech.SetQuirks(quirks);
     }
 
     private void UnallocateAll() {

--- a/ssw/src/main/java/ssw/gui/frmMainWide.java
+++ b/ssw/src/main/java/ssw/gui/frmMainWide.java
@@ -2746,7 +2746,7 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
         }
     }
     
-        private void ResetQuirks() {
+    private void ResetQuirks() {
         quirks = new ArrayList<>();
         tblQuirks.setModel(new javax.swing.table.DefaultTableModel(
             new Object [][] {


### PR DESCRIPTION
This fixes more issues related to saving quirks by correctly resetting them when the "New Mech" menu button is clicked.