### PR TITLE
Updated Roster Printing Code

### DIFF
--- a/sswlib/src/main/java/Force/Force.java
+++ b/sswlib/src/main/java/Force/Force.java
@@ -213,7 +213,7 @@ public class Force extends AbstractTableModel implements ifSerializable {
         for ( Unit u : getUnits() ) {
             if ( u.UsingC3 )
                 u.setForceC3BV(TotalC3BV);
-            
+
             TotalBaseBV += u.BaseBV;
             TotalModifier += u.MiscMod;
             TotalTonnage += u.Tonnage;
@@ -321,7 +321,7 @@ public class Force extends AbstractTableModel implements ifSerializable {
         for ( Group g : Groups ) {
             if ( g.getUnits().size() == 0 ) { remove.add(g); }
         }
-        
+
         for ( Group d : remove ) {
             Groups.remove(d);
         }
@@ -434,7 +434,7 @@ public class Force extends AbstractTableModel implements ifSerializable {
             String colName = "Mechwarrior";
             if( curGroup.length() >= 25) colName = "";
             p.WriteStr(colName, 140);
-            p.WriteStr("Type", 60);
+            p.WriteStr("Type", 70);
             p.WriteStr("Tonnage", 50);
             p.WriteStr("Base BV", 40);
             p.WriteStr("G/P", 30);
@@ -453,7 +453,7 @@ public class Force extends AbstractTableModel implements ifSerializable {
                 p.setFont(PrintConsts.SmallItalicFont);
                 p.WriteStr(g.getUnits().size() + " Units", 120);
                 p.WriteStr("", 140);
-                p.WriteStr("", 60);
+                p.WriteStr("", 70);
                 p.WriteStr(String.format("%1$,.2f", g.getTotalTonnage()), 50);
                 p.WriteStr(String.format("%1$,.0f", g.getTotalBaseBV()), 40);
                 p.WriteStr("", 30);
@@ -472,7 +472,7 @@ public class Force extends AbstractTableModel implements ifSerializable {
             p.setFont(PrintConsts.ItalicFont);
             p.WriteStr(TotalUnits + " Units", 120);
             p.WriteStr("", 140);
-            p.WriteStr("", 60);
+            p.WriteStr("", 70);
             p.WriteStr(String.format("%1$,.2f", TotalTonnage), 50);
             p.WriteStr(String.format("%1$,.0f", TotalBaseBV), 40);
             p.WriteStr("", 30);

--- a/sswlib/src/main/java/Force/Force.java
+++ b/sswlib/src/main/java/Force/Force.java
@@ -445,6 +445,7 @@ public class Force extends AbstractTableModel implements ifSerializable {
 
             for ( Unit u : g.getUnits() ) {
                 u.RenderPrint(p);
+                p.currentY += 2;
             }
 
             if ( Groups.size() > 1 ) {

--- a/sswlib/src/main/java/Force/Unit.java
+++ b/sswlib/src/main/java/Force/Unit.java
@@ -498,8 +498,9 @@ public class Unit implements ifSerializable {
     public void RenderPrint(ForceListPrinter p) {
         p.setFont(PrintConsts.PlainFont);
         String[] typeParts = PrintConsts.wrapText(TypeModel, 22, true);
+        String[] mechwarriorParts = PrintConsts.wrapText(getMechwarrior(), 25, true);
         p.WriteStr(typeParts[0], 120);
-        p.WriteStr(getMechwarrior(), 140);
+        p.WriteStr(mechwarriorParts[0], 140);
         p.WriteStr(CommonTools.UnitTypes[UnitType], 70);
         p.WriteStr(String.format("%1$,.2f", Tonnage), 50);
         p.WriteStr(String.format("%1$,.0f", BaseBV), 40);
@@ -509,12 +510,12 @@ public class Unit implements ifSerializable {
         p.WriteStr(String.format("%1$,.0f", TotalBV), 0);
         p.NewLine();
 
-        //Intentionally only doing 1 extra for now until we can see if there is any data that requires more
-        if (typeParts.length > 1) {
-            p.WriteStr(typeParts[1], 120);
+        //Handles all the lines for whichever part is the longest
+        for (Integer idx = 1; idx < Math.max(typeParts.length, mechwarriorParts.length); idx++) {
+            p.WriteStr((typeParts.length > idx) ? typeParts[idx] : "", 120);
+            p.WriteStr((mechwarriorParts.length > idx) ? mechwarriorParts[idx] : "", 140);
             p.NewLine();
         }
-
     }
 
     public void SerializeXML(BufferedWriter file) throws IOException {

--- a/sswlib/src/main/java/Force/Unit.java
+++ b/sswlib/src/main/java/Force/Unit.java
@@ -497,9 +497,10 @@ public class Unit implements ifSerializable {
 
     public void RenderPrint(ForceListPrinter p) {
         p.setFont(PrintConsts.PlainFont);
-        p.WriteStr(TypeModel, 120);
+        String[] typeParts = PrintConsts.wrapText(TypeModel, 22, true);
+        p.WriteStr(typeParts[0], 120);
         p.WriteStr(getMechwarrior(), 140);
-        p.WriteStr(CommonTools.UnitTypes[UnitType], 60);
+        p.WriteStr(CommonTools.UnitTypes[UnitType], 70);
         p.WriteStr(String.format("%1$,.2f", Tonnage), 50);
         p.WriteStr(String.format("%1$,.0f", BaseBV), 40);
         p.WriteStr(GetSkills(), 30);
@@ -507,6 +508,13 @@ public class Unit implements ifSerializable {
         p.WriteStr(Boolean.valueOf(UsingC3).toString(), 30);
         p.WriteStr(String.format("%1$,.0f", TotalBV), 0);
         p.NewLine();
+
+        //Intentionally only doing 1 extra for now until we can see if there is any data that requires more
+        if (typeParts.length > 1) {
+            p.WriteStr(typeParts[1], 120);
+            p.NewLine();
+        }
+
     }
 
     public void SerializeXML(BufferedWriter file) throws IOException {


### PR DESCRIPTION
Will now split long Unit or Mechwarrior names into multiple lines.