### PR TITLE
Set Armor Level for IM to Experimental

### DIFF
--- a/sswlib/src/main/java/states/stArmorHD.java
+++ b/sswlib/src/main/java/states/stArmorHD.java
@@ -45,7 +45,7 @@ public class stArmorHD implements ifArmor, ifState {
         AC.SetCLCodes( 'E', 'X', 'X', 'X', 'E' );
         AC.SetCLDates( 0, 0, false, 3126, 0, 0, false, false );
         AC.SetCLFactions( "", "", "--", "" );
-        AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
+        AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
         AC.SetPBMAllowed(true);
     }
 

--- a/sswlib/src/main/java/states/stArmorISAB.java
+++ b/sswlib/src/main/java/states/stArmorISAB.java
@@ -42,7 +42,7 @@ public class stArmorISAB implements ifArmor, ifState {
         AC.SetISCodes( 'E', 'X', 'X', 'X', 'E' );
         AC.SetISDates( 0, 0, false, 3114, 0, 0, false, false );
         AC.SetISFactions( "", "", "DC", "" );
-        AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED );
+        AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED );
         AC.SetPBMAllowed(true);
     }
 

--- a/sswlib/src/main/java/states/stArmorISBR.java
+++ b/sswlib/src/main/java/states/stArmorISBR.java
@@ -42,7 +42,7 @@ public class stArmorISBR implements ifArmor, ifState {
         AC.SetISCodes( 'E', 'X', 'X', 'X', 'E' );
         AC.SetISDates( 0, 0, false, 3131, 0, 0, false, false );
         AC.SetISFactions( "", "", "DC", "" );
-        AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED );
+        AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED );
         AC.SetPBMAllowed(true);
     }
 

--- a/sswlib/src/main/java/states/stArmorISFF.java
+++ b/sswlib/src/main/java/states/stArmorISFF.java
@@ -42,7 +42,7 @@ public class stArmorISFF implements ifArmor, ifState {
         AC.SetISCodes( 'E', 'D', 'F', 'D', 'C' );
         AC.SetISDates( 0, 0, false, 2571, 2810, 3040, true, true );
         AC.SetISFactions( "", "", "TH", "DC" );
-        AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );
+        AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );
         AC.SetPBMAllowed(true);
     }
 

--- a/sswlib/src/main/java/states/stArmorISHF.java
+++ b/sswlib/src/main/java/states/stArmorISHF.java
@@ -38,7 +38,7 @@ public class stArmorISHF implements ifArmor, ifState {
         AC.SetISCodes( 'E', 'X', 'X', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 3056, 0, 0, false, false );
         AC.SetISFactions( "", "", "LA", "" );
-        AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );
+        AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );
         AC.SetPBMAllowed(true);
     }
 

--- a/sswlib/src/main/java/states/stArmorISIR.java
+++ b/sswlib/src/main/java/states/stArmorISIR.java
@@ -45,7 +45,7 @@ public class stArmorISIR implements ifArmor, ifState {
         /*AC.SetCLCodes( 'E', 'X', 'X', 'X', 'E' );
         AC.SetCLDates( 0, 0, false, 3126, 0, 0, false, false );
         AC.SetCLFactions( "", "", "TH", "" );*/
-        AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
+        AC.SetRulesLevels( AvailableCode.RULES_ADVANCED, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED, AvailableCode.RULES_UNALLOWED );
         AC.SetPBMAllowed(true);
     }
 

--- a/sswlib/src/main/java/states/stArmorISLF.java
+++ b/sswlib/src/main/java/states/stArmorISLF.java
@@ -42,7 +42,7 @@ public class stArmorISLF implements ifArmor, ifState {
         AC.SetISCodes( 'F', 'X', 'X', 'E', 'D' );
         AC.SetISDates( 0, 0, false, 3055, 0, 0, false, false );
         AC.SetISFactions( "", "", "FW", "" );
-        AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_ADVANCED, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );
+        AC.SetRulesLevels( AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_EXPERIMENTAL, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT, AvailableCode.RULES_TOURNAMENT );
         AC.SetPBMAllowed(true);
     }
 


### PR DESCRIPTION
TacOps states (page 92 of the new Split Version)
"IndustrialMechs that use any armor type other than Commercial, Industrial or Heavy Industrial (Standard) must be classified as Experimental-rules units. In addition, Experimental-rules IMs may also make use of all other BM-legal armor types."
#239