### PR TITLE
Set curlotsize when deserializing Ammunition

### DIFF
--- a/sswlib/src/main/java/filehandlers/JsonReader.java
+++ b/sswlib/src/main/java/filehandlers/JsonReader.java
@@ -29,6 +29,10 @@ public class JsonReader {
     public ArrayList ReadAllAmmo(Path f) throws Exception {
         Type collectionType = new TypeToken<Map<String, Ammunition>>(){}.getType();
         Map<String, Ammunition> map = gson.fromJson(new FileReader(f.toString()), collectionType);
+        // hack to get the lot size showing correctly in the GUI
+        for (Ammunition ammo : map.values()) {
+            ammo.SetLotSize(ammo.GetMaxLotSize());
+        }
         return new ArrayList<>(map.values());
 
     }


### PR DESCRIPTION
This fixes #226 by setting `CurLotSize` to `LotSize`, which represents the maximum lot size for most ammunition. This bug occurred because in the old method, the `Ammunition` constructor explicitly set CurLotSize to LotSize when loading objects, which the default Gson deserializer doesn't do. 

IMO it's not ideal to iterate over the ammo list in the JsonReader class after loading it, but the only other approaches I can think of are to write a custom serializer or to serialize the value, both of which are worse.