### PR TITLE
Various fixes including for regressions on latest RC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,13 @@ fabric.properties
 # .idea/misc.xml
 # *.ipr
 
+# Eclipse
+/.metadata/
+.classpath
+.project
+.settings/
+/*/bin
+
 
 ### Gradle ###
 .gradle

--- a/Data/Equipment/equipment.json
+++ b/Data/Equipment/equipment.json
@@ -6766,7 +6766,7 @@
   },
   "Combat Vehicle Escape Pod": {
     "ActualName": "Combat Vehicle Escape Pod",
-    "CritName": "Combat Vehicle Escape Pod	",
+    "CritName": "Combat Vehicle Escape Pod",
     "Type": "PE",
     "LookupName": "Combat Vehicle Escape Pod",
     "MegaMekName": "ISCombatVehicleEscapePod",

--- a/Data/Equipment/quirks.json
+++ b/Data/Equipment/quirks.json
@@ -1,7 +1,7 @@
 {
   "Accurate Weapon": {
     "name": "Accurate Weapon",
-    "cost": 0,
+    "cost": 1,
     "description": "Being of exceptional design, a weapon or bay is more accurate than normal, and receives a –1 Target Number modifier. The cost is 1 point per 5 points (or fraction thereof) of maximum damage the weapon or bay can inflict in a single Damage Value grouping. More than one weapon or bay on a unit can receive this positive quirk, but the cost for each must be paid. If the “weapon” deals 0 damage (such as TAG), the cost is 2 points.",
     "positive": true,
     "battlemech": true,
@@ -19,7 +19,7 @@
   },
   "Anti-Aircraft Targeting": {
     "name": "Anti-Aircraft Targeting",
-    "cost": 0,
+    "cost": 1,
     "description": "Some 'Mechs, like the Rifleman, have an advanced targeting system that can accurately target airborne units. This includes 'Mechs performing a combat drop (see p. 20, SO), but not jumping 'Mechs. All attacks against such units while airborne (not grounded) receive a –2 Target Number modifier. The cost is 1 point per 7 points (or fraction thereof ) of maximum damage that all the weapons mounted on the 'Mech can inflict (excluding physical attack weapons). This bonus is only available when the 'Mech itself is on the ground.",
     "positive": true,
     "battlemech": true,
@@ -182,7 +182,7 @@
   "Directional Torso Mount": {
     "name": "Directional Torso Mount",
     "cost": 2,
-    "description": "A well-known feature of the original Goliath, a Directional Torso Mount acts as a somewhat more restrictive BattleMech shoulder turret, allowing any weapons in the mount to shoot in either the front arc or the rear arc, depending on the mount's current facing. The mount's facing is set at the start of the game, and can be changed at the same time torso twists are made. However, unlike a torso twist, it does not reset at each End Phase: the arc chosen remains until deliberately changed. The mount rotates with any torso twist as normal.  Each time a location with a Directional Torso Mount takes a hit (Front or Rear), the player must roll 2D6. A result of 9+ means the mount is destroyed and its weapon locked in its current arc, in addition to the normal effects of the attack.  The 3-point version of this quirk is available only to quad 'Mechs. In this case, the mount operates as a full turret, capable of rotating a full 360 degrees.  No weapon with location placement restrictions (such as a heavy Gauss rifle) can be placed in a Directional Torso Mount",
+    "description": "A well-known feature of the original Goliath, a Directional Torso Mount acts as a somewhat more restrictive BattleMech shoulder turret, allowing any weapons in the mount to shoot in either the front arc or the rear arc, depending on the mount's current facing. The mount's facing is set at the start of the game, and can be changed at the same time torso twists are made. However, unlike a torso twist, it does not reset at each End Phase: the arc chosen remains until deliberately changed. The mount rotates with any torso twist as normal.  Each time a location with a Directional Torso Mount takes a hit (Front or Rear), the player must roll 2D6. A result of 9+ means the mount is destroyed and its weapon locked in its current arc, in addition to the normal effects of the attack.  No weapon with location placement restrictions (such as a heavy Gauss rifle) can be placed in a Directional Torso Mount",
     "positive": true,
     "battlemech": true,
     "industrialmech": true,
@@ -195,7 +195,25 @@
     "warship": false,
     "spacestation": false,
     "protomech": false,
-    "isvariable": true
+    "isvariable": false
+  },
+  "Directional Torso Mount, Quad": {
+    "name": "Directional Torso Mount, Quad",
+    "cost": 3,
+    "description": "The 3-point version of the Directional Torso Mount quirk is available only to quad 'Mechs. In this case, the mount operates as a full turret, capable of rotating a full 360 degrees.  Each time a location with a Directional Torso Mount takes a hit (Front or Rear), the player must roll 2D6. A result of 9+ means the mount is destroyed and its weapon locked in its current arc, in addition to the normal effects of the attack.  No weapon with location placement restrictions (such as a heavy Gauss rifle) can be placed in a Directional Torso Mount",
+    "positive": true,
+    "battlemech": true,
+    "industrialmech": true,
+    "combatvehicle": false,
+    "battlearmor": false,
+    "aerospacefighter": false,
+    "conventionalfighter": false,
+    "dropship": false,
+    "jumpship": false,
+    "warship": false,
+    "spacestation": false,
+    "protomech": false,
+    "isvariable": false
   },
   "Distracting": {
     "name": "Distracting",
@@ -558,8 +576,8 @@
   },
   "Narrow/Low Profile": {
     "name": "Narrow/Low Profile",
-    "cost": 2,
-    "description": "If the Margin of Success for a weapon attack made against a Narrow/low profile Unit is 0 or 1, the hit is considered a Glancing Blow.",
+    "cost": 3,
+    "description": "If the Margin of Success for a weapon attack made against a Narrow/low profile Unit is 0 or 1, the hit is considered a Glancing Blow.  A glancing blow inflicts half the normal damage (rounded down); for weapons that roll on the Cluster Hits Table, instead apply a –4 modifier to the Cluster roll result (with a minimum result of 2). Additionally, apply a –2 modifier when rolling on the Determining Critical Hits Table any time a glancing blow yields the possibility of a critical hit; if using the Advanced Determining Critical Hits rule (see p. 83, TO:AR), apply a –4 modifier instead.  This quirk has no effect versus non-weapon attacks, such as falls or physical attacks. It also has no effect versus all-or-nothing weapon attacks, such as Streak missile launchers. If using the Linking Weapons rule (see p. 83, TO:AR), the entire linked group is considered a glancing blow.  If also using the Glancing Blow rule (see p. 78, TO:AR), the effects stack (1/4 damage is dealt). Any subtractive damage reduction effects (such as ferro-lamellor armor) are applied after all other damage reduction effects.",
     "positive": true,
     "battlemech": true,
     "industrialmech": true,
@@ -720,7 +738,7 @@
   },
   "Stabilized Weapon": {
     "name": "Stabilized Weapon",
-    "cost": 0,
+    "cost": 1,
     "description": "Some weapons, such as the center torso and head lasers of the Mongoose, are better cushioned against or otherwise compensated for the increased inaccuracy caused by moving at high speeds. If the 'Mech runs, all Target Numbers for that weapon receive a –1 modifier.  The cost is 1 point per 7 points (or fraction thereof) of maximum damage the weapon can inflict in a single Damage Value grouping. If the “weapon” deals 0 damage (such as TAG), the cost is 1 point. More than one weapon can receive this positive quirk, but the cost for each must be paid.",
     "positive": true,
     "battlemech": true,
@@ -774,7 +792,7 @@
   },
   "Variable Range Targeting": {
     "name": "Variable Range Targeting",
-    "cost": 0,
+    "cost": 1,
     "description": "A BattleMech with this quirk has an advanced targeting system that allows it to launch more accurate attacks at either long or short range, at the expense of reduced accuracy at other ranges. During a turn's End Phase, the controlling player must designate whether this improved targeting feature will be active at long or short range the next turn. All weapon attacks at the designated range receive a -1 target number modifier, but all weapon attacks at the alternative range receive a +1 target number modifier (medium range remains unmodified).",
     "positive": true,
     "battlemech": true,
@@ -1548,7 +1566,7 @@
   },
   "Weak Head Armor": {
     "name": "Weak Head Armor",
-    "cost": 0,
+    "cost": 1,
     "description": "The Value of this quirk is equal to the number of armor points effectively lost.",
     "positive": false,
     "battlemech": true,

--- a/saw/src/main/java/saw/gui/dlgPrefs.form
+++ b/saw/src/main/java/saw/gui/dlgPrefs.form
@@ -16,6 +16,7 @@
   </Properties>
   <SyntheticProperties>
     <SyntheticProperty name="formSizePolicy" type="int" value="1"/>
+    <SyntheticProperty name="generateCenter" type="boolean" value="false"/>
   </SyntheticProperties>
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
@@ -1224,7 +1225,7 @@
                 </Component>
                 <Component class="javax.swing.JCheckBox" name="chkLoadLastMech">
                   <Properties>
-                    <Property name="text" type="java.lang.String" value="Load last &apos;Mech on startup"/>
+                    <Property name="text" type="java.lang.String" value="Load last Vee on startup"/>
                   </Properties>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
@@ -1380,13 +1381,26 @@
                     </Constraint>
                   </Constraints>
                 </Component>
+                <Component class="javax.swing.JRadioButton" name="rdoLargescreen">
+                  <Properties>
+                    <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
+                      <ComponentRef name="btgScreenSize"/>
+                    </Property>
+                    <Property name="text" type="java.lang.String" value="Large Screen (1600 wide)"/>
+                  </Properties>
+                  <Constraints>
+                    <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                      <GridBagConstraints gridX="0" gridY="2" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+                    </Constraint>
+                  </Constraints>
+                </Component>
                 <Component class="javax.swing.JLabel" name="lblScreenSizeNotice">
                   <Properties>
                     <Property name="text" type="java.lang.String" value="Change requires restart of SSW."/>
                   </Properties>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                      <GridBagConstraints gridX="0" gridY="2" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+                      <GridBagConstraints gridX="0" gridY="3" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
                     </Constraint>
                   </Constraints>
                 </Component>

--- a/saw/src/main/java/saw/gui/dlgPrefs.java
+++ b/saw/src/main/java/saw/gui/dlgPrefs.java
@@ -1731,9 +1731,9 @@ public class dlgPrefs extends javax.swing.JDialog {
     private javax.swing.JRadioButton rdoArmorTorsoPriority;
     private javax.swing.JRadioButton rdoExportSortIn;
     private javax.swing.JRadioButton rdoExportSortOut;
+    private javax.swing.JRadioButton rdoLargescreen;
     private javax.swing.JRadioButton rdoNormalSize;
     private javax.swing.JRadioButton rdoWidescreen;
-    private javax.swing.JRadioButton rdoLargescreen;
     private javax.swing.JTextField txtAmmoExportName;
     private javax.swing.JTextField txtAmmoPrintName;
     private javax.swing.JTextField txtCTRArmor;

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -50,6 +50,7 @@ import visitors.VSetArmorTonnage;
 import visitors.ifVisitor;
 
 import javax.swing.*;
+import javax.swing.event.ListSelectionListener;
 import javax.swing.text.JTextComponent;
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
@@ -1158,41 +1159,13 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         lblArmorLeftInLot = new javax.swing.JLabel();
         jPanel3 = new javax.swing.JPanel();
         tbpWeaponChooser = new JTabbedPane();
-        JPanel pnlBallistic = new JPanel();
-        JSeparator jSeparator5 = new JSeparator();
-        JScrollPane jScrollPane8 = new JScrollPane();
         lstChooseBallistic = new javax.swing.JList();
-        JSeparator jSeparator6 = new JSeparator();
-        JPanel pnlEnergy = new JPanel();
-        JSeparator jSeparator7 = new JSeparator();
-        JScrollPane jScrollPane9 = new JScrollPane();
         lstChooseEnergy = new javax.swing.JList();
-        JSeparator jSeparator8 = new JSeparator();
-        JPanel pnlMissile = new JPanel();
-        JSeparator jSeparator9 = new JSeparator();
-        JScrollPane jScrollPane19 = new JScrollPane();
         lstChooseMissile = new javax.swing.JList();
-        JSeparator jSeparator10 = new JSeparator();
-        JPanel pnlPhysical = new JPanel();
-        JSeparator jSeparator11 = new JSeparator();
-        JScrollPane jScrollPane20 = new JScrollPane();
         lstChoosePhysical = new javax.swing.JList();
-        JSeparator jSeparator12 = new JSeparator();
-        JPanel pnlEquipmentChooser = new JPanel();
-        JSeparator jSeparator13 = new JSeparator();
-        JScrollPane jScrollPane21 = new JScrollPane();
         lstChooseEquipment = new javax.swing.JList();
-        JSeparator jSeparator14 = new JSeparator();
-        JPanel pnlArtillery = new JPanel();
-        JSeparator jSeparator18 = new JSeparator();
-        JScrollPane jScrollPane24 = new JScrollPane();
         lstChooseArtillery = new javax.swing.JList();
-        JSeparator jSeparator19 = new JSeparator();
-        JPanel pnlAmmunition = new JPanel();
-        JSeparator jSeparator15 = new JSeparator();
-        JScrollPane jScrollPane22 = new JScrollPane();
         lstChooseAmmunition = new javax.swing.JList();
-        JSeparator jSeparator16 = new JSeparator();
         JPanel pnlSpecials = new JPanel();
         JLabel jLabel37 = new JLabel();
         chkUseTC = new javax.swing.JCheckBox();
@@ -3077,328 +3050,31 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
 
         tbpMainTabPane.addTab("Armor", jPanel2);
 
+        //region Equipment Tab / Weapons and Equipment Lists
+        AbstractListModel placeholder = new AbstractListModel() {
+            String[] strings = { "Placeholder" };
+            public int getSize() { return strings.length; }
+            public Object getElementAt(int i) { return strings[i]; }
+        };
+
+        MouseListener mlAddEquip = new MouseAdapter() {
+            public void mouseClicked( MouseEvent e ) {
+                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
+                    btnAddEquipActionPerformed( null );
+                }
+            }
+        };
+
         tbpWeaponChooser.setTabPlacement(JTabbedPane.RIGHT);
         tbpWeaponChooser.setMaximumSize(new Dimension(300, 300));
         tbpWeaponChooser.setMinimumSize(new Dimension(300, 300));
-
-        jSeparator5.setOrientation(SwingConstants.VERTICAL);
-        jSeparator5.setAlignmentX(0.0F);
-        jSeparator5.setAlignmentY(0.0F);
-
-        jScrollPane8.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane8.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane8.setMaximumSize(new Dimension(300, 300));
-        jScrollPane8.setMinimumSize(new Dimension(300, 300));
-        jScrollPane8.setPreferredSize(new Dimension(300, 300));
-
-        lstChooseBallistic.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseBallistic.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseBallistic.setMaximumSize(new Dimension(300, 300));
-        lstChooseBallistic.setMinimumSize(new Dimension(300, 300));
-        lstChooseBallistic.setPreferredSize(new Dimension(300, 300));
-        lstChooseBallistic.setVisibleRowCount(16);
-        lstChooseBallistic.addListSelectionListener(this::lstChooseBallisticValueChanged);
-        MouseListener mlBallistic = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseBallistic.addMouseListener( mlBallistic );
-        lstChooseBallistic.setCellRenderer( new saw.gui.EquipmentListRenderer( this ) );
-        jScrollPane8.setViewportView(lstChooseBallistic);
-
-        jSeparator6.setOrientation(SwingConstants.VERTICAL);
-        jSeparator6.setAlignmentX(0.0F);
-        jSeparator6.setAlignmentY(0.0F);
-
-        javax.swing.GroupLayout pnlBallisticLayout = new javax.swing.GroupLayout(pnlBallistic);
-        pnlBallistic.setLayout(pnlBallisticLayout);
-        pnlBallisticLayout.setHorizontalGroup(
-            pnlBallisticLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(pnlBallisticLayout.createSequentialGroup()
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jScrollPane8, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED))
-        );
-        pnlBallisticLayout.setVerticalGroup(
-            pnlBallisticLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(pnlBallisticLayout.createSequentialGroup()
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jScrollPane8, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED))
-        );
-
-        tbpWeaponChooser.addTab("Ballistic", pnlBallistic);
-
-        pnlEnergy.setLayout(new javax.swing.BoxLayout(pnlEnergy, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator7.setOrientation(SwingConstants.VERTICAL);
-        jSeparator7.setAlignmentX(0.0F);
-        jSeparator7.setAlignmentY(0.0F);
-        pnlEnergy.add(jSeparator7);
-
-        jScrollPane9.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane9.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane9.setMaximumSize(new Dimension(300, 300));
-        jScrollPane9.setMinimumSize(new Dimension(300, 300));
-        jScrollPane9.setPreferredSize(new Dimension(300, 300));
-
-        lstChooseEnergy.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseEnergy.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseEnergy.setMaximumSize(new Dimension(300, 300));
-        lstChooseEnergy.setMinimumSize(new Dimension(300, 300));
-        lstChooseEnergy.setPreferredSize(new Dimension(300, 300));
-        lstChooseEnergy.setVisibleRowCount(16);
-        lstChooseEnergy.addListSelectionListener(this::lstChooseEnergyValueChanged);
-        MouseListener mlEnergy = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseEnergy.addMouseListener( mlEnergy );
-        lstChooseEnergy.setCellRenderer( new saw.gui.EquipmentListRenderer( this ) );
-        jScrollPane9.setViewportView(lstChooseEnergy);
-
-        pnlEnergy.add(jScrollPane9);
-
-        jSeparator8.setOrientation(SwingConstants.VERTICAL);
-        jSeparator8.setAlignmentX(0.0F);
-        jSeparator8.setAlignmentY(0.0F);
-        pnlEnergy.add(jSeparator8);
-
-        tbpWeaponChooser.addTab("Energy", pnlEnergy);
-
-        pnlMissile.setLayout(new javax.swing.BoxLayout(pnlMissile, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator9.setOrientation(SwingConstants.VERTICAL);
-        jSeparator9.setAlignmentX(0.0F);
-        jSeparator9.setAlignmentY(0.0F);
-        pnlMissile.add(jSeparator9);
-
-        jScrollPane19.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane19.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane19.setMaximumSize(new Dimension(300, 300));
-        jScrollPane19.setMinimumSize(new Dimension(300, 300));
-        jScrollPane19.setPreferredSize(new Dimension(300, 300));
-
-        lstChooseMissile.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseMissile.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseMissile.setMaximumSize(new Dimension(300, 300));
-        lstChooseMissile.setMinimumSize(new Dimension(300, 300));
-        lstChooseMissile.setPreferredSize(new Dimension(300, 300));
-        lstChooseMissile.setVisibleRowCount(16);
-        lstChooseMissile.addListSelectionListener(this::lstChooseMissileValueChanged);
-        MouseListener mlMissile = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseMissile.addMouseListener( mlMissile );
-        lstChooseMissile.setCellRenderer( new saw.gui.EquipmentListRenderer( this ) );
-        jScrollPane19.setViewportView(lstChooseMissile);
-
-        pnlMissile.add(jScrollPane19);
-
-        jSeparator10.setOrientation(SwingConstants.VERTICAL);
-        jSeparator10.setAlignmentX(0.0F);
-        jSeparator10.setAlignmentY(0.0F);
-        pnlMissile.add(jSeparator10);
-
-        tbpWeaponChooser.addTab("Missile", pnlMissile);
-
-        pnlPhysical.setLayout(new javax.swing.BoxLayout(pnlPhysical, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator11.setOrientation(SwingConstants.VERTICAL);
-        jSeparator11.setAlignmentX(0.0F);
-        jSeparator11.setAlignmentY(0.0F);
-        pnlPhysical.add(jSeparator11);
-
-        jScrollPane20.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane20.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane20.setMaximumSize(new Dimension(300, 300));
-        jScrollPane20.setMinimumSize(new Dimension(300, 300));
-        jScrollPane20.setPreferredSize(new Dimension(300, 300));
-
-        lstChoosePhysical.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChoosePhysical.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChoosePhysical.setMaximumSize(new Dimension(300, 300));
-        lstChoosePhysical.setMinimumSize(new Dimension(300, 300));
-        lstChoosePhysical.setPreferredSize(new Dimension(300, 300));
-        lstChoosePhysical.setVisibleRowCount(16);
-        lstChoosePhysical.addListSelectionListener(this::lstChoosePhysicalValueChanged);
-        MouseListener mlPhysical = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChoosePhysical.addMouseListener( mlPhysical );
-        lstChoosePhysical.setCellRenderer( new saw.gui.EquipmentListRenderer( this ) );
-        jScrollPane20.setViewportView(lstChoosePhysical);
-
-        pnlPhysical.add(jScrollPane20);
-
-        jSeparator12.setOrientation(SwingConstants.VERTICAL);
-        jSeparator12.setAlignmentX(0.0F);
-        jSeparator12.setAlignmentY(0.0F);
-        pnlPhysical.add(jSeparator12);
-
-        tbpWeaponChooser.addTab("Physical", pnlPhysical);
-
-        pnlEquipmentChooser.setLayout(new javax.swing.BoxLayout(pnlEquipmentChooser, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator13.setOrientation(SwingConstants.VERTICAL);
-        jSeparator13.setAlignmentX(0.0F);
-        jSeparator13.setAlignmentY(0.0F);
-        pnlEquipmentChooser.add(jSeparator13);
-
-        jScrollPane21.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane21.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane21.setMaximumSize(new Dimension(300, 300));
-        jScrollPane21.setMinimumSize(new Dimension(300, 300));
-        jScrollPane21.setPreferredSize(new Dimension(300, 300));
-
-        lstChooseEquipment.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseEquipment.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseEquipment.setMaximumSize(new Dimension(300, 300));
-        lstChooseEquipment.setMinimumSize(new Dimension(300, 300));
-        lstChooseEquipment.setPreferredSize(new Dimension(300, 300));
-        lstChooseEquipment.setVisibleRowCount(16);
-        lstChooseEquipment.addListSelectionListener(this::lstChooseEquipmentValueChanged);
-        MouseListener mlEquipment = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseEquipment.addMouseListener( mlEquipment );
-        lstChooseEquipment.setCellRenderer( new saw.gui.EquipmentListRenderer( this ) );
-        jScrollPane21.setViewportView(lstChooseEquipment);
-
-        pnlEquipmentChooser.add(jScrollPane21);
-
-        jSeparator14.setOrientation(SwingConstants.VERTICAL);
-        jSeparator14.setAlignmentX(0.0F);
-        jSeparator14.setAlignmentY(0.0F);
-        pnlEquipmentChooser.add(jSeparator14);
-
-        tbpWeaponChooser.addTab("Equipment", pnlEquipmentChooser);
-
-        pnlArtillery.setLayout(new javax.swing.BoxLayout(pnlArtillery, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator18.setOrientation(SwingConstants.VERTICAL);
-        jSeparator18.setAlignmentX(0.0F);
-        jSeparator18.setAlignmentY(0.0F);
-        pnlArtillery.add(jSeparator18);
-
-        jScrollPane24.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane24.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane24.setMaximumSize(new Dimension(300, 300));
-        jScrollPane24.setMinimumSize(new Dimension(300, 300));
-        jScrollPane24.setPreferredSize(new Dimension(300, 300));
-
-        lstChooseArtillery.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseArtillery.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseArtillery.setMaximumSize(new Dimension(300, 300));
-        lstChooseArtillery.setMinimumSize(new Dimension(300, 300));
-        lstChooseArtillery.setPreferredSize(new Dimension(300, 300));
-        lstChooseArtillery.setVisibleRowCount(16);
-        lstChooseArtillery.addListSelectionListener(this::lstChooseArtilleryValueChanged);
-        MouseListener mlArtillery = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseArtillery.addMouseListener( mlArtillery );
-        lstChooseArtillery.setCellRenderer( new saw.gui.EquipmentListRenderer( this ) );
-        jScrollPane24.setViewportView(lstChooseArtillery);
-
-        pnlArtillery.add(jScrollPane24);
-
-        jSeparator19.setOrientation(SwingConstants.VERTICAL);
-        jSeparator19.setAlignmentX(0.0F);
-        jSeparator19.setAlignmentY(0.0F);
-        pnlArtillery.add(jSeparator19);
-
-        tbpWeaponChooser.addTab("Artillery", pnlArtillery);
-
-        pnlAmmunition.setLayout(new javax.swing.BoxLayout(pnlAmmunition, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator15.setOrientation(SwingConstants.VERTICAL);
-        jSeparator15.setAlignmentX(0.0F);
-        jSeparator15.setAlignmentY(0.0F);
-        pnlAmmunition.add(jSeparator15);
-
-        jScrollPane22.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane22.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane22.setMaximumSize(new Dimension(300, 300));
-        jScrollPane22.setMinimumSize(new Dimension(300, 300));
-        jScrollPane22.setPreferredSize(new Dimension(300, 300));
-
-        lstChooseAmmunition.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseAmmunition.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseAmmunition.setMaximumSize(new Dimension(300, 300));
-        lstChooseAmmunition.setMinimumSize(new Dimension(300, 300));
-        lstChooseAmmunition.setPreferredSize(new Dimension(300, 300));
-        lstChooseAmmunition.setVisibleRowCount(16);
-        lstChooseAmmunition.addListSelectionListener(this::lstChooseAmmunitionValueChanged);
-        MouseListener mlAmmo = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseAmmunition.addMouseListener( mlAmmo );
-        lstChooseAmmunition.setCellRenderer( new saw.gui.EquipmentListRenderer( this ) );
-        jScrollPane22.setViewportView(lstChooseAmmunition);
-
-        pnlAmmunition.add(jScrollPane22);
-
-        jSeparator16.setOrientation(SwingConstants.VERTICAL);
-        jSeparator16.setAlignmentX(0.0F);
-        jSeparator16.setAlignmentY(0.0F);
-        pnlAmmunition.add(jSeparator16);
-
-        tbpWeaponChooser.addTab("Ammunition", pnlAmmunition);
+        tbpWeaponChooser.addTab("Ballistic", EquipmentLocation(lstChooseBallistic, this::lstChooseBallisticValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Energy", EquipmentLocation(lstChooseEnergy, this::lstChooseEnergyValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Missile", EquipmentLocation(lstChooseMissile, this::lstChooseMissileValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Physical", EquipmentLocation(lstChoosePhysical, this::lstChoosePhysicalValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Equipment", EquipmentLocation(lstChooseEquipment, this::lstChooseEquipmentValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Artillery", EquipmentLocation(lstChooseArtillery, this::lstChooseArtilleryValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Ammunition", EquipmentLocation(lstChooseAmmunition, this::lstChooseAmmunitionValueChanged, mlAddEquip, placeholder));
 
         pnlSpecials.setBorder(javax.swing.BorderFactory.createTitledBorder(javax.swing.BorderFactory.createEtchedBorder(), "Specials"));
         pnlSpecials.setLayout(new java.awt.GridBagLayout());
@@ -4694,6 +4370,22 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
 
         pack();
     }// </editor-fold>//GEN-END:initComponents
+
+    private JPanel EquipmentLocation(JList list, ListSelectionListener selection, MouseListener listener, AbstractListModel display) {
+        JPanel panel = new JPanel();
+        list.setModel(display);
+        list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        list.addListSelectionListener(selection);
+        list.addMouseListener( listener );
+        list.setCellRenderer( new EquipmentListRenderer( this ) );
+        JScrollPane pane = new JScrollPane();
+        pane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+        pane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+        pane.setViewportView(list);
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.add(pane);
+        return panel;
+    }
 
     private void RefreshSummary() {
         // refreshes the display completely using info from the mech.

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -341,7 +341,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             public Object getValueAt( int row, int col ) {
                 Object o = CurVee.GetLoadout().GetEquipment().get( row );
                 if( col == 1 ) {
-                    return ((abPlaceable) o).GetManufacturer();
+                    return CommonTools.UnknownToEmpty( ((abPlaceable) o).GetManufacturer() );
                 } else {
                     return ((abPlaceable) o).CritName();
                 }
@@ -6179,7 +6179,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
                 if (CurVee.GetLoadout().GetEquipment().size() <= row) { return null; }
                 Object o = CurVee.GetLoadout().GetEquipment().get( row );
                 if( col == 1 ) {
-                    return ((abPlaceable) o).GetManufacturer();
+                    return CommonTools.UnknownToEmpty( ((abPlaceable) o).GetManufacturer() );
                 } else {
                     return ((abPlaceable) o).CritName();
                 }
@@ -7988,20 +7988,20 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         Variants.SetText( CurVee.getVariants() );
         Notables.SetText( CurVee.getNotables() );
         Additional.SetText( CurVee.GetAdditional() );
-        txtManufacturer.setText( CurVee.GetCompany() );
-        txtManufacturerLocation.setText( CurVee.GetLocation() );
-        txtEngineManufacturer.setText( CurVee.GetEngineManufacturer() );
-        txtArmorModel.setText( CurVee.GetArmorModel() );
-        txtChassisModel.setText( CurVee.GetChassisModel() );
+        txtManufacturer.setText( CommonTools.UnknownToEmpty( CurVee.GetCompany() ) );
+        txtManufacturerLocation.setText( CommonTools.UnknownToEmpty( CurVee.GetLocation() ) );
+        txtEngineManufacturer.setText( CommonTools.UnknownToEmpty( CurVee.GetEngineManufacturer() ) );
+        txtArmorModel.setText( CommonTools.UnknownToEmpty( CurVee.GetArmorModel() ) );
+        txtChassisModel.setText( CommonTools.UnknownToEmpty( CurVee.GetChassisModel() ) );
         if( CurVee.GetJumpJets().GetNumJJ() > 0 ) {
             txtJJModel.setEnabled( true );
         }
         txtSource.setText( CurVee.getSource() );
 
         // omnimechs may have jump jets in one loadout and not another.
-        txtJJModel.setText( CurVee.GetJJModel() );
-        txtCommSystem.setText( CurVee.GetCommSystem() );
-        txtTNTSystem.setText( CurVee.GetTandTSystem() );
+        txtJJModel.setText( CommonTools.UnknownToEmpty( CurVee.GetJJModel() ) );
+        txtCommSystem.setText( CommonTools.UnknownToEmpty( CurVee.GetCommSystem() ) );
+        txtTNTSystem.setText( CommonTools.UnknownToEmpty( CurVee.GetTandTSystem() ) );
 
         setTitle( saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
         CurVee.SetChanged(false);

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -2230,7 +2230,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         //endregion
 
         //region Equipment Tab / Weapons and Equipment Lists
-        AbstractListModel placeholder = new javax.swing.AbstractListModel() {
+        AbstractListModel placeholder = new AbstractListModel() {
             String[] strings = { "Placeholder" };
             public int getSize() { return strings.length; }
             public Object getElementAt(int i) { return strings[i]; }
@@ -2678,10 +2678,10 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
     private JPanel EquipmentLocation(JList list, ListSelectionListener selection, MouseListener listener, AbstractListModel display) {
         JPanel panel = new JPanel();
         list.setModel(display);
-        list.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
+        list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         list.addListSelectionListener(selection);
         list.addMouseListener( listener );
-        list.setCellRenderer( new saw.gui.EquipmentListRenderer( this ) );
+        list.setCellRenderer( new EquipmentListRenderer( this ) );
         JScrollPane pane = new JScrollPane();
         pane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
         pane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -146,7 +146,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         CurVee = new CombatVehicle( );
         initComponents();
 
-        Prefs = Preferences.userRoot().node( Constants.SSWPrefs );
+        Prefs = Preferences.userRoot().node( Constants.SAWPrefs );
         ArmorTons = new VSetArmorTonnage( Prefs );
         cmbMotiveTypeActionPerformed(null);
         spnTonnageStateChanged(null);

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -325,7 +325,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             public Object getValueAt( int row, int col ) {
                 Object o = CurVee.GetLoadout().GetEquipment().get( row );
                 if( col == 1 ) {
-                    return ((abPlaceable) o).GetManufacturer();
+                    return CommonTools.UnknownToEmpty( ((abPlaceable) o).GetManufacturer() );
                 } else {
                     return ((abPlaceable) o).CritName();
                 }
@@ -3860,7 +3860,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
                 if (CurVee.GetLoadout().GetEquipment().size() <= row) { return null; }
                 Object o = CurVee.GetLoadout().GetEquipment().get( row );
                 if( col == 1 ) {
-                    return ((abPlaceable) o).GetManufacturer();
+                    return CommonTools.UnknownToEmpty( ((abPlaceable) o).GetManufacturer() );
                 } else {
                     return ((abPlaceable) o).CritName();
                 }
@@ -4609,20 +4609,20 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         Variants.SetText( CurVee.getVariants() );
         Notables.SetText( CurVee.getNotables() );
         Additional.SetText( CurVee.GetAdditional() );
-        txtManufacturer.setText( CurVee.GetCompany() );
-        txtManufacturerLocation.setText( CurVee.GetLocation() );
-        txtEngineManufacturer.setText( CurVee.GetEngineManufacturer() );
-        txtArmorModel.setText( CurVee.GetArmorModel() );
-        txtChassisModel.setText( CurVee.GetChassisModel() );
+        txtManufacturer.setText( CommonTools.UnknownToEmpty( CurVee.GetCompany() ) );
+        txtManufacturerLocation.setText( CommonTools.UnknownToEmpty( CurVee.GetLocation() ) );
+        txtEngineManufacturer.setText( CommonTools.UnknownToEmpty( CurVee.GetEngineManufacturer() ) );
+        txtArmorModel.setText( CommonTools.UnknownToEmpty( CurVee.GetArmorModel() ) );
+        txtChassisModel.setText( CommonTools.UnknownToEmpty( CurVee.GetChassisModel() ) );
         if( CurVee.GetJumpJets().GetNumJJ() > 0 ) {
             txtJJModel.setEnabled( true );
         }
         txtSource.setText( CurVee.getSource() );
 
         // omnimechs may have jump jets in one loadout and not another.
-        txtJJModel.setText( CurVee.GetJJModel() );
-        txtCommSystem.setText( CurVee.GetCommSystem() );
-        txtTNTSystem.setText( CurVee.GetTandTSystem() );
+        txtJJModel.setText( CommonTools.UnknownToEmpty( CurVee.GetJJModel() ) );
+        txtCommSystem.setText( CommonTools.UnknownToEmpty( CurVee.GetCommSystem() ) );
+        txtTNTSystem.setText( CommonTools.UnknownToEmpty( CurVee.GetTandTSystem() ) );
 
         setTitle( saw.Constants.AppName + " " + saw.Constants.GetVersion() + " - " + CurVee.GetName() + " " + CurVee.GetModel() );
         CurVee.SetChanged(false);

--- a/ssw/src/main/java/ssw/gui/frmMain.java
+++ b/ssw/src/main/java/ssw/gui/frmMain.java
@@ -481,7 +481,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
             public Object getValueAt( int row, int col ) {
                 Object o = CurMech.GetLoadout().GetEquipment().get( row );
                 if( col == 1 ) {
-                    return ((abPlaceable) o).GetManufacturer();
+                    return CommonTools.UnknownToEmpty( ((abPlaceable) o).GetManufacturer() );
                 } else {
                     return ((abPlaceable) o).CritName();
                 }
@@ -2781,7 +2781,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
             public Object getValueAt( int row, int col ) {
                 Object o = CurMech.GetLoadout().GetEquipment().get( row );
                 if( col == 1 ) {
-                    return ((abPlaceable) o).GetManufacturer();
+                    return CommonTools.UnknownToEmpty( ((abPlaceable) o).GetManufacturer() );
                 } else {
                     return ((abPlaceable) o).CritName();
                 }
@@ -13384,20 +13384,20 @@ public void LoadMechIntoGUI() {
     Additional.SetText( CurMech.GetAdditional() );
     quirks = CurMech.GetQuirks();
     tblQuirks.setModel( new tbQuirks(quirks) );
-    txtManufacturer.setText( CurMech.GetCompany() );
-    txtManufacturerLocation.setText( CurMech.GetLocation() );
-    txtEngineManufacturer.setText( CurMech.GetEngineManufacturer() );
-    txtArmorModel.setText( CurMech.GetArmorModel() );
-    txtChassisModel.setText( CurMech.GetChassisModel() );
+    txtManufacturer.setText( CommonTools.UnknownToEmpty( CurMech.GetCompany() ) );
+    txtManufacturerLocation.setText( CommonTools.UnknownToEmpty( CurMech.GetLocation() ) );
+    txtEngineManufacturer.setText( CommonTools.UnknownToEmpty( CurMech.GetEngineManufacturer() ) );
+    txtArmorModel.setText( CommonTools.UnknownToEmpty( CurMech.GetArmorModel() ) );
+    txtChassisModel.setText( CommonTools.UnknownToEmpty( CurMech.GetChassisModel() ) );
     if( CurMech.GetJumpJets().GetNumJJ() > 0 ) {
         txtJJModel.setEnabled( true );
     }
     txtSource.setText( CurMech.GetSource() );
 
     // omnimechs may have jump jets in one loadout and not another.
-    txtJJModel.setText( CurMech.GetJJModel() );
-    txtCommSystem.setText( CurMech.GetCommSystem() );
-    txtTNTSystem.setText( CurMech.GetTandTSystem() );
+    txtJJModel.setText( CommonTools.UnknownToEmpty( CurMech.GetJJModel() ) );
+    txtCommSystem.setText( CommonTools.UnknownToEmpty( CurMech.GetCommSystem() ) );
+    txtTNTSystem.setText( CommonTools.UnknownToEmpty( CurMech.GetTandTSystem() ) );
 
     // see if we should enable the Power Amplifier display
     if( CurMech.GetEngine().IsNuclear() ) {

--- a/ssw/src/main/java/ssw/gui/frmMain.java
+++ b/ssw/src/main/java/ssw/gui/frmMain.java
@@ -458,6 +458,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         cmbEngineType.setSelectedItem( SSWConstants.DEFAULT_ENGINE );
         cmbGyroType.setSelectedItem( SSWConstants.DEFAULT_GYRO );
         cmbCockpitType.setSelectedItem( SSWConstants.DEFAULT_COCKPIT );
+        chkCommandConsole.setSelected( false );
         cmbPhysEnhance.setSelectedItem( SSWConstants.DEFAULT_ENHANCEMENT );
         cmbHeatSinkType.setSelectedItem( Prefs.get( "NewMech_Heatsinks", "Single Heat Sink" ) );
         cmbJumpJetType.setSelectedItem( SSWConstants.DEFAULT_JUMPJET );
@@ -2714,6 +2715,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         cmbEngineType.setSelectedItem( SSWConstants.DEFAULT_ENGINE );
         cmbGyroType.setSelectedItem( SSWConstants.DEFAULT_GYRO );
         cmbCockpitType.setSelectedItem( SSWConstants.DEFAULT_COCKPIT );
+        chkCommandConsole.setSelected( false );
         cmbPhysEnhance.setSelectedItem( SSWConstants.DEFAULT_ENHANCEMENT );
         cmbHeatSinkType.setSelectedItem( Prefs.get( "NewMech_Heatsinks", "Single Heat Sink" ) );
         cmbJumpJetType.setSelectedItem( SSWConstants.DEFAULT_JUMPJET );
@@ -3411,8 +3413,6 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         chkHDTurret.setEnabled( true );
         chkLTTurret.setEnabled( true );
         chkRTTurret.setEnabled( true );
-        chkOmnimech.setSelected( false );
-        chkOmnimech.setEnabled( true );
         btnLockChassis.setEnabled( false );
         spnWalkMP.setEnabled( true );
         chkYearRestrict.setEnabled( true );
@@ -12521,6 +12521,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
             FixWalkMPSpinner();
             FixJJSpinnerModel();
             RefreshEquipment();
+            CheckOmnimech();
 
             // now reset the combo boxes to the closest choices we previously selected
             LoadSelections();

--- a/ssw/src/main/java/ssw/gui/frmMain.java
+++ b/ssw/src/main/java/ssw/gui/frmMain.java
@@ -49,6 +49,7 @@ import visitors.VSetArmorTonnage;
 import visitors.ifVisitor;
 
 import javax.swing.*;
+import javax.swing.event.ListSelectionListener;
 import javax.swing.text.JTextComponent;
 import java.awt.*;
 import java.awt.datatransfer.DataFlavor;
@@ -4982,41 +4983,13 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         lblPWRLLoc = new javax.swing.JLabel();
         pnlEquipment = new javax.swing.JPanel();
         tbpWeaponChooser = new javax.swing.JTabbedPane();
-        pnlBallistic = new javax.swing.JPanel();
-        jSeparator3 = new javax.swing.JSeparator();
-        jScrollPane8 = new javax.swing.JScrollPane();
         lstChooseBallistic = new javax.swing.JList();
-        jSeparator4 = new javax.swing.JSeparator();
-        pnlEnergy = new javax.swing.JPanel();
-        jSeparator2 = new javax.swing.JSeparator();
-        jScrollPane9 = new javax.swing.JScrollPane();
         lstChooseEnergy = new javax.swing.JList();
-        jSeparator1 = new javax.swing.JSeparator();
-        pnlMissile = new javax.swing.JPanel();
-        jSeparator5 = new javax.swing.JSeparator();
-        jScrollPane19 = new javax.swing.JScrollPane();
         lstChooseMissile = new javax.swing.JList();
-        jSeparator6 = new javax.swing.JSeparator();
-        pnlPhysical = new javax.swing.JPanel();
-        jSeparator8 = new javax.swing.JSeparator();
-        jScrollPane20 = new javax.swing.JScrollPane();
         lstChoosePhysical = new javax.swing.JList();
-        jSeparator7 = new javax.swing.JSeparator();
-        pnlEquipmentChooser = new javax.swing.JPanel();
-        jSeparator10 = new javax.swing.JSeparator();
-        jScrollPane21 = new javax.swing.JScrollPane();
         lstChooseEquipment = new javax.swing.JList();
-        jSeparator9 = new javax.swing.JSeparator();
-        pnlArtillery = new javax.swing.JPanel();
-        jSeparator18 = new javax.swing.JSeparator();
-        jScrollPane24 = new javax.swing.JScrollPane();
         lstChooseArtillery = new javax.swing.JList();
-        jSeparator19 = new javax.swing.JSeparator();
-        pnlAmmunition = new javax.swing.JPanel();
-        jSeparator11 = new javax.swing.JSeparator();
-        jScrollPane22 = new javax.swing.JScrollPane();
         lstChooseAmmunition = new javax.swing.JList();
-        jSeparator12 = new javax.swing.JSeparator();
         pnlSpecials = new javax.swing.JPanel();
         jLabel16 = new javax.swing.JLabel();
         chkUseTC = new javax.swing.JCheckBox();
@@ -7629,339 +7602,32 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
 
         pnlEquipment.setLayout(new org.netbeans.lib.awtextra.AbsoluteLayout());
 
+        //region Equipment Tab / Weapons and Equipment Lists
+        AbstractListModel placeholder = new AbstractListModel() {
+            String[] strings = { "Placeholder" };
+            public int getSize() { return strings.length; }
+            public Object getElementAt(int i) { return strings[i]; }
+        };
+
+        MouseListener mlAddEquip = new MouseAdapter() {
+            public void mouseClicked( MouseEvent e ) {
+                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
+                    btnAddEquipActionPerformed( null );
+                }
+            }
+        };
+
         tbpWeaponChooser.setTabPlacement(javax.swing.JTabbedPane.RIGHT);
         tbpWeaponChooser.setMaximumSize(new java.awt.Dimension(300, 300));
         tbpWeaponChooser.setMinimumSize(new java.awt.Dimension(300, 300));
         tbpWeaponChooser.setPreferredSize(new java.awt.Dimension(300, 300));
-
-        pnlBallistic.setLayout(new javax.swing.BoxLayout(pnlBallistic, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator3.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator3.setAlignmentX(0.0F);
-        jSeparator3.setAlignmentY(0.0F);
-        pnlBallistic.add(jSeparator3);
-
-        jScrollPane8.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane8.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane8.setMaximumSize(new java.awt.Dimension(200, 260));
-        jScrollPane8.setMinimumSize(new java.awt.Dimension(200, 260));
-        jScrollPane8.setPreferredSize(new java.awt.Dimension(200, 260));
-
-        lstChooseBallistic.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseBallistic.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseBallistic.setMaximumSize(new java.awt.Dimension(180, 10000));
-        lstChooseBallistic.setMinimumSize(new java.awt.Dimension(180, 100));
-        lstChooseBallistic.setVisibleRowCount(16);
-        lstChooseBallistic.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
-            public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
-                lstChooseBallisticValueChanged(evt);
-            }
-        });
-        MouseListener mlBallistic = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseBallistic.addMouseListener( mlBallistic );
-        lstChooseBallistic.setCellRenderer( new ssw.gui.EquipmentListRenderer( this ) );
-        jScrollPane8.setViewportView(lstChooseBallistic);
-
-        pnlBallistic.add(jScrollPane8);
-
-        jSeparator4.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator4.setAlignmentX(0.0F);
-        jSeparator4.setAlignmentY(0.0F);
-        pnlBallistic.add(jSeparator4);
-
-        tbpWeaponChooser.addTab("Ballistic", pnlBallistic);
-
-        pnlEnergy.setLayout(new javax.swing.BoxLayout(pnlEnergy, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator2.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator2.setAlignmentX(0.0F);
-        jSeparator2.setAlignmentY(0.0F);
-        pnlEnergy.add(jSeparator2);
-
-        jScrollPane9.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane9.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane9.setMaximumSize(new java.awt.Dimension(200, 260));
-        jScrollPane9.setMinimumSize(new java.awt.Dimension(200, 260));
-        jScrollPane9.setPreferredSize(new java.awt.Dimension(200, 260));
-
-        lstChooseEnergy.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseEnergy.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseEnergy.setMaximumSize(new java.awt.Dimension(180, 10000));
-        lstChooseEnergy.setMinimumSize(new java.awt.Dimension(180, 100));
-        lstChooseEnergy.setVisibleRowCount(16);
-        lstChooseEnergy.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
-            public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
-                lstChooseEnergyValueChanged(evt);
-            }
-        });
-        MouseListener mlEnergy = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseEnergy.addMouseListener( mlEnergy );
-        lstChooseEnergy.setCellRenderer( new ssw.gui.EquipmentListRenderer( this ) );
-        jScrollPane9.setViewportView(lstChooseEnergy);
-
-        pnlEnergy.add(jScrollPane9);
-
-        jSeparator1.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator1.setAlignmentX(0.0F);
-        jSeparator1.setAlignmentY(0.0F);
-        pnlEnergy.add(jSeparator1);
-
-        tbpWeaponChooser.addTab("Energy", pnlEnergy);
-
-        pnlMissile.setLayout(new javax.swing.BoxLayout(pnlMissile, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator5.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator5.setAlignmentX(0.0F);
-        jSeparator5.setAlignmentY(0.0F);
-        pnlMissile.add(jSeparator5);
-
-        jScrollPane19.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane19.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane19.setMaximumSize(new java.awt.Dimension(200, 260));
-        jScrollPane19.setMinimumSize(new java.awt.Dimension(200, 260));
-        jScrollPane19.setPreferredSize(new java.awt.Dimension(200, 260));
-
-        lstChooseMissile.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseMissile.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseMissile.setMaximumSize(new java.awt.Dimension(180, 10000));
-        lstChooseMissile.setMinimumSize(new java.awt.Dimension(180, 100));
-        lstChooseMissile.setVisibleRowCount(16);
-        lstChooseMissile.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
-            public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
-                lstChooseMissileValueChanged(evt);
-            }
-        });
-        MouseListener mlMissile = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseMissile.addMouseListener( mlMissile );
-        lstChooseMissile.setCellRenderer( new ssw.gui.EquipmentListRenderer( this ) );
-        jScrollPane19.setViewportView(lstChooseMissile);
-
-        pnlMissile.add(jScrollPane19);
-
-        jSeparator6.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator6.setAlignmentX(0.0F);
-        jSeparator6.setAlignmentY(0.0F);
-        pnlMissile.add(jSeparator6);
-
-        tbpWeaponChooser.addTab("Missile", pnlMissile);
-
-        pnlPhysical.setLayout(new javax.swing.BoxLayout(pnlPhysical, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator8.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator8.setAlignmentX(0.0F);
-        jSeparator8.setAlignmentY(0.0F);
-        pnlPhysical.add(jSeparator8);
-
-        jScrollPane20.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane20.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane20.setMaximumSize(new java.awt.Dimension(200, 260));
-        jScrollPane20.setMinimumSize(new java.awt.Dimension(200, 260));
-        jScrollPane20.setPreferredSize(new java.awt.Dimension(200, 260));
-
-        lstChoosePhysical.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChoosePhysical.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChoosePhysical.setMaximumSize(new java.awt.Dimension(180, 10000));
-        lstChoosePhysical.setMinimumSize(new java.awt.Dimension(180, 100));
-        lstChoosePhysical.setVisibleRowCount(16);
-        lstChoosePhysical.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
-            public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
-                lstChoosePhysicalValueChanged(evt);
-            }
-        });
-        MouseListener mlPhysical = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChoosePhysical.addMouseListener( mlPhysical );
-        lstChoosePhysical.setCellRenderer( new ssw.gui.EquipmentListRenderer( this ) );
-        jScrollPane20.setViewportView(lstChoosePhysical);
-
-        pnlPhysical.add(jScrollPane20);
-
-        jSeparator7.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator7.setAlignmentX(0.0F);
-        jSeparator7.setAlignmentY(0.0F);
-        pnlPhysical.add(jSeparator7);
-
-        tbpWeaponChooser.addTab("Physical", pnlPhysical);
-
-        pnlEquipmentChooser.setLayout(new javax.swing.BoxLayout(pnlEquipmentChooser, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator10.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator10.setAlignmentX(0.0F);
-        jSeparator10.setAlignmentY(0.0F);
-        pnlEquipmentChooser.add(jSeparator10);
-
-        jScrollPane21.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane21.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane21.setMaximumSize(new java.awt.Dimension(200, 260));
-        jScrollPane21.setMinimumSize(new java.awt.Dimension(200, 260));
-        jScrollPane21.setPreferredSize(new java.awt.Dimension(200, 260));
-
-        lstChooseEquipment.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseEquipment.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseEquipment.setMaximumSize(new java.awt.Dimension(180, 10000));
-        lstChooseEquipment.setMinimumSize(new java.awt.Dimension(180, 100));
-        lstChooseEquipment.setVisibleRowCount(16);
-        lstChooseEquipment.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
-            public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
-                lstChooseEquipmentValueChanged(evt);
-            }
-        });
-        MouseListener mlEquipment = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseEquipment.addMouseListener( mlEquipment );
-        lstChooseEquipment.setCellRenderer( new ssw.gui.EquipmentListRenderer( this ) );
-        jScrollPane21.setViewportView(lstChooseEquipment);
-
-        pnlEquipmentChooser.add(jScrollPane21);
-
-        jSeparator9.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator9.setAlignmentX(0.0F);
-        jSeparator9.setAlignmentY(0.0F);
-        pnlEquipmentChooser.add(jSeparator9);
-
-        tbpWeaponChooser.addTab("Equipment", pnlEquipmentChooser);
-
-        pnlArtillery.setLayout(new javax.swing.BoxLayout(pnlArtillery, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator18.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator18.setAlignmentX(0.0F);
-        jSeparator18.setAlignmentY(0.0F);
-        pnlArtillery.add(jSeparator18);
-
-        jScrollPane24.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane24.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane24.setMaximumSize(new java.awt.Dimension(200, 260));
-        jScrollPane24.setMinimumSize(new java.awt.Dimension(200, 260));
-        jScrollPane24.setPreferredSize(new java.awt.Dimension(200, 260));
-
-        lstChooseArtillery.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseArtillery.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseArtillery.setMaximumSize(new java.awt.Dimension(180, 10000));
-        lstChooseArtillery.setMinimumSize(new java.awt.Dimension(180, 100));
-        lstChooseArtillery.setVisibleRowCount(16);
-        lstChooseArtillery.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
-            public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
-                lstChooseArtilleryValueChanged(evt);
-            }
-        });
-        MouseListener mlArtillery = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseArtillery.addMouseListener( mlArtillery );
-        lstChooseArtillery.setCellRenderer( new ssw.gui.EquipmentListRenderer( this ) );
-        jScrollPane24.setViewportView(lstChooseArtillery);
-
-        pnlArtillery.add(jScrollPane24);
-
-        jSeparator19.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator19.setAlignmentX(0.0F);
-        jSeparator19.setAlignmentY(0.0F);
-        pnlArtillery.add(jSeparator19);
-
-        tbpWeaponChooser.addTab("Artillery", pnlArtillery);
-
-        pnlAmmunition.setLayout(new javax.swing.BoxLayout(pnlAmmunition, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator11.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator11.setAlignmentX(0.0F);
-        jSeparator11.setAlignmentY(0.0F);
-        pnlAmmunition.add(jSeparator11);
-
-        jScrollPane22.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane22.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane22.setMaximumSize(new java.awt.Dimension(200, 260));
-        jScrollPane22.setMinimumSize(new java.awt.Dimension(200, 260));
-        jScrollPane22.setPreferredSize(new java.awt.Dimension(200, 260));
-
-        lstChooseAmmunition.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseAmmunition.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseAmmunition.setMaximumSize(new java.awt.Dimension(180, 10000));
-        lstChooseAmmunition.setMinimumSize(new java.awt.Dimension(180, 100));
-        lstChooseAmmunition.setVisibleRowCount(16);
-        lstChooseAmmunition.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
-            public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
-                lstChooseAmmunitionValueChanged(evt);
-            }
-        });
-        MouseListener mlAmmo = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseAmmunition.addMouseListener( mlAmmo );
-        lstChooseAmmunition.setCellRenderer( new ssw.gui.EquipmentListRenderer( this ) );
-        jScrollPane22.setViewportView(lstChooseAmmunition);
-
-        pnlAmmunition.add(jScrollPane22);
-
-        jSeparator12.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator12.setAlignmentX(0.0F);
-        jSeparator12.setAlignmentY(0.0F);
-        pnlAmmunition.add(jSeparator12);
-
-        tbpWeaponChooser.addTab("Ammunition", pnlAmmunition);
+        tbpWeaponChooser.addTab("Ballistic", EquipmentLocation(lstChooseBallistic, this::lstChooseBallisticValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Energy", EquipmentLocation(lstChooseEnergy, this::lstChooseEnergyValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Missile", EquipmentLocation(lstChooseMissile, this::lstChooseMissileValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Physical", EquipmentLocation(lstChoosePhysical, this::lstChoosePhysicalValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Equipment", EquipmentLocation(lstChooseEquipment, this::lstChooseEquipmentValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Artillery", EquipmentLocation(lstChooseArtillery, this::lstChooseArtilleryValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Ammunition", EquipmentLocation(lstChooseAmmunition, this::lstChooseAmmunitionValueChanged, mlAddEquip, placeholder));
 
         pnlEquipment.add(tbpWeaponChooser, new org.netbeans.lib.awtextra.AbsoluteConstraints(20, 20, -1, -1));
 
@@ -10658,6 +10324,22 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
 
         pack();
     }// </editor-fold>//GEN-END:initComponents
+
+    private JPanel EquipmentLocation(JList list, ListSelectionListener selection, MouseListener listener, AbstractListModel display) {
+        JPanel panel = new JPanel();
+        list.setModel(display);
+        list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        list.addListSelectionListener(selection);
+        list.addMouseListener( listener );
+        list.setCellRenderer( new EquipmentListRenderer( this ) );
+        JScrollPane pane = new JScrollPane();
+        pane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+        pane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+        pane.setViewportView(list);
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.add(pane);
+        return panel;
+    }
 
     private void mnuExitActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_mnuExitActionPerformed
         if( CurMech.HasChanged() ) {
@@ -15186,26 +14868,12 @@ private void setViewToolbar(boolean Visible)
     private javax.swing.JScrollPane jScrollPane16;
     private javax.swing.JScrollPane jScrollPane17;
     private javax.swing.JScrollPane jScrollPane18;
-    private javax.swing.JScrollPane jScrollPane19;
-    private javax.swing.JScrollPane jScrollPane20;
-    private javax.swing.JScrollPane jScrollPane21;
-    private javax.swing.JScrollPane jScrollPane22;
     private javax.swing.JScrollPane jScrollPane23;
-    private javax.swing.JScrollPane jScrollPane24;
-    private javax.swing.JScrollPane jScrollPane8;
-    private javax.swing.JScrollPane jScrollPane9;
-    private javax.swing.JSeparator jSeparator1;
-    private javax.swing.JSeparator jSeparator10;
-    private javax.swing.JSeparator jSeparator11;
-    private javax.swing.JSeparator jSeparator12;
     private javax.swing.JSeparator jSeparator13;
     private javax.swing.JSeparator jSeparator14;
     private javax.swing.JSeparator jSeparator15;
     private javax.swing.JSeparator jSeparator16;
     private javax.swing.JSeparator jSeparator17;
-    private javax.swing.JSeparator jSeparator18;
-    private javax.swing.JSeparator jSeparator19;
-    private javax.swing.JSeparator jSeparator2;
     private javax.swing.JSeparator jSeparator20;
     private javax.swing.JToolBar.Separator jSeparator21;
     private javax.swing.JToolBar.Separator jSeparator22;
@@ -15216,14 +14884,7 @@ private void setViewToolbar(boolean Visible)
     private javax.swing.JSeparator jSeparator27;
     private javax.swing.JSeparator jSeparator28;
     private javax.swing.JSeparator jSeparator29;
-    private javax.swing.JSeparator jSeparator3;
     private javax.swing.JSeparator jSeparator30;
-    private javax.swing.JSeparator jSeparator4;
-    private javax.swing.JSeparator jSeparator5;
-    private javax.swing.JSeparator jSeparator6;
-    private javax.swing.JSeparator jSeparator7;
-    private javax.swing.JSeparator jSeparator8;
-    private javax.swing.JSeparator jSeparator9;
     private javax.swing.JTextArea jTextAreaBFConversion;
     private javax.swing.JLabel lblAVInLot;
     private javax.swing.JLabel lblArmorCoverage;
@@ -15401,13 +15062,10 @@ private void setViewToolbar(boolean Visible)
     private javax.swing.JCheckBoxMenuItem mnuViewToolbar;
     private javax.swing.JPanel onlLoadoutControls;
     private javax.swing.JPanel pnlAdditionalFluff;
-    private javax.swing.JPanel pnlAmmunition;
     private javax.swing.JPanel pnlArmor;
     private javax.swing.JPanel pnlArmorInfo;
     private javax.swing.JPanel pnlArmorSetup;
-    private javax.swing.JPanel pnlArtillery;
     private javax.swing.JPanel pnlBFStats;
-    private javax.swing.JPanel pnlBallistic;
     private javax.swing.JPanel pnlBasicInformation;
     private javax.swing.JPanel pnlBasicSetup;
     private javax.swing.JPanel pnlBasicSummary;
@@ -15422,10 +15080,8 @@ private void setViewToolbar(boolean Visible)
     private javax.swing.JPanel pnlCriticals;
     private javax.swing.JPanel pnlDamageChart;
     private javax.swing.JPanel pnlDeployment;
-    private javax.swing.JPanel pnlEnergy;
     private javax.swing.JPanel pnlEquipInfo;
     private javax.swing.JPanel pnlEquipment;
-    private javax.swing.JPanel pnlEquipmentChooser;
     private javax.swing.JPanel pnlEquipmentToPlace;
     private javax.swing.JPanel pnlExport;
     private javax.swing.JPanel pnlFluff;
@@ -15444,13 +15100,11 @@ private void setViewToolbar(boolean Visible)
     private javax.swing.JPanel pnlLTCrits;
     private javax.swing.JPanel pnlLTRArmorBox;
     private javax.swing.JPanel pnlManufacturers;
-    private javax.swing.JPanel pnlMissile;
     private javax.swing.JPanel pnlMovement;
     private javax.swing.JPanel pnlNotables;
     private javax.swing.JPanel pnlOmniInfo;
     private javax.swing.JPanel pnlOverview;
     private javax.swing.JPanel pnlPatchworkChoosers;
-    private javax.swing.JPanel pnlPhysical;
     private javax.swing.JPanel pnlQuirks;
     private javax.swing.JPanel pnlRAArmorBox;
     private javax.swing.JPanel pnlRACrits;

--- a/ssw/src/main/java/ssw/gui/frmMainWide.java
+++ b/ssw/src/main/java/ssw/gui/frmMainWide.java
@@ -49,6 +49,7 @@ import visitors.VSetArmorTonnage;
 import visitors.ifVisitor;
 
 import javax.swing.*;
+import javax.swing.event.ListSelectionListener;
 import javax.swing.text.JTextComponent;
 import java.awt.*;
 import java.awt.datatransfer.DataFlavor;
@@ -4915,41 +4916,13 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
         lblPWRLLoc = new javax.swing.JLabel();
         pnlEquipment = new javax.swing.JPanel();
         tbpWeaponChooser = new javax.swing.JTabbedPane();
-        pnlBallistic = new javax.swing.JPanel();
-        jSeparator3 = new javax.swing.JSeparator();
-        jScrollPane8 = new javax.swing.JScrollPane();
         lstChooseBallistic = new javax.swing.JList();
-        jSeparator4 = new javax.swing.JSeparator();
-        pnlEnergy = new javax.swing.JPanel();
-        jSeparator2 = new javax.swing.JSeparator();
-        jScrollPane9 = new javax.swing.JScrollPane();
         lstChooseEnergy = new javax.swing.JList();
-        jSeparator1 = new javax.swing.JSeparator();
-        pnlMissile = new javax.swing.JPanel();
-        jSeparator5 = new javax.swing.JSeparator();
-        jScrollPane19 = new javax.swing.JScrollPane();
         lstChooseMissile = new javax.swing.JList();
-        jSeparator6 = new javax.swing.JSeparator();
-        pnlPhysical = new javax.swing.JPanel();
-        jSeparator8 = new javax.swing.JSeparator();
-        jScrollPane20 = new javax.swing.JScrollPane();
         lstChoosePhysical = new javax.swing.JList();
-        jSeparator7 = new javax.swing.JSeparator();
-        pnlEquipmentChooser = new javax.swing.JPanel();
-        jSeparator10 = new javax.swing.JSeparator();
-        jScrollPane21 = new javax.swing.JScrollPane();
         lstChooseEquipment = new javax.swing.JList();
-        jSeparator9 = new javax.swing.JSeparator();
-        pnlArtillery = new javax.swing.JPanel();
-        jSeparator18 = new javax.swing.JSeparator();
-        jScrollPane24 = new javax.swing.JScrollPane();
         lstChooseArtillery = new javax.swing.JList();
-        jSeparator19 = new javax.swing.JSeparator();
-        pnlAmmunition = new javax.swing.JPanel();
-        jSeparator11 = new javax.swing.JSeparator();
-        jScrollPane22 = new javax.swing.JScrollPane();
         lstChooseAmmunition = new javax.swing.JList();
-        jSeparator12 = new javax.swing.JSeparator();
         pnlSpecials = new javax.swing.JPanel();
         jLabel16 = new javax.swing.JLabel();
         chkUseTC = new javax.swing.JCheckBox();
@@ -7534,339 +7507,32 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
 
         pnlEquipment.setLayout(new org.netbeans.lib.awtextra.AbsoluteLayout());
 
+        //region Equipment Tab / Weapons and Equipment Lists
+        AbstractListModel placeholder = new AbstractListModel() {
+            String[] strings = { "Placeholder" };
+            public int getSize() { return strings.length; }
+            public Object getElementAt(int i) { return strings[i]; }
+        };
+
+        MouseListener mlAddEquip = new MouseAdapter() {
+            public void mouseClicked( MouseEvent e ) {
+                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
+                    btnAddEquipActionPerformed( null );
+                }
+            }
+        };
+
         tbpWeaponChooser.setTabPlacement(javax.swing.JTabbedPane.RIGHT);
         tbpWeaponChooser.setMaximumSize(new java.awt.Dimension(300, 300));
         tbpWeaponChooser.setMinimumSize(new java.awt.Dimension(300, 300));
         tbpWeaponChooser.setPreferredSize(new java.awt.Dimension(300, 300));
-
-        pnlBallistic.setLayout(new javax.swing.BoxLayout(pnlBallistic, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator3.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator3.setAlignmentX(0.0F);
-        jSeparator3.setAlignmentY(0.0F);
-        pnlBallistic.add(jSeparator3);
-
-        jScrollPane8.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane8.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane8.setMaximumSize(new java.awt.Dimension(200, 260));
-        jScrollPane8.setMinimumSize(new java.awt.Dimension(200, 260));
-        jScrollPane8.setPreferredSize(new java.awt.Dimension(200, 260));
-
-        lstChooseBallistic.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseBallistic.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseBallistic.setMaximumSize(new java.awt.Dimension(180, 10000));
-        lstChooseBallistic.setMinimumSize(new java.awt.Dimension(180, 100));
-        lstChooseBallistic.setVisibleRowCount(16);
-        lstChooseBallistic.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
-            public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
-                lstChooseBallisticValueChanged(evt);
-            }
-        });
-        MouseListener mlBallistic = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseBallistic.addMouseListener( mlBallistic );
-        lstChooseBallistic.setCellRenderer( new ssw.gui.EquipmentListRenderer( this ) );
-        jScrollPane8.setViewportView(lstChooseBallistic);
-
-        pnlBallistic.add(jScrollPane8);
-
-        jSeparator4.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator4.setAlignmentX(0.0F);
-        jSeparator4.setAlignmentY(0.0F);
-        pnlBallistic.add(jSeparator4);
-
-        tbpWeaponChooser.addTab("Ballistic", pnlBallistic);
-
-        pnlEnergy.setLayout(new javax.swing.BoxLayout(pnlEnergy, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator2.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator2.setAlignmentX(0.0F);
-        jSeparator2.setAlignmentY(0.0F);
-        pnlEnergy.add(jSeparator2);
-
-        jScrollPane9.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane9.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane9.setMaximumSize(new java.awt.Dimension(200, 260));
-        jScrollPane9.setMinimumSize(new java.awt.Dimension(200, 260));
-        jScrollPane9.setPreferredSize(new java.awt.Dimension(200, 260));
-
-        lstChooseEnergy.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseEnergy.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseEnergy.setMaximumSize(new java.awt.Dimension(180, 10000));
-        lstChooseEnergy.setMinimumSize(new java.awt.Dimension(180, 100));
-        lstChooseEnergy.setVisibleRowCount(16);
-        lstChooseEnergy.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
-            public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
-                lstChooseEnergyValueChanged(evt);
-            }
-        });
-        MouseListener mlEnergy = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseEnergy.addMouseListener( mlEnergy );
-        lstChooseEnergy.setCellRenderer( new ssw.gui.EquipmentListRenderer( this ) );
-        jScrollPane9.setViewportView(lstChooseEnergy);
-
-        pnlEnergy.add(jScrollPane9);
-
-        jSeparator1.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator1.setAlignmentX(0.0F);
-        jSeparator1.setAlignmentY(0.0F);
-        pnlEnergy.add(jSeparator1);
-
-        tbpWeaponChooser.addTab("Energy", pnlEnergy);
-
-        pnlMissile.setLayout(new javax.swing.BoxLayout(pnlMissile, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator5.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator5.setAlignmentX(0.0F);
-        jSeparator5.setAlignmentY(0.0F);
-        pnlMissile.add(jSeparator5);
-
-        jScrollPane19.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane19.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane19.setMaximumSize(new java.awt.Dimension(200, 260));
-        jScrollPane19.setMinimumSize(new java.awt.Dimension(200, 260));
-        jScrollPane19.setPreferredSize(new java.awt.Dimension(200, 260));
-
-        lstChooseMissile.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseMissile.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseMissile.setMaximumSize(new java.awt.Dimension(180, 10000));
-        lstChooseMissile.setMinimumSize(new java.awt.Dimension(180, 100));
-        lstChooseMissile.setVisibleRowCount(16);
-        lstChooseMissile.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
-            public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
-                lstChooseMissileValueChanged(evt);
-            }
-        });
-        MouseListener mlMissile = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseMissile.addMouseListener( mlMissile );
-        lstChooseMissile.setCellRenderer( new ssw.gui.EquipmentListRenderer( this ) );
-        jScrollPane19.setViewportView(lstChooseMissile);
-
-        pnlMissile.add(jScrollPane19);
-
-        jSeparator6.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator6.setAlignmentX(0.0F);
-        jSeparator6.setAlignmentY(0.0F);
-        pnlMissile.add(jSeparator6);
-
-        tbpWeaponChooser.addTab("Missile", pnlMissile);
-
-        pnlPhysical.setLayout(new javax.swing.BoxLayout(pnlPhysical, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator8.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator8.setAlignmentX(0.0F);
-        jSeparator8.setAlignmentY(0.0F);
-        pnlPhysical.add(jSeparator8);
-
-        jScrollPane20.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane20.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane20.setMaximumSize(new java.awt.Dimension(200, 260));
-        jScrollPane20.setMinimumSize(new java.awt.Dimension(200, 260));
-        jScrollPane20.setPreferredSize(new java.awt.Dimension(200, 260));
-
-        lstChoosePhysical.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChoosePhysical.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChoosePhysical.setMaximumSize(new java.awt.Dimension(180, 10000));
-        lstChoosePhysical.setMinimumSize(new java.awt.Dimension(180, 100));
-        lstChoosePhysical.setVisibleRowCount(16);
-        lstChoosePhysical.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
-            public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
-                lstChoosePhysicalValueChanged(evt);
-            }
-        });
-        MouseListener mlPhysical = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChoosePhysical.addMouseListener( mlPhysical );
-        lstChoosePhysical.setCellRenderer( new ssw.gui.EquipmentListRenderer( this ) );
-        jScrollPane20.setViewportView(lstChoosePhysical);
-
-        pnlPhysical.add(jScrollPane20);
-
-        jSeparator7.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator7.setAlignmentX(0.0F);
-        jSeparator7.setAlignmentY(0.0F);
-        pnlPhysical.add(jSeparator7);
-
-        tbpWeaponChooser.addTab("Physical", pnlPhysical);
-
-        pnlEquipmentChooser.setLayout(new javax.swing.BoxLayout(pnlEquipmentChooser, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator10.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator10.setAlignmentX(0.0F);
-        jSeparator10.setAlignmentY(0.0F);
-        pnlEquipmentChooser.add(jSeparator10);
-
-        jScrollPane21.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane21.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane21.setMaximumSize(new java.awt.Dimension(200, 260));
-        jScrollPane21.setMinimumSize(new java.awt.Dimension(200, 260));
-        jScrollPane21.setPreferredSize(new java.awt.Dimension(200, 260));
-
-        lstChooseEquipment.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseEquipment.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseEquipment.setMaximumSize(new java.awt.Dimension(180, 10000));
-        lstChooseEquipment.setMinimumSize(new java.awt.Dimension(180, 100));
-        lstChooseEquipment.setVisibleRowCount(16);
-        lstChooseEquipment.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
-            public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
-                lstChooseEquipmentValueChanged(evt);
-            }
-        });
-        MouseListener mlEquipment = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseEquipment.addMouseListener( mlEquipment );
-        lstChooseEquipment.setCellRenderer( new ssw.gui.EquipmentListRenderer( this ) );
-        jScrollPane21.setViewportView(lstChooseEquipment);
-
-        pnlEquipmentChooser.add(jScrollPane21);
-
-        jSeparator9.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator9.setAlignmentX(0.0F);
-        jSeparator9.setAlignmentY(0.0F);
-        pnlEquipmentChooser.add(jSeparator9);
-
-        tbpWeaponChooser.addTab("Equipment", pnlEquipmentChooser);
-
-        pnlArtillery.setLayout(new javax.swing.BoxLayout(pnlArtillery, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator18.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator18.setAlignmentX(0.0F);
-        jSeparator18.setAlignmentY(0.0F);
-        pnlArtillery.add(jSeparator18);
-
-        jScrollPane24.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane24.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane24.setMaximumSize(new java.awt.Dimension(200, 260));
-        jScrollPane24.setMinimumSize(new java.awt.Dimension(200, 260));
-        jScrollPane24.setPreferredSize(new java.awt.Dimension(200, 260));
-
-        lstChooseArtillery.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseArtillery.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseArtillery.setMaximumSize(new java.awt.Dimension(180, 10000));
-        lstChooseArtillery.setMinimumSize(new java.awt.Dimension(180, 100));
-        lstChooseArtillery.setVisibleRowCount(16);
-        lstChooseArtillery.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
-            public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
-                lstChooseArtilleryValueChanged(evt);
-            }
-        });
-        MouseListener mlArtillery = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseArtillery.addMouseListener( mlArtillery );
-        lstChooseArtillery.setCellRenderer( new ssw.gui.EquipmentListRenderer( this ) );
-        jScrollPane24.setViewportView(lstChooseArtillery);
-
-        pnlArtillery.add(jScrollPane24);
-
-        jSeparator19.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator19.setAlignmentX(0.0F);
-        jSeparator19.setAlignmentY(0.0F);
-        pnlArtillery.add(jSeparator19);
-
-        tbpWeaponChooser.addTab("Artillery", pnlArtillery);
-
-        pnlAmmunition.setLayout(new javax.swing.BoxLayout(pnlAmmunition, javax.swing.BoxLayout.Y_AXIS));
-
-        jSeparator11.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator11.setAlignmentX(0.0F);
-        jSeparator11.setAlignmentY(0.0F);
-        pnlAmmunition.add(jSeparator11);
-
-        jScrollPane22.setHorizontalScrollBarPolicy(javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        jScrollPane22.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-        jScrollPane22.setMaximumSize(new java.awt.Dimension(200, 260));
-        jScrollPane22.setMinimumSize(new java.awt.Dimension(200, 260));
-        jScrollPane22.setPreferredSize(new java.awt.Dimension(200, 260));
-
-        lstChooseAmmunition.setModel(new javax.swing.AbstractListModel() {
-            String[] strings = { "Placeholder" };
-            public int getSize() { return strings.length; }
-            public Object getElementAt(int i) { return strings[i]; }
-        });
-        lstChooseAmmunition.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
-        lstChooseAmmunition.setMaximumSize(new java.awt.Dimension(180, 10000));
-        lstChooseAmmunition.setMinimumSize(new java.awt.Dimension(180, 100));
-        lstChooseAmmunition.setVisibleRowCount(16);
-        lstChooseAmmunition.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
-            public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
-                lstChooseAmmunitionValueChanged(evt);
-            }
-        });
-        MouseListener mlAmmo = new MouseAdapter() {
-            public void mouseClicked( MouseEvent e ) {
-                if ( e.getClickCount() == 2 && e.getButton() == 1 ) {
-                    btnAddEquipActionPerformed( null );
-                }
-            }
-        };
-        lstChooseAmmunition.addMouseListener( mlAmmo );
-        lstChooseAmmunition.setCellRenderer( new ssw.gui.EquipmentListRenderer( this ) );
-        jScrollPane22.setViewportView(lstChooseAmmunition);
-
-        pnlAmmunition.add(jScrollPane22);
-
-        jSeparator12.setOrientation(javax.swing.SwingConstants.VERTICAL);
-        jSeparator12.setAlignmentX(0.0F);
-        jSeparator12.setAlignmentY(0.0F);
-        pnlAmmunition.add(jSeparator12);
-
-        tbpWeaponChooser.addTab("Ammunition", pnlAmmunition);
+        tbpWeaponChooser.addTab("Ballistic", EquipmentLocation(lstChooseBallistic, this::lstChooseBallisticValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Energy", EquipmentLocation(lstChooseEnergy, this::lstChooseEnergyValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Missile", EquipmentLocation(lstChooseMissile, this::lstChooseMissileValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Physical", EquipmentLocation(lstChoosePhysical, this::lstChoosePhysicalValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Equipment", EquipmentLocation(lstChooseEquipment, this::lstChooseEquipmentValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Artillery", EquipmentLocation(lstChooseArtillery, this::lstChooseArtilleryValueChanged, mlAddEquip, placeholder));
+        tbpWeaponChooser.addTab("Ammunition", EquipmentLocation(lstChooseAmmunition, this::lstChooseAmmunitionValueChanged, mlAddEquip, placeholder));
 
         pnlEquipment.add(tbpWeaponChooser, new org.netbeans.lib.awtextra.AbsoluteConstraints(10, 10, -1, -1));
 
@@ -10488,6 +10154,22 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
 
         pack();
     }// </editor-fold>//GEN-END:initComponents
+
+    private JPanel EquipmentLocation(JList list, ListSelectionListener selection, MouseListener listener, AbstractListModel display) {
+        JPanel panel = new JPanel();
+        list.setModel(display);
+        list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        list.addListSelectionListener(selection);
+        list.addMouseListener( listener );
+        list.setCellRenderer( new EquipmentListRenderer( this ) );
+        JScrollPane pane = new JScrollPane();
+        pane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+        pane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+        pane.setViewportView(list);
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.add(pane);
+        return panel;
+    }
 
     private void mnuExitActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_mnuExitActionPerformed
         if( CurMech.HasChanged() ) {
@@ -15016,25 +14698,11 @@ private void setViewToolbar(boolean Visible)
     private javax.swing.JScrollPane jScrollPane16;
     private javax.swing.JScrollPane jScrollPane17;
     private javax.swing.JScrollPane jScrollPane18;
-    private javax.swing.JScrollPane jScrollPane19;
-    private javax.swing.JScrollPane jScrollPane20;
-    private javax.swing.JScrollPane jScrollPane21;
-    private javax.swing.JScrollPane jScrollPane22;
-    private javax.swing.JScrollPane jScrollPane24;
-    private javax.swing.JScrollPane jScrollPane8;
-    private javax.swing.JScrollPane jScrollPane9;
-    private javax.swing.JSeparator jSeparator1;
-    private javax.swing.JSeparator jSeparator10;
-    private javax.swing.JSeparator jSeparator11;
-    private javax.swing.JSeparator jSeparator12;
     private javax.swing.JSeparator jSeparator13;
     private javax.swing.JSeparator jSeparator14;
     private javax.swing.JSeparator jSeparator15;
     private javax.swing.JSeparator jSeparator16;
     private javax.swing.JSeparator jSeparator17;
-    private javax.swing.JSeparator jSeparator18;
-    private javax.swing.JSeparator jSeparator19;
-    private javax.swing.JSeparator jSeparator2;
     private javax.swing.JSeparator jSeparator20;
     private javax.swing.JToolBar.Separator jSeparator21;
     private javax.swing.JToolBar.Separator jSeparator22;
@@ -15045,14 +14713,7 @@ private void setViewToolbar(boolean Visible)
     private javax.swing.JSeparator jSeparator27;
     private javax.swing.JSeparator jSeparator28;
     private javax.swing.JSeparator jSeparator29;
-    private javax.swing.JSeparator jSeparator3;
     private javax.swing.JSeparator jSeparator30;
-    private javax.swing.JSeparator jSeparator4;
-    private javax.swing.JSeparator jSeparator5;
-    private javax.swing.JSeparator jSeparator6;
-    private javax.swing.JSeparator jSeparator7;
-    private javax.swing.JSeparator jSeparator8;
-    private javax.swing.JSeparator jSeparator9;
     private javax.swing.JTextArea jTextAreaBFConversion;
     private javax.swing.JLabel lblAVInLot;
     private javax.swing.JLabel lblArmorCoverage;
@@ -15228,13 +14889,10 @@ private void setViewToolbar(boolean Visible)
     private javax.swing.JMenuItem mnuUnlock;
     private javax.swing.JCheckBoxMenuItem mnuViewToolbar;
     private javax.swing.JPanel pnlAdditionalFluff;
-    private javax.swing.JPanel pnlAmmunition;
     private javax.swing.JPanel pnlArmor;
     private javax.swing.JPanel pnlArmorInfo;
     private javax.swing.JPanel pnlArmorSetup;
-    private javax.swing.JPanel pnlArtillery;
     private javax.swing.JPanel pnlBFStats;
-    private javax.swing.JPanel pnlBallistic;
     private javax.swing.JPanel pnlBasicInformation;
     private javax.swing.JPanel pnlBasicSetup;
     private javax.swing.JPanel pnlBasicSummary;
@@ -15247,10 +14905,8 @@ private void setViewToolbar(boolean Visible)
     private javax.swing.JPanel pnlControls;
     private javax.swing.JPanel pnlDamageChart;
     private javax.swing.JPanel pnlDeployment;
-    private javax.swing.JPanel pnlEnergy;
     private javax.swing.JPanel pnlEquipInfo;
     private javax.swing.JPanel pnlEquipment;
-    private javax.swing.JPanel pnlEquipmentChooser;
     private javax.swing.JPanel pnlEquipmentToPlace;
     private javax.swing.JPanel pnlExport;
     private javax.swing.JPanel pnlFluff;
@@ -15269,13 +14925,11 @@ private void setViewToolbar(boolean Visible)
     private javax.swing.JPanel pnlLTCrits;
     private javax.swing.JPanel pnlLTRArmorBox;
     private javax.swing.JPanel pnlManufacturers;
-    private javax.swing.JPanel pnlMissile;
     private javax.swing.JPanel pnlMovement;
     private javax.swing.JPanel pnlNotables;
     private javax.swing.JPanel pnlOmniInfo;
     private javax.swing.JPanel pnlOverview;
     private javax.swing.JPanel pnlPatchworkChoosers;
-    private javax.swing.JPanel pnlPhysical;
     private javax.swing.JPanel pnlQuirks;
     private javax.swing.JPanel pnlRAArmorBox;
     private javax.swing.JPanel pnlRACrits;

--- a/ssw/src/main/java/ssw/gui/frmMainWide.java
+++ b/ssw/src/main/java/ssw/gui/frmMainWide.java
@@ -451,6 +451,7 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
         cmbEngineType.setSelectedItem( SSWConstants.DEFAULT_ENGINE );
         cmbGyroType.setSelectedItem( SSWConstants.DEFAULT_GYRO );
         cmbCockpitType.setSelectedItem( SSWConstants.DEFAULT_COCKPIT );
+        chkCommandConsole.setSelected( false );
         cmbPhysEnhance.setSelectedItem( SSWConstants.DEFAULT_ENHANCEMENT );
         cmbHeatSinkType.setSelectedItem( Prefs.get( "NewMech_Heatsinks", "Single Heat Sink" ) );
         cmbJumpJetType.setSelectedItem( SSWConstants.DEFAULT_JUMPJET );
@@ -2709,6 +2710,7 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
         cmbEngineType.setSelectedItem( SSWConstants.DEFAULT_ENGINE );
         cmbGyroType.setSelectedItem( SSWConstants.DEFAULT_GYRO );
         cmbCockpitType.setSelectedItem( SSWConstants.DEFAULT_COCKPIT );
+        chkCommandConsole.setSelected( false );
         cmbPhysEnhance.setSelectedItem( SSWConstants.DEFAULT_ENHANCEMENT );
         cmbHeatSinkType.setSelectedItem( Prefs.get( "NewMech_Heatsinks", "Single Heat Sink" ) );
         cmbJumpJetType.setSelectedItem( SSWConstants.DEFAULT_JUMPJET );
@@ -3360,8 +3362,6 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
         chkHDTurret.setEnabled( true );
         chkLTTurret.setEnabled( true );
         chkRTTurret.setEnabled( true );
-        chkOmnimech.setSelected( false );
-        chkOmnimech.setEnabled( true );
         btnLockChassis.setEnabled( false );
         spnWalkMP.setEnabled( true );
         chkYearRestrict.setEnabled( true );
@@ -14097,6 +14097,7 @@ private void cmbRulesLevelActionPerformed(java.awt.event.ActionEvent evt) {//GEN
         FixWalkMPSpinner();
         FixJJSpinnerModel();
         RefreshEquipment();
+        CheckOmnimech();
 
         // now reset the combo boxes to the closest choices we previously selected
         LoadSelections();

--- a/ssw/src/main/java/ssw/gui/frmMainWide.java
+++ b/ssw/src/main/java/ssw/gui/frmMainWide.java
@@ -474,7 +474,7 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
             public Object getValueAt( int row, int col ) {
                 Object o = CurMech.GetLoadout().GetEquipment().get( row );
                 if( col == 1 ) {
-                    return ((abPlaceable) o).GetManufacturer();
+                    return CommonTools.UnknownToEmpty( ((abPlaceable) o).GetManufacturer() );
                 } else {
                     return ((abPlaceable) o).CritName();
                 }
@@ -10707,20 +10707,20 @@ public void LoadMechIntoGUI() {
     Additional.SetText( CurMech.GetAdditional() );
     quirks = CurMech.GetQuirks();
     tblQuirks.setModel(new tbQuirks(quirks));
-    txtManufacturer.setText( CurMech.GetCompany() );
-    txtManufacturerLocation.setText( CurMech.GetLocation() );
-    txtEngineManufacturer.setText( CurMech.GetEngineManufacturer() );
-    txtArmorModel.setText( CurMech.GetArmorModel() );
-    txtChassisModel.setText( CurMech.GetChassisModel() );
+    txtManufacturer.setText( CommonTools.UnknownToEmpty( CurMech.GetCompany() ) );
+    txtManufacturerLocation.setText( CommonTools.UnknownToEmpty( CurMech.GetLocation() ) );
+    txtEngineManufacturer.setText( CommonTools.UnknownToEmpty( CurMech.GetEngineManufacturer() ) );
+    txtArmorModel.setText( CommonTools.UnknownToEmpty( CurMech.GetArmorModel() ) );
+    txtChassisModel.setText( CommonTools.UnknownToEmpty( CurMech.GetChassisModel() ) );
     if( CurMech.GetJumpJets().GetNumJJ() > 0 ) {
         txtJJModel.setEnabled( true );
     }
     txtSource.setText( CurMech.GetSource() );
 
     // omnimechs may have jump jets in one loadout and not another.
-    txtJJModel.setText( CurMech.GetJJModel() );
-    txtCommSystem.setText( CurMech.GetCommSystem() );
-    txtTNTSystem.setText( CurMech.GetTandTSystem() );
+    txtJJModel.setText( CommonTools.UnknownToEmpty( CurMech.GetJJModel() ) );
+    txtCommSystem.setText( CommonTools.UnknownToEmpty( CurMech.GetCommSystem() ) );
+    txtTNTSystem.setText( CommonTools.UnknownToEmpty( CurMech.GetTandTSystem() ) );
 
     // see if we should enable the Power Amplifier display
     if( CurMech.GetEngine().IsNuclear() ) {

--- a/sswlib/src/main/java/common/CommonTools.java
+++ b/sswlib/src/main/java/common/CommonTools.java
@@ -864,4 +864,13 @@ public class CommonTools {
         }
         return newPath;
     }
+
+    public static String UnknownToEmpty( String str ) {
+        if( str == null || str.isEmpty()
+                || str.equalsIgnoreCase( "Unknown" )
+                || str.equalsIgnoreCase( "None" ) ) {
+            return "";
+        }
+        return str;
+    }
 }

--- a/sswlib/src/main/java/components/CVArmor.java
+++ b/sswlib/src/main/java/components/CVArmor.java
@@ -1001,7 +1001,7 @@ public class CVArmor extends abPlaceable {
 
     @Override
     public double GetCost() {
-        if( Owner.GetYear() < 2450 ) {
+        if( Owner.YearWasSpecified() && Owner.GetYear() < 2450 ) {
             return GetTonnage() * Config.GetCostMult() * 2.0;
         } else {
             return GetTonnage() * Config.GetCostMult();

--- a/sswlib/src/main/java/components/CVJumpJetFactory.java
+++ b/sswlib/src/main/java/components/CVJumpJetFactory.java
@@ -94,6 +94,10 @@ public class CVJumpJetFactory {
         return CurConfig.IsUMU();
     }
 
+    public boolean IsProto() {
+        return CurConfig.IsProto();
+    }
+
     public int GetNumJJ() {
         return NumJJ;
     }

--- a/sswlib/src/main/java/components/Equipment.java
+++ b/sswlib/src/main/java/components/Equipment.java
@@ -597,16 +597,4 @@ public class Equipment extends abPlaceable implements ifEquipment {
     public String toString() {
         return CritName();
     }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (!(obj instanceof Equipment))
-            return false;
-
-        if (((Equipment) obj).ActualName() == ActualName()) {
-            return true;
-        }
-
-        return false;
-    }
 }

--- a/sswlib/src/main/java/components/Mech.java
+++ b/sswlib/src/main/java/components/Mech.java
@@ -2995,7 +2995,7 @@ public class Mech implements ifUnit, ifBattleforce {
 
         double wheat = GetBVWeaponHeat();
 
-        if( GetRulesLevel() == AvailableCode.RULES_EXPERIMENTAL ) {
+        if( GetRulesLevel() >= AvailableCode.RULES_EXPERIMENTAL ) {
             // check for coolant pods
             int NumHS = GetHeatSinks().GetNumHS(), MaxHSBonus = NumHS * 2, NumPods = 0;
             for( int i = 0; i < v.size(); i++ ) {

--- a/sswlib/src/main/java/components/VehicularGrenadeLauncher.java
+++ b/sswlib/src/main/java/components/VehicularGrenadeLauncher.java
@@ -157,6 +157,11 @@ public class VehicularGrenadeLauncher extends abPlaceable implements ifWeapon {
         return false;
     }
 
+    @Override
+    public boolean CanAllocCVBody() {
+        return false;
+    }
+
     public int NumCrits() {
         return 1;
     }

--- a/sswlib/src/main/java/filehandlers/CVReader.java
+++ b/sswlib/src/main/java/filehandlers/CVReader.java
@@ -557,7 +557,8 @@ public class CVReader {
                 } else {
                     abPlaceable p = GetEquipmentByName( eName, eType, m );
                     if( p == null ) {
-                        throw new Exception( "Could not find " + eName + " as a piece of equipment.\nThe CombatVehicle cannot be loaded." );
+                        Messages += "Could not find " + eName + " as a piece of equipment.\n";
+                        continue;
                     }
                     p.SetManufacturer( eMan );
                     if( p instanceof Equipment ) {
@@ -1024,7 +1025,8 @@ public class CVReader {
                         } else {
                             abPlaceable p = GetEquipmentByName( eName, eType, m );
                             if( p == null ) {
-                                throw new Exception( "Could not find " + eName + " as a piece of equipment.\nThe CombatVehicle cannot be loaded." );
+                                Messages += "Could not find " + eName + " as a piece of equipment.\n";
+                                continue;
                             }
                             p.SetManufacturer( eMan );
                             if( p instanceof Equipment ) {
@@ -1211,7 +1213,7 @@ public class CVReader {
                 name = FileCommon.LookupStripArc( name );
             }
         }
-        if( ! name.contains( "(CL)" ) |! name.contains( "(IS)" ) ) {
+        if( ! name.contains( "(CL)" ) && ! name.contains( "(IS)" ) ) {
             // old style save file or an item that can be used by both techbases
             // we'll need to check.
             if( m.GetTechbase() == AvailableCode.TECH_CLAN ) {

--- a/sswlib/src/main/java/filehandlers/CVReader.java
+++ b/sswlib/src/main/java/filehandlers/CVReader.java
@@ -575,7 +575,12 @@ public class CVReader {
                         ((VehicularGrenadeLauncher) p).SetArc( VGLArc );
                         ((VehicularGrenadeLauncher) p).SetAmmoType( VGLAmmo );
                     }
-                    m.GetLoadout().AddTo(p, l.Location);
+                    try {
+                        m.GetLoadout().AddTo(p, l.Location);
+                    } catch (Exception e) {
+                        Messages += e.toString();
+                        continue;
+                    }
                 }
             } else if( n.item( i ).getNodeName().equals( "armored_locations" ) ) {
                 NodeList nl = n.item( i ).getChildNodes();
@@ -1028,20 +1033,25 @@ public class CVReader {
                                 Messages += "Could not find " + eName + " as a piece of equipment.\n";
                                 continue;
                             }
-                            p.SetManufacturer( eMan );
-                            if( p instanceof Equipment ) {
-                                if( ((Equipment) p).IsVariableSize() ) {
-                                    ((Equipment) p).SetTonnage( vtons );
+                            try {
+                                p.SetManufacturer( eMan );
+                                if( p instanceof Equipment ) {
+                                    if( ((Equipment) p).IsVariableSize() ) {
+                                        ((Equipment) p).SetTonnage( vtons );
+                                    }
                                 }
+                                if( ( p instanceof Ammunition ) && lotsize > 0 ) {
+                                    ((Ammunition) p).SetLotSize( lotsize );
+                                }
+                                if( p instanceof VehicularGrenadeLauncher ) {
+                                    ((VehicularGrenadeLauncher) p).SetArc( VGLArc );
+                                    ((VehicularGrenadeLauncher) p).SetAmmoType( VGLAmmo );
+                                }
+                                m.GetLoadout().AddTo(p, l.Location);
+                            } catch( Exception e ) {
+                                Messages += e.toString();
+                                continue;
                             }
-                            if( ( p instanceof Ammunition ) && lotsize > 0 ) {
-                                ((Ammunition) p).SetLotSize( lotsize );
-                            }
-                            if( p instanceof VehicularGrenadeLauncher ) {
-                                ((VehicularGrenadeLauncher) p).SetArc( VGLArc );
-                                ((VehicularGrenadeLauncher) p).SetAmmoType( VGLAmmo );
-                            }
-                            m.GetLoadout().AddTo(p, l.Location);
                         }
                     } else if( n.item( i ).getNodeName().equals( "armored_locations" ) ) {
                         NodeList nl = n.item( i ).getChildNodes();

--- a/sswlib/src/main/java/filehandlers/CVReader.java
+++ b/sswlib/src/main/java/filehandlers/CVReader.java
@@ -319,8 +319,8 @@ public class CVReader {
         } else if( n.item( 0 ).getTextContent().equals( AvailableCode.TechBaseSTR[AvailableCode.TECH_BOTH] ) ) {
             m.SetMixed();
         }
-        m.SetCompany( FileCommon.DecodeFluff( map.getNamedItem( "manufacturer" ).getTextContent() ) );
-        m.SetLocation( FileCommon.DecodeFluff( map.getNamedItem( "location" ).getTextContent() ) );
+        m.SetCompany( FileCommon.DecodeFluff( CommonTools.UnknownToEmpty( map.getNamedItem( "manufacturer" ).getTextContent() ) ) );
+        m.SetLocation( FileCommon.DecodeFluff( CommonTools.UnknownToEmpty( map.getNamedItem( "location" ).getTextContent() ) ) );
         n = d.getElementsByTagName( "year" );
         map = n.item( 0 ).getAttributes();
         m.SetYear( Integer.parseInt( n.item( 0 ).getTextContent() ), true );
@@ -370,7 +370,7 @@ public class CVReader {
                 m.Visit( v );
             }
         }
-        m.SetChassisModel( FileCommon.DecodeFluff( map.getNamedItem( "manufacturer" ).getTextContent() ) );
+        m.SetChassisModel( FileCommon.DecodeFluff( CommonTools.UnknownToEmpty( map.getNamedItem( "manufacturer" ).getTextContent() ) ) );
         
         n = d.getElementsByTagName( "engine" );
         map = n.item( 0 ).getAttributes();
@@ -393,7 +393,7 @@ public class CVReader {
             m.Visit( v );
         }
         //m.SetEngineRating( Integer.parseInt( map.getNamedItem( "rating" ).getTextContent() ) );
-        m.SetEngineManufacturer( FileCommon.DecodeFluff( map.getNamedItem( "manufacturer" ).getTextContent() ) );
+        m.SetEngineManufacturer( FileCommon.DecodeFluff( CommonTools.UnknownToEmpty( map.getNamedItem( "manufacturer" ).getTextContent() ) ) );
 
         // base loadout
         // get the actuators first since that will complete the structural components
@@ -511,7 +511,7 @@ public class CVReader {
                 for( int j = 0; j < nl.getLength(); j++ ) {
                     if( nl.item( j ).getNodeName().equals( "name" ) ) {
                         map = nl.item( j ).getAttributes();
-                        eMan = map.getNamedItem( "manufacturer" ).getTextContent();
+                        eMan = CommonTools.UnknownToEmpty( map.getNamedItem( "manufacturer" ).getTextContent() );
                         eName = nl.item( j ).getTextContent();
                     } else if( nl.item( j ).getNodeName().equals( "type" ) ) {
                         eType = nl.item( j ).getTextContent();
@@ -631,7 +631,7 @@ public class CVReader {
         String pwtype = "";
         int pwtech = 0;
         boolean oldfile = false, clanarmor = false;
-        m.SetArmorModel( FileCommon.DecodeFluff( map.getNamedItem( "manufacturer" ).getTextContent() ) );
+        m.SetArmorModel( FileCommon.DecodeFluff( CommonTools.UnknownToEmpty( map.getNamedItem( "manufacturer" ).getTextContent() ) ) );
         if( map.getNamedItem( "techbase" ) == null ) {
             // old style save file, set the armor based on the 'CombatVehicle's techbase
             if( m.GetBaseTechbase() == AvailableCode.TECH_CLAN ) {
@@ -984,7 +984,7 @@ public class CVReader {
                         for( int j = 0; j < nl.getLength(); j++ ) {
                             if( nl.item( j ).getNodeName().equals( "name" ) ) {
                                 map = nl.item( j ).getAttributes();
-                                eMan = map.getNamedItem( "manufacturer" ).getTextContent();
+                                eMan = CommonTools.UnknownToEmpty( map.getNamedItem( "manufacturer" ).getTextContent() );
                                 eName = nl.item( j ).getTextContent();
                             } else if( nl.item( j ).getNodeName().equals( "type" ) ) {
                                 eType = nl.item( j ).getTextContent();
@@ -1166,23 +1166,11 @@ public class CVReader {
             m.SetQuirks(quirks);
         }
         n = d.getElementsByTagName( "jumpjet_model" );
-        if( n.item( 0 ).getTextContent() == null ) {
-            m.SetJJModel( "" );
-        } else {
-            m.SetJJModel( FileCommon.DecodeFluff( n.item( 0 ).getTextContent() ) );
-        }
+        m.SetJJModel( FileCommon.DecodeFluff( CommonTools.UnknownToEmpty( n.item( 0 ).getTextContent() ) ) );
         n = d.getElementsByTagName( "commsystem" );
-        if( n.item( 0 ).getTextContent() == null ) {
-            m.SetCommSystem( "" );
-        } else {
-            m.SetCommSystem( FileCommon.DecodeFluff( n.item( 0 ).getTextContent() ) );
-        }
+        m.SetCommSystem( FileCommon.DecodeFluff( CommonTools.UnknownToEmpty( n.item( 0 ).getTextContent() ) ) );
         n = d.getElementsByTagName( "tandtsystem" );
-        if( n.item( 0 ).getTextContent() == null ) {
-            m.SetTandTSystem( "" );
-        } else {
-            m.SetTandTSystem( FileCommon.DecodeFluff( n.item( 0 ).getTextContent() ) );
-        }
+        m.SetTandTSystem( FileCommon.DecodeFluff( CommonTools.UnknownToEmpty( n.item( 0 ).getTextContent() ) ) );
 
         // all done, return the CombatVehicle
         m.SetChanged( false );

--- a/sswlib/src/main/java/filehandlers/CVTXTWriter.java
+++ b/sswlib/src/main/java/filehandlers/CVTXTWriter.java
@@ -58,6 +58,7 @@ public class CVTXTWriter {
     }
 
     public CVTXTWriter( ArrayList<Force> forces ) {
+        this();
         this.forces = forces;
     }
 
@@ -143,8 +144,8 @@ public class CVTXTWriter {
             retval += "Construction Options: Fractional Accounting" + NL + NL;
         }
 
-        //retval += "Chassis: " + CurVee.GetChassisModel() + " " + CurVee.GetIntStruc().CritName() + NL;
-        retval += "Power Plant: " + CurVee.GetEngineManufacturer() + " " + CurVee.GetEngine().GetRating() + " " + CurVee.GetEngine() + NL;
+        //retval += "Chassis: " + ( IsUnknown( CurVee.GetChassisModel() ) ? "" : CurVee.GetChassisModel() + " " ) + " " + CurVee.GetIntStruc().CritName() + NL;
+        retval += "Power Plant: " + ( IsUnknown( CurVee.GetEngineManufacturer() ) ? "" : CurVee.GetEngineManufacturer() + " " ) + " " + CurVee.GetEngine().GetRating() + " " + CurVee.GetEngine() + NL;
         //retval += "Cruise Speed: " + CommonTools.FormatSpeed( CurVee.GetAdjustedCruiseMP(false, true) * 10.8 ) + " km/h" + NL;
         //retval += "Flanking Speed: " + CommonTools.FormatSpeed( CurVee.GetAdjustedFlankMP(false, true) * 10.8 ) + " km/h" + NL;
         if( CurVee.GetAdjustedCruiseMP( false, true ) != CurVee.getCruiseMP() ) {
@@ -158,15 +159,23 @@ public class CVTXTWriter {
             retval += "Maximum Speed: " + CommonTools.FormatSpeed( CurVee.getFlankMP() * 10.8 ) + " km/h" + NL;
         }
         if ( CurVee.GetJumpJets().GetNumJJ() > 0 ) {
-            retval += "Jump Jets: " + CurVee.GetJJModel() + NL;
+            String jjModel = CurVee.GetJJModel();
+            jjModel = ( IsUnknown( jjModel ) ? "" : jjModel + " " ) + GetJumpJetTypeLine();
+            retval += "Jump Jets: " + jjModel + NL;
             retval += "    Jump Capacity: " + GetJumpJetDistanceLine() + NL;
         }
-        retval += "Armor: " + CurVee.GetArmorModel() + " " + CurVee.GetArmor().CritName() + NL;
+        String armorModel = CurVee.GetArmorModel();
+        retval += "Armor: " + ( IsUnknown( armorModel ) ? "" : armorModel + " " ) + " " + CurVee.GetArmor().CritName() + NL;
         retval += "Armament:" + NL;
         retval += GetArmament();
-        retval += "Manufacturer: " + CurVee.GetCompany() + NL;
-        retval += "    Primary Factory: " + CurVee.GetLocation() + NL;
-        retval += BuildComputerBlock() + NL + NL;
+        if ( ! IsUnknown( CurVee.GetCompany() ) ) {
+            retval += "Manufacturer: " + CurVee.GetCompany() + NL;
+            if ( ! IsUnknown( CurVee.GetLocation() ) ) {
+                retval += "    Primary Factory: " + CurVee.GetLocation() + NL;
+            }
+        }
+        retval += BuildComputerBlock();
+        retval += NL;
 //        retval += "================================================================================" + NL;
         if( ! CurVee.getOverview().equals( "" ) ) {
             retval += "Overview:" + NL;
@@ -782,7 +791,7 @@ public class CVTXTWriter {
         retval += NL;
 */
         // start targeting and tracking system line
