### PR TITLE
Fix #305 - Medium Shield disables jump

### DIFF
--- a/Data/Equipment/physicals.json
+++ b/Data/Equipment/physicals.json
@@ -1279,6 +1279,7 @@
       "MinDefBonus": 0,
       "ArmorMult": 0,
       "IntMult": 0,
+      "CanJump": true,
       "BVMovement": true,
       "BVHeatMod": false
     }


### PR DESCRIPTION
Fix issue #305 - *Medium Shield should not cause Jump speed to show as (0)*

Cause:
JSON reader for mech modifier sets bool to false by default.

Solution:
Add `CanJump` to Medium Shield attribute `Modifier`, with value of `true`.