-        retval += "Targeting and Tracking System: " + CurVee.GetTandTSystem();
+        retval += "Targeting and Tracking System: " + CurVee.GetTandTSystem() + NL;
 /*        if( ! ( BAP instanceof EmptyItem ) ) {
             if( CurVee.UsingTC() ) {
                 retval += NL + "    w/ " + BAP.GetManufacturer() + " " + BAP.GetCritName() + NL + "    and " + CurVee.GetTC().GetCritName();
@@ -940,6 +949,9 @@ public class CVTXTWriter {
                     retval = "Standard";
                 }
             }
+        }
+        if( CurVee.GetJumpJets().IsProto() ) {
+            retval += " (Prototype)";
         }
         return retval;
     }
@@ -1112,5 +1124,9 @@ public class CVTXTWriter {
             return "\"" + data + "\",";
         else
             return data + ",";
+    }
+
+    private boolean IsUnknown( String str ) {
+        return str.isEmpty() || str.equalsIgnoreCase( "Unknown" ) || str.equalsIgnoreCase( "None" );
     }
 }

--- a/sswlib/src/main/java/filehandlers/CVWriter.java
+++ b/sswlib/src/main/java/filehandlers/CVWriter.java
@@ -32,6 +32,7 @@ import java.io.BufferedWriter;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import common.*;
 import battleforce.BattleForceStats;
@@ -51,16 +52,24 @@ public class CVWriter {
     }
 
     public void WriteXML( String filename ) throws IOException {
-        //BufferedWriter FR = new BufferedWriter( new FileWriter( filename ) );
-        BufferedWriter FR = new BufferedWriter( new OutputStreamWriter( new FileOutputStream( filename ), "UTF-8" ) );
+        StringWriter stringWriter = new StringWriter();
+        BufferedWriter FR = new BufferedWriter( stringWriter );
 
         // beginning of an XML file:
         FR.write( "<?xml version=\"1.0\" encoding =\"UTF-8\"?>" );
         FR.newLine();
 
-        WriteXML(FR);
+        try {
+            WriteXML(FR);
+        } catch ( RuntimeException e ) {
+            throw new IOException( e );
+        }
 
         FR.close();
+
+        try( OutputStreamWriter writer = new OutputStreamWriter( new FileOutputStream( filename ), "UTF-8" ) ) {
+            writer.write(stringWriter.toString());
+        }
     }
 
     public void WriteXML( BufferedWriter FR ) throws IOException {

--- a/sswlib/src/main/java/filehandlers/CVWriter.java
+++ b/sswlib/src/main/java/filehandlers/CVWriter.java
@@ -275,7 +275,7 @@ public class CVWriter {
                     FR.newLine();
                 }
                 FR.write( GetEquipmentLines( tab + tab ) );
-                if( CurUnit.GetRulesLevel() == AvailableCode.RULES_EXPERIMENTAL ) {
+                if( CurUnit.GetRulesLevel() >= AvailableCode.RULES_EXPERIMENTAL ) {
                     // check for armored components
                     FR.write( GetArmoredLocations( tab + tab ) );
                 }

--- a/sswlib/src/main/java/filehandlers/MechReader.java
+++ b/sswlib/src/main/java/filehandlers/MechReader.java
@@ -823,84 +823,89 @@ public class MechReader {
                         Messages += "Could not find " + eName + " as a piece of equipment.\n";
                         continue;
                     }
-                    p.SetManufacturer( eMan );
-                    if( p instanceof Equipment ) {
-                        if( ((Equipment) p).IsVariableSize() ) {
-                            ((Equipment) p).SetTonnage( vtons );
-                        }
-                    }
-                    if( ( p instanceof Ammunition ) && lotsize > 0 ) {
-                        ((Ammunition) p).SetLotSize( lotsize );
-                    }
-                    if( p.CanSplit() ) {
-                        if( splitLoc.size() > 0 ) {
-                            m.GetLoadout().AddToQueue( p );
-                            // have to do a hack here because we're using non-standard
-                            // allocation methods.
-                            m.GetLoadout().RemoveFromQueue( p );
-                            for( int j = 0; j < splitLoc.size(); j++ ) {
-                                LocationIndex li = (LocationIndex) splitLoc.get( j );
-                                m.GetLoadout().AddTo( m.GetLoadout().GetCrits( li.Location ), p, li.Index, li.Number );
+                    try {
+                        p.SetManufacturer( eMan );
+                        if( p instanceof Equipment ) {
+                            if( ((Equipment) p).IsVariableSize() ) {
+                                ((Equipment) p).SetTonnage( vtons );
                             }
-                        } else {
-                            m.GetLoadout().AddToQueue( p );
-                            m.GetLoadout().AddTo( p, l.Location, l.Index );
                         }
-                    } else {
-                        if( p instanceof Talons ) {
-                            p.Place( m.GetLoadout() );
-                        } else {
-                            m.GetLoadout().AddToQueue( p );
-                            m.GetLoadout().AddTo( p, l.Location, l.Index );
+                        if( ( p instanceof Ammunition ) && lotsize > 0 ) {
+                            ((Ammunition) p).SetLotSize( lotsize );
                         }
-                        if( turreted ) {
-                            if( l.Location == LocationIndex.MECH_LOC_HD ) {
-                                if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
-                                    if( ! m.GetLoadout().HasHDTurret() ) {
-                                        throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
-                                    }
-                                    if( p instanceof MGArray ) {
-                                        ((MGArray) p).AddToTurret( m.GetLoadout().GetHDTurret() );
-                                    } else {
-                                        ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetHDTurret() );
-                                    }
-                                } else {
-                                    throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
-                                }
-                            } else if( l.Location == LocationIndex.MECH_LOC_LT ) {
-                                if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
-                                    if( ! m.GetLoadout().HasLTTurret() ) {
-                                        throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
-                                    }
-                                    if( p instanceof MGArray ) {
-                                        ((MGArray) p).AddToTurret( m.GetLoadout().GetLTTurret() );
-                                    } else {
-                                        ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetLTTurret() );
-                                    }
-                                } else {
-                                    throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
-                                }
-                            } else if( l.Location == LocationIndex.MECH_LOC_RT ) {
-                                if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
-                                    if( ! m.GetLoadout().HasRTTurret() ) {
-                                        throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
-                                    }
-                                    if( p instanceof MGArray ) {
-                                        ((MGArray) p).AddToTurret( m.GetLoadout().GetRTTurret() );
-                                    } else {
-                                        ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetRTTurret() );
-                                    }
-                                } else {
-                                    throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
+                        if( p.CanSplit() ) {
+                            if( splitLoc.size() > 0 ) {
+                                m.GetLoadout().AddToQueue( p );
+                                // have to do a hack here because we're using non-standard
+                                // allocation methods.
+                                m.GetLoadout().RemoveFromQueue( p );
+                                for( int j = 0; j < splitLoc.size(); j++ ) {
+                                    LocationIndex li = (LocationIndex) splitLoc.get( j );
+                                    m.GetLoadout().AddTo( m.GetLoadout().GetCrits( li.Location ), p, li.Index, li.Number );
                                 }
                             } else {
-                                throw new Exception( "A weapon was specified as turreted, but it is\nnot in a location that can have a turret.\nThe 'Mech cannot be loaded." );
+                                m.GetLoadout().AddToQueue( p );
+                                m.GetLoadout().AddTo( p, l.Location, l.Index );
+                            }
+                        } else {
+                            if( p instanceof Talons ) {
+                                p.Place( m.GetLoadout() );
+                            } else {
+                                m.GetLoadout().AddToQueue( p );
+                                m.GetLoadout().AddTo( p, l.Location, l.Index );
+                            }
+                            if( turreted ) {
+                                if( l.Location == LocationIndex.MECH_LOC_HD ) {
+                                    if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
+                                        if( ! m.GetLoadout().HasHDTurret() ) {
+                                            throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
+                                        }
+                                        if( p instanceof MGArray ) {
+                                            ((MGArray) p).AddToTurret( m.GetLoadout().GetHDTurret() );
+                                        } else {
+                                            ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetHDTurret() );
+                                        }
+                                    } else {
+                                        throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
+                                    }
+                                } else if( l.Location == LocationIndex.MECH_LOC_LT ) {
+                                    if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
+                                        if( ! m.GetLoadout().HasLTTurret() ) {
+                                            throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
+                                        }
+                                        if( p instanceof MGArray ) {
+                                            ((MGArray) p).AddToTurret( m.GetLoadout().GetLTTurret() );
+                                        } else {
+                                            ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetLTTurret() );
+                                        }
+                                    } else {
+                                        throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
+                                    }
+                                } else if( l.Location == LocationIndex.MECH_LOC_RT ) {
+                                    if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
+                                        if( ! m.GetLoadout().HasRTTurret() ) {
+                                            throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
+                                        }
+                                        if( p instanceof MGArray ) {
+                                            ((MGArray) p).AddToTurret( m.GetLoadout().GetRTTurret() );
+                                        } else {
+                                            ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetRTTurret() );
+                                        }
+                                    } else {
+                                        throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
+                                    }
+                                } else {
+                                    throw new Exception( "A weapon was specified as turreted, but it is\nnot in a location that can have a turret.\nThe 'Mech cannot be loaded." );
+                                }
                             }
                         }
-                    }
-                    if( p instanceof VehicularGrenadeLauncher ) {
-                        ((VehicularGrenadeLauncher) p).SetArc( VGLArc );
-                        ((VehicularGrenadeLauncher) p).SetAmmoType( VGLAmmo );
+                        if( p instanceof VehicularGrenadeLauncher ) {
+                            ((VehicularGrenadeLauncher) p).SetArc( VGLArc );
+                            ((VehicularGrenadeLauncher) p).SetAmmoType( VGLAmmo );
+                        }
+                    } catch( Exception e ) {
+                        Messages += e.toString();
+                        continue;
                     }
                 }
             } else if( n.item( i ).getNodeName().equals( "armored_locations" ) ) {
@@ -1589,84 +1594,89 @@ public class MechReader {
                                 Messages += "Could not find " + eName + " as a piece of equipment.\n";
                                 continue;
                             }
-                            p.SetManufacturer( eMan );
-                            if( p instanceof Equipment ) {
-                                if( ((Equipment) p).IsVariableSize() ) {
-                                    ((Equipment) p).SetTonnage( vtons );
+                            try {
+                                p.SetManufacturer( eMan );
+                                if( p instanceof Equipment ) {
+                                    if( ((Equipment) p).IsVariableSize() ) {
+                                        ((Equipment) p).SetTonnage( vtons );
+                                    }
                                 }
-                            }
-                            if( ( p instanceof Ammunition ) && lotsize > 0 ) {
-                                ((Ammunition) p).SetLotSize( lotsize );
-                            }
-                            if( p.CanSplit() ) {
-                                if( splitLoc.size() > 0 ) {
-                                    m.GetLoadout().AddToQueue( p );
-                                    // have to do a hack here because we're using non-standard
-                                    // allocation methods.
-                                    m.GetLoadout().RemoveFromQueue( p );
-                                    for( int j = 0; j < splitLoc.size(); j++ ) {
-                                        LocationIndex li = (LocationIndex) splitLoc.get( j );
-                                        m.GetLoadout().AddTo( m.GetLoadout().GetCrits( li.Location ), p, li.Index, li.Number );
+                                if( ( p instanceof Ammunition ) && lotsize > 0 ) {
+                                    ((Ammunition) p).SetLotSize( lotsize );
+                                }
+                                if( p.CanSplit() ) {
+                                    if( splitLoc.size() > 0 ) {
+                                        m.GetLoadout().AddToQueue( p );
+                                        // have to do a hack here because we're using non-standard
+                                        // allocation methods.
+                                        m.GetLoadout().RemoveFromQueue( p );
+                                        for( int j = 0; j < splitLoc.size(); j++ ) {
+                                            LocationIndex li = (LocationIndex) splitLoc.get( j );
+                                            m.GetLoadout().AddTo( m.GetLoadout().GetCrits( li.Location ), p, li.Index, li.Number );
+                                        }
+                                    } else {
+                                        m.GetLoadout().AddToQueue( p );
+                                        m.GetLoadout().AddTo( p, l.Location, l.Index );
                                     }
                                 } else {
-                                    m.GetLoadout().AddToQueue( p );
-                                    m.GetLoadout().AddTo( p, l.Location, l.Index );
-                                }
-                            } else {
-                                if( p instanceof Talons ) {
-                                    if( ! p.Place( m.GetLoadout() ) ) {
-                                        throw new Exception( "Talons cannot be added to the 'Mech because there is no available space." );
+                                    if( p instanceof Talons ) {
+                                        if( ! p.Place( m.GetLoadout() ) ) {
+                                            throw new Exception( "Talons cannot be added to the 'Mech because there is no available space." );
+                                        }
+                                    } else {
+                                        m.GetLoadout().AddToQueue( p );
+                                        m.GetLoadout().AddTo( p, l.Location, l.Index );
                                     }
-                                } else {
-                                    m.GetLoadout().AddToQueue( p );
-                                    m.GetLoadout().AddTo( p, l.Location, l.Index );
-                                }
-                                if( turreted ) {
-                                    if( l.Location == LocationIndex.MECH_LOC_HD ) {
-                                        if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
-                                            if( ! m.GetLoadout().HasHDTurret() ) {
-                                                throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
-                                            }
-                                            if( p instanceof MGArray ) {
-                                                ((MGArray) p).AddToTurret( m.GetLoadout().GetHDTurret() );
+                                    if( turreted ) {
+                                        if( l.Location == LocationIndex.MECH_LOC_HD ) {
+                                            if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
+                                                if( ! m.GetLoadout().HasHDTurret() ) {
+                                                    throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
+                                                }
+                                                if( p instanceof MGArray ) {
+                                                    ((MGArray) p).AddToTurret( m.GetLoadout().GetHDTurret() );
+                                                } else {
+                                                    ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetHDTurret() );
+                                                }
                                             } else {
-                                                ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetHDTurret() );
+                                                throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
                                             }
-                                        } else {
-                                            throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
-                                        }
-                                    } else if( l.Location == LocationIndex.MECH_LOC_LT ) {
-                                        if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
-                                            if( ! m.GetLoadout().HasLTTurret() ) {
-                                                throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
-                                            }
-                                            if( p instanceof MGArray ) {
-                                                ((MGArray) p).AddToTurret( m.GetLoadout().GetLTTurret() );
+                                        } else if( l.Location == LocationIndex.MECH_LOC_LT ) {
+                                            if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
+                                                if( ! m.GetLoadout().HasLTTurret() ) {
+                                                    throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
+                                                }
+                                                if( p instanceof MGArray ) {
+                                                    ((MGArray) p).AddToTurret( m.GetLoadout().GetLTTurret() );
+                                                } else {
+                                                    ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetLTTurret() );
+                                                }
                                             } else {
-                                                ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetLTTurret() );
+                                                throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
                                             }
-                                        } else {
-                                            throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
-                                        }
-                                    } else if( l.Location == LocationIndex.MECH_LOC_RT ) {
-                                        if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
-                                            if( ! m.GetLoadout().HasRTTurret() ) {
-                                                throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
-                                            }
-                                            if( p instanceof MGArray ) {
-                                                ((MGArray) p).AddToTurret( m.GetLoadout().GetRTTurret() );
+                                        } else if( l.Location == LocationIndex.MECH_LOC_RT ) {
+                                            if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
+                                                if( ! m.GetLoadout().HasRTTurret() ) {
+                                                    throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
+                                                }
+                                                if( p instanceof MGArray ) {
+                                                    ((MGArray) p).AddToTurret( m.GetLoadout().GetRTTurret() );
+                                                } else {
+                                                    ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetRTTurret() );
+                                                }
                                             } else {
-                                                ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetRTTurret() );
+                                                throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
                                             }
-                                        } else {
-                                            throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
                                         }
                                     }
                                 }
-                            }
-                            if( p instanceof VehicularGrenadeLauncher ) {
-                                ((VehicularGrenadeLauncher) p).SetArc( VGLArc );
-                                ((VehicularGrenadeLauncher) p).SetAmmoType( VGLAmmo );
+                                if( p instanceof VehicularGrenadeLauncher ) {
+                                    ((VehicularGrenadeLauncher) p).SetArc( VGLArc );
+                                    ((VehicularGrenadeLauncher) p).SetAmmoType( VGLAmmo );
+                                }
+                            } catch( Exception e ) {
+                                Messages += e.toString();
+                                continue;
                             }
                         }
                     } else if( n.item( i ).getNodeName().equals( "armored_locations" ) ) {

--- a/sswlib/src/main/java/filehandlers/MechReader.java
+++ b/sswlib/src/main/java/filehandlers/MechReader.java
@@ -820,7 +820,8 @@ public class MechReader {
                     if (eName.equals("Drone Operating System")) {m.AddDroneOS();}
                     
                     if( p == null ) {
-                        throw new Exception( "Could not find " + eName + " as a piece of equipment.\nThe Mech cannot be loaded." );
+                        Messages += "Could not find " + eName + " as a piece of equipment.\n";
+                        continue;
                     }
                     p.SetManufacturer( eMan );
                     if( p instanceof Equipment ) {
@@ -1585,7 +1586,8 @@ public class MechReader {
                             }
                             abPlaceable p = GetEquipmentByName( eName, eType, m );
                             if( p == null ) {
-                                throw new Exception( "Could not find " + eName + " as a piece of equipment.\nThe Mech cannot be loaded." );
+                                Messages += "Could not find " + eName + " as a piece of equipment.\n";
+                                continue;
                             }
                             p.SetManufacturer( eMan );
                             if( p instanceof Equipment ) {
@@ -1856,7 +1858,7 @@ public class MechReader {
                 name = FileCommon.LookupStripArc( name );
             }
         }
-        if( ! name.contains( "(CL)" ) |! name.contains( "(IS)" ) ) {
+        if( ! name.contains( "(CL)" ) && ! name.contains( "(IS)" ) ) {
             // old style save file or an item that can be used by both techbases
             // we'll need to check.
             if( m.GetTechbase() == AvailableCode.TECH_CLAN ) {

--- a/sswlib/src/main/java/filehandlers/MechReader.java
+++ b/sswlib/src/main/java/filehandlers/MechReader.java
@@ -420,8 +420,8 @@ public class MechReader {
         } else if( n.item( 0 ).getTextContent().equals( AvailableCode.TechBaseSTR[AvailableCode.TECH_BOTH] ) ) {
             m.SetMixed();
         }
-        m.SetCompany( FileCommon.DecodeFluff( map.getNamedItem( "manufacturer" ).getTextContent() ) );
-        m.SetLocation( FileCommon.DecodeFluff( map.getNamedItem( "location" ).getTextContent() ) );
+        m.SetCompany( FileCommon.DecodeFluff( CommonTools.UnknownToEmpty( map.getNamedItem( "manufacturer" ).getTextContent() ) ) );
+        m.SetLocation( FileCommon.DecodeFluff( CommonTools.UnknownToEmpty( map.getNamedItem( "location" ).getTextContent() ) ) );
         n = d.getElementsByTagName( "year" );
         map = n.item( 0 ).getAttributes();
         m.SetYear( Integer.parseInt( n.item( 0 ).getTextContent() ), true );
@@ -479,7 +479,7 @@ public class MechReader {
             m.Visit( v );
         }
         m.SetEngineRating( Integer.parseInt( map.getNamedItem( "rating" ).getTextContent() ) );
-        m.SetEngineManufacturer( FileCommon.DecodeFluff( map.getNamedItem( "manufacturer" ).getTextContent() ) );
+        m.SetEngineManufacturer( FileCommon.DecodeFluff( CommonTools.UnknownToEmpty( map.getNamedItem( "manufacturer" ).getTextContent() ) ) );
 
         n = d.getElementsByTagName( "cockpit" );
         v = m.Lookup( n.item( 0 ).getTextContent() );
@@ -557,7 +557,7 @@ public class MechReader {
                 m.Visit( v );
             }
         }
-        m.SetChassisModel( FileCommon.DecodeFluff( map.getNamedItem( "manufacturer" ).getTextContent() ) );
+        m.SetChassisModel( FileCommon.DecodeFluff( CommonTools.UnknownToEmpty( map.getNamedItem( "manufacturer" ).getTextContent() ) ) );
 
         // base loadout
         // get the actuators first since that will complete the structural components
@@ -730,7 +730,7 @@ public class MechReader {
                 for( int j = 0; j < nl.getLength(); j++ ) {
                     if( nl.item( j ).getNodeName().equals( "name" ) ) {
                         map = nl.item( j ).getAttributes();
-                        eMan = map.getNamedItem( "manufacturer" ).getTextContent();
+                        eMan = CommonTools.UnknownToEmpty( map.getNamedItem( "manufacturer" ).getTextContent() );
                         eName = nl.item( j ).getTextContent();
                     } else if( nl.item( j ).getNodeName().equals( "type" ) ) {
                         eType = nl.item( j ).getTextContent();
@@ -1043,7 +1043,7 @@ public class MechReader {
         String pwtype = "";
         int pwtech = 0;
         boolean oldfile = false, clanarmor = false;
-        m.SetArmorModel( FileCommon.DecodeFluff( map.getNamedItem( "manufacturer" ).getTextContent() ) );
+        m.SetArmorModel( FileCommon.DecodeFluff( CommonTools.UnknownToEmpty( map.getNamedItem( "manufacturer" ).getTextContent() ) ) );
         if( map.getNamedItem( "techbase" ) == null ) {
             // old style save file, set the armor based on the 'Mech's techbase
             if( m.GetBaseTechbase() == AvailableCode.TECH_CLAN ) {
@@ -1504,7 +1504,7 @@ public class MechReader {
                         for( int j = 0; j < nl.getLength(); j++ ) {
                             if( nl.item( j ).getNodeName().equals( "name" ) ) {
                                 map = nl.item( j ).getAttributes();
-                                eMan = map.getNamedItem( "manufacturer" ).getTextContent();
+                                eMan = CommonTools.UnknownToEmpty( map.getNamedItem( "manufacturer" ).getTextContent() );
                                 eName = nl.item( j ).getTextContent();
                             } else if( nl.item( j ).getNodeName().equals( "type" ) ) {
                                 eType = nl.item( j ).getTextContent();
@@ -1811,23 +1811,11 @@ public class MechReader {
             m.SetQuirks(quirks);
         }
         n = d.getElementsByTagName( "jumpjet_model" );
-        if( n.item( 0 ).getTextContent() == null ) {
-            m.SetJJModel( "" );
-        } else {
-            m.SetJJModel( FileCommon.DecodeFluff( n.item( 0 ).getTextContent() ) );
-        }
+        m.SetJJModel( FileCommon.DecodeFluff( CommonTools.UnknownToEmpty( n.item( 0 ).getTextContent() ) ) );
         n = d.getElementsByTagName( "commsystem" );
-        if( n.item( 0 ).getTextContent() == null ) {
-            m.SetCommSystem( "" );
-        } else {
-            m.SetCommSystem( FileCommon.DecodeFluff( n.item( 0 ).getTextContent() ) );
-        }
+        m.SetCommSystem( FileCommon.DecodeFluff( CommonTools.UnknownToEmpty( n.item( 0 ).getTextContent() ) ) );
         n = d.getElementsByTagName( "tandtsystem" );
-        if( n.item( 0 ).getTextContent() == null ) {
-            m.SetTandTSystem( "" );
-        } else {
-            m.SetTandTSystem( FileCommon.DecodeFluff( n.item( 0 ).getTextContent() ) );
-        }
+        m.SetTandTSystem( FileCommon.DecodeFluff( CommonTools.UnknownToEmpty( n.item( 0 ).getTextContent() ) ) );
 
         // all done, return the mech
         m.SetChanged( false );

--- a/sswlib/src/main/java/filehandlers/MechWriter.java
+++ b/sswlib/src/main/java/filehandlers/MechWriter.java
@@ -32,6 +32,7 @@ import java.io.BufferedWriter;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import common.*;
 import battleforce.BattleForceStats;
@@ -51,16 +52,24 @@ public class MechWriter {
     }
 
     public void WriteXML( String filename ) throws IOException {
-        //BufferedWriter FR = new BufferedWriter( new FileWriter( filename ) );
-        BufferedWriter FR = new BufferedWriter( new OutputStreamWriter( new FileOutputStream( filename ), "UTF-8" ) );
+        StringWriter stringWriter = new StringWriter();
+        BufferedWriter FR = new BufferedWriter( stringWriter );
 
         // beginning of an XML file:
         FR.write( "<?xml version=\"1.0\" encoding =\"UTF-8\"?>" );
         FR.newLine();
 
-        WriteXML(FR);
+        try {
+            WriteXML(FR);
+        } catch ( RuntimeException e ) {
+            throw new IOException( e );
+        }
 
         FR.close();
+
+        try( OutputStreamWriter writer = new OutputStreamWriter( new FileOutputStream( filename ), "UTF-8" ) ) {
+            writer.write(stringWriter.toString());
+        }
     }
 
     public void WriteXML( BufferedWriter FR ) throws IOException {

--- a/sswlib/src/main/java/filehandlers/MechWriter.java
+++ b/sswlib/src/main/java/filehandlers/MechWriter.java
@@ -394,7 +394,7 @@ public class MechWriter {
             FR.newLine();
         }
         FR.write( GetEquipmentLines( tab + tab ) );
-        if( CurMech.GetRulesLevel() == AvailableCode.RULES_EXPERIMENTAL ) {
+        if( CurMech.GetRulesLevel() >= AvailableCode.RULES_EXPERIMENTAL ) {
             // check for armored components
             FR.write( GetArmoredLocations( tab + tab ) );
         }
@@ -478,7 +478,7 @@ public class MechWriter {
                     FR.newLine();
                 }
                 FR.write( GetEquipmentLines( tab + tab ) );
-                if( CurMech.GetRulesLevel() == AvailableCode.RULES_EXPERIMENTAL ) {
+                if( CurMech.GetRulesLevel() >= AvailableCode.RULES_EXPERIMENTAL ) {
                     // check for armored components
                     FR.write( GetArmoredLocations( tab + tab ) );
                 }

--- a/sswlib/src/main/java/filehandlers/TXTWriter.java
+++ b/sswlib/src/main/java/filehandlers/TXTWriter.java
@@ -34,14 +34,12 @@ import common.*;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.Enumeration;
 import java.util.ArrayList;
 import battleforce.BattleForceStats;
 import battleforce.BattleForceTools;
 import components.*;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
-import java.util.ArrayList;
 import java.util.Iterator;
 import list.*;
 import utilities.CostBVBreakdown;
@@ -60,6 +58,7 @@ public class TXTWriter {
     }
 
     public TXTWriter( ArrayList<Force> forces ) {
+        this();
         this.forces = forces;
     }
 
@@ -170,8 +169,8 @@ public class TXTWriter {
             retval += "Construction Options: Fractional Accounting" + NL + NL;
         }
 
-        retval += "Chassis: " + CurMech.GetChassisModel() + " " + CurMech.GetIntStruc().CritName() + NL;
-        retval += "Power Plant: " + CurMech.GetEngineManufacturer() + " " + CurMech.GetEngine().GetRating() + " " + CurMech.GetEngine() + NL;
+        retval += "Chassis: " + ( IsUnknown( CurMech.GetChassisModel() ) ? "" : CurMech.GetChassisModel() + " " ) + CurMech.GetIntStruc().CritName() + NL;
+        retval += "Power Plant: " + ( IsUnknown( CurMech.GetEngineManufacturer() ) ? "" : CurMech.GetEngineManufacturer() + " " ) + CurMech.GetEngine().GetRating() + " " + CurMech.GetEngine() + NL;
         if( CurMech.GetAdjustedWalkingMP( false, true ) != CurMech.GetWalkingMP() ) {
             retval += "Walking Speed: " + CommonTools.FormatSpeed( CurMech.GetWalkingMP() * 10.8 ) + " km/h (" + CommonTools.FormatSpeed( CurMech.GetAdjustedWalkingMP( false, true ) * 10.8 ) + " km/h)" + NL;
         } else {
@@ -182,18 +181,28 @@ public class TXTWriter {
         } else {
             retval += "Maximum Speed: " + CommonTools.FormatSpeed( CurMech.GetRunningMP() * 10.8 ) + " km/h" + NL;
         }
-        retval += "Jump Jets: " + CurMech.GetJJModel() + NL;
+        String jjModel = CurMech.GetJJModel();
+        if ( CurMech.GetJumpJets().GetNumJJ() > 0 ) {
+            jjModel = ( IsUnknown( jjModel ) ? "" : jjModel + " " ) + GetJumpJetTypeLine();
+        }
+        retval += "Jump Jets: " + jjModel + NL;
         retval += "    Jump Capacity: " + GetJumpJetDistanceLine() + NL;
+        String armorModel = CurMech.GetArmorModel();
         if( CurMech.HasCTCase()|| CurMech.HasLTCase() || CurMech.HasRTCase() ) {
-            retval += "Armor: " + CurMech.GetArmorModel() + " " + CurMech.GetArmor().CritName() + " w/ CASE" + NL;
+            retval += "Armor: " + ( IsUnknown( armorModel ) ? "" : armorModel + " " ) + CurMech.GetArmor().CritName() + " w/ CASE" + NL;
         } else {
-            retval += "Armor: " + CurMech.GetArmorModel() + " " + CurMech.GetArmor().CritName() + NL;
+            retval += "Armor: " + ( IsUnknown( armorModel ) ? "" : armorModel + " " ) + CurMech.GetArmor().CritName() + NL;
         }
         retval += "Armament:" + NL;
         retval += GetArmament();
-        retval += "Manufacturer: " + CurMech.GetCompany() + NL;
-        retval += "    Primary Factory: " + CurMech.GetLocation() + NL;
-        retval += BuildComputerBlock() + NL + NL;
+        if( ! IsUnknown( CurMech.GetCompany() ) ) {
+            retval += "Manufacturer: " + CurMech.GetCompany() + NL;
+            if( ! IsUnknown( CurMech.GetLocation() ) ) {
+                retval += "    Primary Factory: " + CurMech.GetLocation() + NL;
+            }
+        }
+        retval += BuildComputerBlock();
+        retval += NL;
 //        retval += "================================================================================" + NL;
         if( ! CurMech.GetOverview().equals( "" ) ) {
             retval += "Overview:" + NL;
@@ -1058,7 +1067,7 @@ public class TXTWriter {
         retval += NL;
 */
         // start targeting and tracking system line
-        retval += "Targeting and Tracking System: " + CurMech.GetTandTSystem();
+        retval += "Targeting and Tracking System: " + CurMech.GetTandTSystem() + NL;
 /*        if( ! ( BAP instanceof EmptyItem ) ) {
             if( CurMech.UsingTC() ) {
                 retval += NL + "    w/ " + BAP.GetManufacturer() + " " + BAP.GetCritName() + NL + "    and " + CurMech.GetTC().GetCritName();
@@ -1251,6 +1260,9 @@ public class TXTWriter {
                 }
             }
         }
+        if( CurMech.GetJumpJets().IsProto() ) {
+            retval += " (Prototype)";
+        }
         return retval;
     }
 
@@ -1430,5 +1442,9 @@ public class TXTWriter {
             return "\"" + data + "\",";
         else
             return data + ",";
+    }
+
+    private boolean IsUnknown( String str ) {
+        return str.isEmpty() || str.equalsIgnoreCase( "Unknown" ) || str.equalsIgnoreCase( "None" );
     }
 }

--- a/sswlib/src/main/java/states/stChassisISCOBP.java
+++ b/sswlib/src/main/java/states/stChassisISCOBP.java
@@ -76,7 +76,7 @@ public class stChassisISCOBP implements ifChassis, ifState {
     }
 
     public String CritName() {
-        return "Composite Structure";
+        return "Composite";
     }
 
     public String LookupName() {

--- a/sswlib/src/main/java/states/stChassisISCOQD.java
+++ b/sswlib/src/main/java/states/stChassisISCOQD.java
@@ -76,7 +76,7 @@ public class stChassisISCOQD implements ifChassis, ifState {
     }
 
     public String CritName() {
-        return "Composite Structure";
+        return "Composite";
     }
 
     public String LookupName() {

--- a/sswlib/src/main/java/states/stChassisPBMBP.java
+++ b/sswlib/src/main/java/states/stChassisPBMBP.java
@@ -79,7 +79,7 @@ public class stChassisPBMBP implements ifChassis, ifState {
     }
 
     public String CritName() {
-        return "Primitive Structure";
+        return "Primitive";
     }
 
     public String LookupName() {

--- a/sswlib/src/main/java/states/stChassisPBMQD.java
+++ b/sswlib/src/main/java/states/stChassisPBMQD.java
@@ -79,7 +79,7 @@ public class stChassisPBMQD implements ifChassis, ifState {
     }
 
     public String CritName() {
-        return "Primitive Structure";
+        return "Primitive";
     }
 
     public String LookupName() {

--- a/sswlib/src/main/java/utilities/CVCostBVBreakdown.java
+++ b/sswlib/src/main/java/utilities/CVCostBVBreakdown.java
@@ -81,7 +81,7 @@ public class CVCostBVBreakdown {
         retval += String.format( "Total Cost                                                         %1$,13.0f", CurUnit.GetTotalCost() ) + NL;
         retval += NL + NL;
         retval += "Defensive BV Calculation Breakdown" + NL;
-        if( CurUnit.GetRulesLevel() == AvailableCode.RULES_EXPERIMENTAL ) {
+        if( CurUnit.GetRulesLevel() >= AvailableCode.RULES_EXPERIMENTAL ) {
             retval += "(Note: BV Calculations include defensive BV for armored components.)" + NL;
         }
         retval += "________________________________________________________________________________" + NL;

--- a/sswlib/src/main/java/utilities/CostBVBreakdown.java
+++ b/sswlib/src/main/java/utilities/CostBVBreakdown.java
@@ -142,7 +142,7 @@ public class CostBVBreakdown {
         retval += String.format( "Total Cost                                                         %1$,13.0f", CurMech.GetTotalCost() ) + NL;
         retval += NL + NL;
         retval += "Defensive BV Calculation Breakdown" + NL;
-        if( CurMech.GetRulesLevel() == AvailableCode.RULES_EXPERIMENTAL ) {
+        if( CurMech.GetRulesLevel() >= AvailableCode.RULES_EXPERIMENTAL ) {
             retval += "(Note: BV Calculations include defensive BV for armored components.)" + NL;
         }
         retval += "________________________________________________________________________________" + NL;
@@ -570,7 +570,7 @@ public class CostBVBreakdown {
     private boolean HasBonusFromCP() {
         ArrayList v = CurMech.GetLoadout().GetNonCore();
         abPlaceable a;
-        if( CurMech.GetRulesLevel() == AvailableCode.RULES_EXPERIMENTAL ) {
+        if( CurMech.GetRulesLevel() >= AvailableCode.RULES_EXPERIMENTAL ) {
             // check for coolant pods
             for( int i = 0; i < v.size(); i++ ) {
                 a = (abPlaceable) v.get( i );
@@ -590,7 +590,7 @@ public class CostBVBreakdown {
         ArrayList v = CurMech.GetLoadout().GetNonCore();
         abPlaceable a;
 
-        if( CurMech.GetRulesLevel() == AvailableCode.RULES_EXPERIMENTAL ) {
+        if( CurMech.GetRulesLevel() >= AvailableCode.RULES_EXPERIMENTAL ) {
             // check for coolant pods
             for( int i = 0; i < v.size(); i++ ) {
                 a = (abPlaceable) v.get( i );


### PR DESCRIPTION
Several fixes and misc changes. There's two more PRs that will follow this, one that has fixes for mech and CV turrets and related UI, and the other for some MML compat options.

Improved error handling:
* Allow loading units with unknown equipment, also fixing an old backcompat check.
* Allow loading units with equipment in invalid locations.
* Unit saving no longer wipes file on error. Shows unexpected exceptions during saving in a dialog.

UI fixes:
* Fix regression from 69bbe7c9 that broke multiples of same equipment. I know there's another outstanding PR (#301) that's supposed to fix it, but don't think conflating an instance of an equipment and the "class" of that equipment for equality purposes is a good idea.
* Use equipment chooser panel from wide CV GUI in all other CV/mech GUIs. This also fixes non-wide CV GUI equipment chooser scrolling regression from e8dd5de. Note: the form files are already out of sync with with the java files and it would be non-trivial to make them work (Netbeans can't handle it, and Eclipse outright crashes).
* Fix wide CV GUI using SSW prefs instead of SAW prefs.
* Reset cockpit command console for new mech.
* Check omnimech eligibility when changing rules level.

Other fixes:
* Fix "All Eras" doubling CV armor cost.
* Disallow vehicular grenade launcher in CV body.
* Remove "Structure" from composite/primitive chassis CritName for consistency with other chassis.
* Armored components are now saved to file in era-specific rules (instead of just experimental rules).
* Cost/BV now properly calculated for coolant pods and armored components in era-specific rules (instead of just experimental rules).
* Read "Unknown"/"None" manufacturer/model as empty string. This also fixes jump jet model still being "None" on a loaded mech after adding jump jets afterwards.
* TRO: Avoid "Unknown" prefix, omit manufacturer/factory section if empty (ala MML), improved jump jet info a bit.
* Fix narrow/low profile quirk cost from 2 to 3 (and fill out its description) - see https://bg.battletech.com/wp-content/uploads/2023/07/Campaign-Operations-2023-07-26-v4.0.pdf
* Separate out quad version of directional torso mount quirk since it has a different point cost.
* Change variable quirk cost from 0 to 1 so user can manually come up with cost by selecting it multiple times.

Misc:
* Add eclipse stuff to .gitgnore. (Netbeans refuses to compile correctly with the ancient version of Gradle being used here, so I defaulted to another prominent free java IDE.)
* Sync SAW dlgPrefs form with java source.
* Fix minor whitespace issue in equipment.json.