### PR TITLE
Mech/vehicle/omnivehicle turret fixes & improvements

### DIFF
--- a/Data/Templates/Vee_HTML.html
+++ b/Data/Templates/Vee_HTML.html
@@ -160,6 +160,7 @@
 	</tr>
 <+-SSW_REMOVE_IF_BLANK-+><tr><td colspan="3">Power Amplifier:</td><td align="right"><+-SSW_POWER_AMP_TONNAGE-+></td></tr>
 <+-SSW_REMOVE_IF_BLANK-+><tr><td colspan="3">Turret:</td><td align="right"><+-SSW_TURRET_TONNAGE-+></td></tr>
+<+-SSW_REMOVE_IF_BLANK-+><tr><td colspan="3">Rear Turret:</td><td align="right"><+-SSW_REAR_TURRET_TONNAGE-+></td></tr>
 	<tr>
 		<td>Armor:</td>
 		<td colspan="2"><+-SSW_ARMOR_FACTOR-+> points - <+-SSW_ARMOR_TYPE-+></td>
@@ -190,6 +191,7 @@
 		<td align="center"><+-SSW_LEFT_ARMOR-+>/<+-SSW_RIGHT_ARMOR-+></td>
 	</tr>
 	<+-SSW_REMOVE_IF_BLANK-+><tr><td colspan="2" align="right">Turret:</td><td align="center"></td><td align="center"><+-SSW_TURRET_ARMOR-+></td></tr>
+	<+-SSW_REMOVE_IF_BLANK-+><tr><td colspan="2" align="right">Rear Turret:</td><td align="center"></td><td align="center"><+-SSW_REAR_TURRET_ARMOR-+></td></tr>
 	<+-SSW_REMOVE_IF_BLANK-+><tr><td colspan="2" align="right">Rotor:</td><td align="center"></td><td align="center"><+-SSW_ROTOR_ARMOR-+></td>
 	</tr>
 	<tr>

--- a/saw/src/main/java/saw/filehandlers/HTMLWriter.java
+++ b/saw/src/main/java/saw/filehandlers/HTMLWriter.java
@@ -1326,11 +1326,13 @@ public class HTMLWriter {
         lookup.put( "<+-SSW_RIGHT_ARMOR-+>", "" + CurVee.GetArmor().GetLocationArmor( LocationIndex.CV_LOC_RIGHT ) );
         lookup.put( "<+-SSW_REAR_ARMOR-+>", "" + CurVee.GetArmor().GetLocationArmor( LocationIndex.CV_LOC_REAR ) );
         lookup.put( "<+-SSW_TURRET_ARMOR-+>", "" + (CurVee.isHasTurret1() ? CurVee.GetArmor().GetLocationArmor( LocationIndex.CV_LOC_TURRET1 ) : "") );
+        lookup.put( "<+-SSW_REAR_TURRET_ARMOR-+>", "" + (CurVee.isHasTurret2() ? CurVee.GetArmor().GetLocationArmor( LocationIndex.CV_LOC_TURRET2 ) : "") );
         lookup.put( "<+-SSW_ROTOR_ARMOR-+>", "" + (CurVee.IsVTOL() ? CurVee.GetArmor().GetLocationArmor( LocationIndex.CV_LOC_ROTOR ) : "") );
         lookup.put( "<+-SSW_FRONT_ARMOR_TYPE-+>", " (" + CurVee.GetArmor().GetFrontArmorType().LookupName() + ")" );
         lookup.put( "<+-SSW_LEFT_ARMOR_TYPE-+>", " (" + CurVee.GetArmor().GetLeftArmorType().LookupName() + ")" );
         lookup.put( "<+-SSW_RIGHT_ARMOR_TYPE-+>", " (" + CurVee.GetArmor().GetRightArmorType().LookupName() + ")" );
         lookup.put( "<+-SSW_TURRET_ARMOR_TYPE-+>", (CurVee.isHasTurret1() ? " (" + CurVee.GetArmor().GetTurret1ArmorType().LookupName() + ")" : "") );
+        lookup.put( "<+-SSW_REAR_TURRET_ARMOR_TYPE-+>", (CurVee.isHasTurret2() ? " (" + CurVee.GetArmor().GetTurret2ArmorType().LookupName() + ")" : "") );
         lookup.put( "<+-SSW_ROTOR_ARMOR_TYPE-+>", ( CurVee.IsVTOL() ? " (" + CurVee.GetArmor().GetRotorArmorType().LookupName() + ")" : "" ) );
         lookup.put( "<+-SSW_REAR_ARMOR_TYPE-+>", " (" + CurVee.GetArmor().GetRearArmorType().LookupName() + ")" );
         lookup.put( "<+-SSW_ARMOR_COVERAGE-+>", "" + CurVee.GetArmor().GetCoverage() );
@@ -1382,6 +1384,7 @@ public class HTMLWriter {
         lookup.put( "<+-SSW_CONTROLS_TONNAGE-+>", CurVee.GetControls() );
         lookup.put( "<+-SSW_LIFTEQUIPMENT_TONNAGE-+>", (CurVee.GetLiftEquipmentTonnage() == 0) ? "" : CurVee.GetLiftEquipmentTonnage() + "" );
         lookup.put( "<+-SSW_TURRET_TONNAGE-+>", (CurVee.GetLoadout().GetTurret().GetTonnage() == 0) ? "" : CurVee.GetLoadout().GetTurret().GetTonnage() + "" );
+        lookup.put( "<+-SSW_REAR_TURRET_TONNAGE-+>", (CurVee.GetLoadout().GetRearTurret().GetTonnage() == 0) ? "" : CurVee.GetLoadout().GetRearTurret().GetTonnage() + "" );
         lookup.put( "<+-SSW_RULES_LEVEL-+>", CommonTools.GetRulesLevelString( CurVee.GetRulesLevel() ) );
         if( CurVee.IsOmni() ) {
             lookup.put( "<+-SSW_POD_TONNAGE-+>", FormatTonnage( ( CurVee.GetTonnage() - CurVee.GetCurrentTons() ), 1 ) );

--- a/saw/src/main/java/saw/gui/frmVee.form
+++ b/saw/src/main/java/saw/gui/frmVee.form
@@ -413,7 +413,23 @@
           <Properties>
             <Property name="editable" type="boolean" value="false"/>
             <Property name="horizontalAlignment" type="int" value="0"/>
-            <Property name="text" type="java.lang.String" value="Turret: 000.00"/>
+            <Property name="text" type="java.lang.String" value="Turret: 00.0/00.0"/>
+            <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[100, 20]"/>
+            </Property>
+            <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[100, 20]"/>
+            </Property>
+            <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[100, 20]"/>
+            </Property>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JTextField" name="txtRearTurretInfo">
+          <Properties>
+            <Property name="editable" type="boolean" value="false"/>
+            <Property name="horizontalAlignment" type="int" value="0"/>
+            <Property name="text" type="java.lang.String" value="Rear Turret: 00.0/00.0"/>
             <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
               <Dimension value="[120, 20]"/>
             </Property>
@@ -421,7 +437,7 @@
               <Dimension value="[120, 20]"/>
             </Property>
             <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[100, 20]"/>
+              <Dimension value="[120, 20]"/>
             </Property>
           </Properties>
         </Component>
@@ -445,15 +461,15 @@
           <Properties>
             <Property name="editable" type="boolean" value="false"/>
             <Property name="horizontalAlignment" type="int" value="0"/>
-            <Property name="text" type="java.lang.String" value="Cost: 000,000,000,000.00"/>
+            <Property name="text" type="java.lang.String" value="Cost: 000,000,000"/>
             <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[165, 20]"/>
+              <Dimension value="[120, 20]"/>
             </Property>
             <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[165, 20]"/>
+              <Dimension value="[120, 20]"/>
             </Property>
             <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[165, 20]"/>
+              <Dimension value="[120, 20]"/>
             </Property>
           </Properties>
         </Component>
@@ -3563,7 +3579,7 @@
             </Container>
           </SubComponents>
         </Container>
-        <Container class="javax.swing.JPanel" name="jPanel3">
+        <Container class="javax.swing.JPanel" name="pnlEquipment">
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
               <JTabbedPaneConstraints tabName="Equipment">

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -665,10 +665,6 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         boolean caseless = LegalCaseless( CurItem ) && CommonTools.IsAllowed( CaselessAmmoAC, CurVee );
         boolean lotchange = LegalLotChange( CurItem );
         boolean dumper = LegalDumper( CurItem );
-        mnuAddCapacitor.setEnabled( cap );
-        mnuAddInsulator.setEnabled( insul );
-        mnuAddPulseModule.setEnabled(pulseModule);
-        mnuCaseless.setEnabled( caseless );
         mnuAddCapacitor.setVisible( cap );
         mnuAddInsulator.setVisible( insul );
         mnuAddPulseModule.setVisible(pulseModule);

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -4559,8 +4559,6 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
     }
 
     private void BuildLocationSelector() {
-        int curSelection = Math.max(cmbLocation.getSelectedIndex(), 0);
-
         ArrayList locs = new ArrayList();
         locs.add("Front");
         locs.add("Left");
@@ -4577,6 +4575,10 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             locs.add("Rear Turret");
 
         cmbLocation.setModel(new DefaultComboBoxModel(locs.toArray()));
+        int curSelection = cmbLocation.getSelectedIndex();
+        if ( curSelection < 0 || curSelection >= locs.size()) {
+            curSelection = 0; // reset to Front
+        }
         cmbLocation.setSelectedIndex(curSelection);
     }
 

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -1017,6 +1017,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         JLabel jLabel91 = new JLabel();
         spnHeatSinks = new javax.swing.JSpinner();
         spnTurretTonnage = new javax.swing.JSpinner();
+        spnRearTurretTonnage = new javax.swing.JSpinner();
         JPanel pnlMovement = new JPanel();
         JLabel jLabel10 = new JLabel();
         spnCruiseMP = new javax.swing.JSpinner();
@@ -1757,8 +1758,12 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         spnTurretTonnage.setModel(new javax.swing.SpinnerNumberModel(0.0d, 0.0d, 50.0d, 0.5d));
         spnTurretTonnage.setEnabled(false);
         spnTurretTonnage.addChangeListener(this::spnTurretTonnageStateChanged);
+        ((JSpinner.DefaultEditor)spnTurretTonnage.getEditor()).getTextField().addFocusListener(spinners);
 
-        // TODO: copy spnRearTurretTonnage code from frmVeeWide
+        spnRearTurretTonnage.setModel(new javax.swing.SpinnerNumberModel(0.0d, 0.0d, 50.0d, 0.5d));
+        spnRearTurretTonnage.setEnabled(false);
+        spnRearTurretTonnage.addChangeListener(this::spnRearTurretTonnageStateChanged);
+        ((JSpinner.DefaultEditor)spnRearTurretTonnage.getEditor()).getTextField().addFocusListener(spinners);
 
         javax.swing.GroupLayout pnlChassisLayout = new javax.swing.GroupLayout(pnlChassis);
         pnlChassis.setLayout(pnlChassisLayout);
@@ -1783,7 +1788,9 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
                             .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                             .addComponent(cmbTurret, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                             .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                            .addComponent(spnTurretTonnage))
+                            .addComponent(spnTurretTonnage)
+                            .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                            .addComponent(spnRearTurretTonnage))
                         .addGroup(pnlChassisLayout.createSequentialGroup()
                             .addComponent(jLabel9)
                             .addGap(2, 2, 2)
@@ -1834,7 +1841,8 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
                 .addGroup(pnlChassisLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jLabel32)
                     .addComponent(cmbTurret, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(spnTurretTonnage, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addComponent(spnTurretTonnage, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(spnRearTurretTonnage, javax.swing.GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(pnlChassisLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addGroup(pnlChassisLayout.createSequentialGroup()
@@ -6062,6 +6070,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         cmbTechBase.setEnabled( true );
         cmbTurret.setSelectedIndex(0);
         spnTurretTonnage.setModel(new SpinnerNumberModel(0.0, 0.0, 50.0, 0.5));
+        spnRearTurretTonnage.setModel(new SpinnerNumberModel(0.0, 0.0, 50.0, 0.5));
 
         cmbOmniVariant.setModel( new javax.swing.DefaultComboBoxModel( new String[0] ) );
 
@@ -6346,6 +6355,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         cmbEngineType.setEnabled( true );
         cmbTurret.setEnabled( true );
         spnTurretTonnage.setEnabled( true );
+        spnRearTurretTonnage.setEnabled( true );
         spnFrontArmor.setEnabled( true );
         spnLeftArmor.setEnabled( true );
         spnRightArmor.setEnabled( true );
@@ -6373,7 +6383,6 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         chkJetBooster.setEnabled(true);
         chkEnviroSealing.setEnabled( false );
         // now enable the Omni controls
-        cmbOmniVariant.setSelectedItem("");
         cmbOmniVariant.setEnabled( false );
         btnAddVariant.setEnabled( false );
         btnDeleteVariant.setEnabled( false );
@@ -6967,20 +6976,29 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         if( Load ) { return; }
 
         String Turret = cmbTurret.getSelectedItem().toString();
-        if ( Turret.equals("Single Turret") || Turret.equals("Chin Turret")) {
+        if(Turret.equals("Single Turret") || Turret.equals("Chin Turret") ) {
             CurVee.setHasTurret1(true);
-            spnTurretTonnage.setEnabled(chkOmniVee.isSelected() && !isLocked);
-        } else if(Turret.equals("Dual Turret")) {
+            CurVee.setHasTurret2(false);
+        } else if( Turret.equals("Dual Turret") ) {
             CurVee.setHasTurret1(true);
             CurVee.setHasTurret2(true);
-            spnTurretTonnage.setEnabled(chkOmniVee.isSelected() && !isLocked);
         } else {
             CurVee.setHasTurret1(false);
             CurVee.setHasTurret2(false);
-            spnTurretTonnage.setEnabled(false);
         }
-        if( ! spnTurretTonnage.isEnabled() ) {
-            spnTurretTonnage.setValue(0);
+        if( CurVee.isHasTurret1() ) {
+            spnTurretTonnage.setEnabled( chkOmniVee.isSelected() && !isLocked );
+            SetTurretTonnage( null );
+        } else {
+            spnTurretTonnage.setEnabled( false );
+            SetTurretTonnage( 0.0 );
+        }
+        if( CurVee.isHasTurret2() ) {
+            spnRearTurretTonnage.setEnabled( chkOmniVee.isSelected() && !isLocked );
+            SetRearTurretTonnage( null );
+        } else {
+            spnRearTurretTonnage.setEnabled( false );
+            SetRearTurretTonnage( 0.0 );
         }
 
         BuildLocationSelector();
@@ -7593,6 +7611,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         cmbEngineType.setEnabled( false );
         cmbTurret.setEnabled( false );
         spnTurretTonnage.setEnabled( false );
+        spnRearTurretTonnage.setEnabled( false );
         spnFrontArmor.setEnabled( false );
         spnLeftArmor.setEnabled( false );
         spnRightArmor.setEnabled( false );
@@ -7932,21 +7951,35 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         cmbMotiveType.setSelectedItem( CurVee.GetMotiveLookupName() );
         spnTonnage.setModel( new javax.swing.SpinnerNumberModel(CurVee.GetTonnage(), 1, CurVee.GetMaxTonnage(), 1) );
         spnCruiseMP.setModel( new javax.swing.SpinnerNumberModel(CurVee.getCruiseMP(), CurVee.getMinCruiseMP(), CurVee.getMaxCruiseMP(), 1) );
-        if ( CurVee.isHasTurret1() ) cmbTurret.setSelectedItem("Single Turret");
-        if ( CurVee.isHasTurret2() ) cmbTurret.setSelectedItem("Dual Turret");
         FixArmorSpinners();
 
         // now that we're done with the special stuff...
         Load = false;
 
-        cmbOmniVariant.setModel( new javax.swing.DefaultComboBoxModel( new String[0] ) );
         if( CurVee.IsOmni() ) {
-            if ( CurVee.isHasTurret1() )
-                spnTurretTonnage.setModel( new SpinnerNumberModel(CurVee.GetBaseLoadout().GetTurret().GetMaxTonnage(), 0, 99.0, 0.5) );
             LockGUIForOmni();
             RefreshOmniVariants();
             RefreshOmniChoices();
+        } else {
+            cmbOmniVariant.setModel( new javax.swing.DefaultComboBoxModel( new String[0] ) );
         }
+
+        double turretTons = 0.0;
+        if( CurVee.isHasTurret1() ) {
+            if( chkOmniVee.isSelected() ) {
+                spnTurretTonnage.setEnabled( !isLocked );
+                turretTons = CurVee.GetLoadout().GetTurret().GetTonnage();
+            }
+        }
+        SetTurretTonnage( turretTons );
+        double rearTurretTons = 0.0;
+        if( CurVee.isHasTurret2() ) {
+            if( chkOmniVee.isSelected() ) {
+                spnRearTurretTonnage.setEnabled( !isLocked );
+                rearTurretTons = CurVee.GetLoadout().GetRearTurret().GetTonnage();
+            }
+        }
+        SetRearTurretTonnage( rearTurretTons );
 
         FixTonnageSpinner( CurVee.GetMinTonnage(), CurVee.GetMaxTonnage() );
 
@@ -8669,20 +8702,59 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
     }
 
     private void spnTurretTonnageStateChanged(javax.swing.event.ChangeEvent evt) {
+        SetTurretTonnage( null );
+        RefreshSummary();
+        RefreshInfoPane();
+    }
+
+    private void SetTurretTonnage( Double Tons ) {
         try {
-            if( spnTurretTonnage.isEnabled() ) {
-                double Tons = Double.parseDouble(spnTurretTonnage.getValue().toString());
-                CurVee.GetLoadout().GetTurret().SetTonnage(Tons);
+            if( Tons != null ) {
+                // following may end up calling spnTurretTonnageStateChanged
+                // which in turn will call this again with null Tons,
+                // so it's okay although potentially redundant
+                spnTurretTonnage.setValue( Tons );
+            }
+            if( CurVee.isHasTurret1() && chkOmniVee.isSelected() ) {
+                if( Tons == null) {
+                    Tons = Double.parseDouble( spnTurretTonnage.getValue().toString() );
+                }
+                CurVee.GetLoadout().GetTurret().SetTonnage( Tons );
             } else {
                 CurVee.GetLoadout().GetTurret().UnsetTonnage();
             }
-        } catch ( Exception e ) {
+        } catch( Exception e ) {
             Media.Messager(e.getMessage());
             return;
         }
+    }
 
+    private void spnRearTurretTonnageStateChanged(javax.swing.event.ChangeEvent evt) {
+        SetRearTurretTonnage( null );
         RefreshSummary();
         RefreshInfoPane();
+    }
+
+    private void SetRearTurretTonnage( Double Tons ) {
+        try {
+            if( Tons != null ) {
+                // following may end up calling spnRearTurretTonnageStateChanged
+                // which in turn will call this again with null Tons,
+                // so it's okay although potentially redundant
+                spnRearTurretTonnage.setValue( Tons );
+            }
+            if( CurVee.isHasTurret2() && chkOmniVee.isSelected() ) {
+                if( Tons == null) {
+                    Tons = Double.parseDouble( spnRearTurretTonnage.getValue().toString() );
+                }
+                CurVee.GetLoadout().GetRearTurret().SetTonnage( Tons );
+            } else {
+                CurVee.GetLoadout().GetRearTurret().UnsetTonnage();
+            }
+        } catch( Exception e ) {
+            Media.Messager(e.getMessage());
+            return;
+        }
     }
 
     private void chkTrailerActionPerformed(java.awt.event.ActionEvent evt) {
@@ -9028,6 +9100,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
     private javax.swing.JSpinner spnTonnage;
     private javax.swing.JSpinner spnTurretArmor;
     private javax.swing.JSpinner spnTurretTonnage;
+    private javax.swing.JSpinner spnRearTurretTonnage;
     private javax.swing.JTable tblWeaponManufacturers;
     private JTabbedPane tbpMainTabPane;
     private JTabbedPane tbpWeaponChooser;

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -6234,11 +6234,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
 
         // now let's ensure that all the omni controls are enabled or disabled
         // as appropriate
-        if( chkOmniVee.isEnabled() ) {
-            btnLockChassis.setEnabled(chkOmniVee.isSelected());
-        } else {
-            btnLockChassis.setEnabled( false );
-        }
+        btnLockChassis.setEnabled( chkOmniVee.isEnabled() && chkOmniVee.isSelected() );
     }
 
     private void RefreshEquipment() {
@@ -6347,7 +6343,6 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         // an Omni.
         isLocked = false;
 
-        chkOmniVee.setSelected( false );
         chkOmniVee.setEnabled( true );
         mnuUnlock.setEnabled( false );
         cmbMotiveType.setEnabled( true );
@@ -6370,13 +6365,11 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         chkTrailer.setEnabled( true );
         //btnEfficientArmor.setEnabled( true );
         //btnBalanceArmor.setEnabled( true );
-        btnLockChassis.setEnabled( false );
+        btnLockChassis.setEnabled( chkOmniVee.isSelected() );
         chkFCSAIV.setEnabled( true );
         chkFCSAV.setEnabled( true );
         chkFCSApollo.setEnabled( true );
         chkCASE.setEnabled( true );
-        chkOmniVee.setSelected( false );
-        chkOmniVee.setEnabled( true );
         spnCruiseMP.setEnabled( true );
         chkYearRestrict.setEnabled( true );
         chkSupercharger.setEnabled( true );
@@ -7555,7 +7548,6 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
 
         // make it an omni
         CurVee.SetOmni(VariantName);
-        chkOmniVee.setEnabled(false);
         FixJJSpinnerModel();
         FixHeatSinkSpinnerModel();
         LockGUIForOmni();
@@ -7603,7 +7595,6 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         // this locks most of the GUI controls.  Used mainly by OmniVehicles.
         isLocked = true;
 
-        chkOmniVee.setSelected( true );
         chkOmniVee.setEnabled( false );
         mnuUnlock.setEnabled( true );
         spnTonnage.setEnabled( false );
@@ -7780,11 +7771,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
     }
 
     private void chkOmniVeeActionPerformed(java.awt.event.ActionEvent evt) {
-        if( chkOmniVee.isSelected() ) {
-            btnLockChassis.setEnabled( true );
-        } else {
-            btnLockChassis.setEnabled( false );
-        }
+        btnLockChassis.setEnabled( chkOmniVee.isSelected() );
         cmbTurretActionPerformed(evt);
     }
 
@@ -7957,6 +7944,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         Load = false;
 
         if( CurVee.IsOmni() ) {
+            chkOmniVee.setSelected( true );
             LockGUIForOmni();
             RefreshOmniVariants();
             RefreshOmniChoices();

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -794,6 +794,33 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
             txtInfoFreeCrits.setForeground(Color.black);
         }
 
+        if( CurVee.isHasTurret1() ) {
+            txtTurretInfo.setVisible( true );
+            Turret turret = CurVee.GetLoadout().GetTurret();
+            if( turret.isTonnageSet() ) {
+                if( turret.GetTonnageFromItems() > turret.GetMaxTonnage() ) {
+                    txtTurretInfo.setForeground( Color.red );
+                } else {
+                    txtTurretInfo.setForeground( Color.black );
+                }
+            }
+        } else {
+            txtTurretInfo.setVisible( false );
+        }
+        if( CurVee.isHasTurret2() ) {
+            txtRearTurretInfo.setVisible( true );
+            Turret turret = CurVee.GetLoadout().GetRearTurret();
+            if( turret.isTonnageSet() ) {
+                if( turret.GetTonnageFromItems() > turret.GetMaxTonnage() ) {
+                    txtRearTurretInfo.setForeground( Color.red );
+                } else {
+                    txtRearTurretInfo.setForeground( Color.black );
+                }
+            }
+        } else {
+            txtRearTurretInfo.setVisible( false );
+        }
+
         // fill in the movement summary
         String temp = "Max C/F: ";
         temp += CurVee.GetAdjustedCruiseMP( false, true ) + "/";
@@ -957,6 +984,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         txtInfoFreeTons = new javax.swing.JTextField();
         txtInfoFreeCrits = new javax.swing.JTextField();
         txtTurretInfo = new javax.swing.JTextField();
+        txtRearTurretInfo = new javax.swing.JTextField();
         txtInfoBattleValue = new javax.swing.JTextField();
         txtInfoCost = new javax.swing.JTextField();
         tlbIconBar = new javax.swing.JToolBar();
@@ -1154,7 +1182,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         txtArmorSpace = new javax.swing.JTextField();
         lblArmorTonsWasted = new javax.swing.JLabel();
         lblArmorLeftInLot = new javax.swing.JLabel();
-        jPanel3 = new javax.swing.JPanel();
+        pnlEquipment = new javax.swing.JPanel();
         tbpWeaponChooser = new JTabbedPane();
         lstChooseBallistic = new javax.swing.JList();
         lstChooseEnergy = new javax.swing.JList();
@@ -1372,11 +1400,19 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
 
         txtTurretInfo.setEditable(false);
         txtTurretInfo.setHorizontalAlignment(javax.swing.JTextField.CENTER);
-        txtTurretInfo.setText("Turret: 000.00");
-        txtTurretInfo.setMaximumSize(new Dimension(120, 20));
-        txtTurretInfo.setMinimumSize(new Dimension(120, 20));
+        txtTurretInfo.setText("Turret: 00.0/0.00");
+        txtTurretInfo.setMaximumSize(new Dimension(100, 20));
+        txtTurretInfo.setMinimumSize(new Dimension(100, 20));
         txtTurretInfo.setPreferredSize(new Dimension(100, 20));
         pnlInfoPane.add(txtTurretInfo);
+
+        txtRearTurretInfo.setEditable(false);
+        txtRearTurretInfo.setHorizontalAlignment(javax.swing.JTextField.CENTER);
+        txtRearTurretInfo.setText("Rear Turret: 00.0/0.00");
+        txtRearTurretInfo.setMaximumSize(new Dimension(120, 20));
+        txtRearTurretInfo.setMinimumSize(new Dimension(120, 20));
+        txtRearTurretInfo.setPreferredSize(new Dimension(120, 20));
+        pnlInfoPane.add(txtRearTurretInfo);
 
         txtInfoBattleValue.setEditable(false);
         txtInfoBattleValue.setHorizontalAlignment(javax.swing.JTextField.CENTER);
@@ -1388,10 +1424,10 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
 
         txtInfoCost.setEditable(false);
         txtInfoCost.setHorizontalAlignment(javax.swing.JTextField.CENTER);
-        txtInfoCost.setText("Cost: 000,000,000,000.00");
-        txtInfoCost.setMaximumSize(new Dimension(165, 20));
-        txtInfoCost.setMinimumSize(new Dimension(165, 20));
-        txtInfoCost.setPreferredSize(new Dimension(165, 20));
+        txtInfoCost.setText("Cost: 000,000,000");
+        txtInfoCost.setMaximumSize(new Dimension(120, 20));
+        txtInfoCost.setMinimumSize(new Dimension(120, 20));
+        txtInfoCost.setPreferredSize(new Dimension(120, 20));
         pnlInfoPane.add(txtInfoCost);
 
         tlbIconBar.setFloatable(false);
@@ -3525,17 +3561,17 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         gridBagConstraints.insets = new java.awt.Insets(4, 0, 4, 0);
         pnlControls.add(jScrollPane1, gridBagConstraints);
 
-        javax.swing.GroupLayout jPanel3Layout = new javax.swing.GroupLayout(jPanel3);
-        jPanel3.setLayout(jPanel3Layout);
-        jPanel3Layout.setHorizontalGroup(
-            jPanel3Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(jPanel3Layout.createSequentialGroup()
+        javax.swing.GroupLayout pnlEquipmentLayout = new javax.swing.GroupLayout(pnlEquipment);
+        pnlEquipment.setLayout(pnlEquipmentLayout);
+        pnlEquipmentLayout.setHorizontalGroup(
+            pnlEquipmentLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(pnlEquipmentLayout.createSequentialGroup()
                 .addContainerGap()
-                .addGroup(jPanel3Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addGroup(jPanel3Layout.createSequentialGroup()
+                .addGroup(pnlEquipmentLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(pnlEquipmentLayout.createSequentialGroup()
                         .addComponent(tbpWeaponChooser, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                         .addGap(18, 18, 18)
-                        .addGroup(jPanel3Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                        .addGroup(pnlEquipmentLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
                             .addComponent(pnlControls, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                             .addComponent(pnlSpecials, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -3543,12 +3579,12 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
                     .addComponent(pnlEquipInfo, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addContainerGap())
         );
-        jPanel3Layout.setVerticalGroup(
-            jPanel3Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(jPanel3Layout.createSequentialGroup()
+        pnlEquipmentLayout.setVerticalGroup(
+            pnlEquipmentLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(pnlEquipmentLayout.createSequentialGroup()
                 .addContainerGap()
-                .addGroup(jPanel3Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel3Layout.createSequentialGroup()
+                .addGroup(pnlEquipmentLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, pnlEquipmentLayout.createSequentialGroup()
                         .addComponent(pnlControls, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                         .addComponent(pnlSpecials, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
@@ -3558,7 +3594,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
                 .addComponent(pnlEquipInfo, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
         );
 
-        tbpMainTabPane.addTab("Equipment", jPanel3);
+        tbpMainTabPane.addTab("Equipment", pnlEquipment);
 
         pnlFluff.setLayout(new java.awt.GridBagLayout());
 
@@ -4410,7 +4446,8 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         txtSumConTons.setText("" + CurVee.GetControls() );
         txtSumTurTons.setText("" + CurVee.GetLoadout().GetTurret().GetTonnage() );
         txtSumTurAV.setText( CurVee.GetLoadout().GetTurret().GetAvailability().GetBestCombinedCode() );
-        txtTurretInfo.setText("Turret: " + CurVee.GetLoadout().GetTurret().GetTonnage() );
+        txtTurretInfo.setText( "Turret: " + CurVee.GetLoadout().GetTurret().GetTonnageText() );
+        txtRearTurretInfo.setText( "Rear Turret: " + CurVee.GetLoadout().GetRearTurret().GetTonnageText() );
         txtSumRTuTons.setText("" + CurVee.GetLoadout().GetRearTurret().GetTonnage() );
         txtSumRTuAV.setText( CurVee.GetLoadout().GetRearTurret().GetAvailability().GetBestCombinedCode() );
         txtSumSpnTons.setText("" + CurVee.GetLoadout().GetSponsonTurretTonnage() );
@@ -5915,8 +5952,8 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
 
         // if we have any systems that requires ECM and don't have it, let the user know
         if( ! CurVee.ValidateECM() ) {
-            Media.Messager( "This 'Mech requires an ECM system of some sort to be valid.\nPlease install an ECM system." );
-            tbpMainTabPane.setSelectedComponent( jPanel3 );
+            Media.Messager( "This Vehicle requires an ECM system of some sort to be valid.\nPlease install an ECM system." );
+            tbpMainTabPane.setSelectedComponent( pnlEquipment );
             SetSource = true;
             return false;
         }
@@ -8999,7 +9036,6 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
     private javax.swing.JComboBox cmbRulesLevel;
     private javax.swing.JComboBox cmbTechBase;
     private javax.swing.JComboBox cmbTurret;
-    private javax.swing.JPanel jPanel3;
     private javax.swing.JTextArea jTextAreaBFConversion;
     private javax.swing.JLabel lblArmorCoverage;
     private javax.swing.JLabel lblArmorLeftInLot;
@@ -9069,6 +9105,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
     private javax.swing.JPanel pnlBasicSetup;
     private javax.swing.JPanel pnlCapabilities;
     private javax.swing.JPanel pnlDeployment;
+    private javax.swing.JPanel pnlEquipment;
     private javax.swing.JPanel pnlHistory;
     private javax.swing.JPanel pnlNotables;
     private javax.swing.JPanel pnlOverview;
@@ -9109,6 +9146,7 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
     private javax.swing.JTextField txtManufacturerLocation;
     private javax.swing.JTextField txtModel;
     private javax.swing.JTextField txtProdYear;
+    private javax.swing.JTextField txtRearTurretInfo;
     private javax.swing.JTextField txtSource;
     private javax.swing.JTextField txtSumArmAV;
     private javax.swing.JTextField txtSumArmSpace;

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -5959,24 +5959,43 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         }
 
         // ensure we're not overweight
+        ArrayList<ifCVLoadout> loadouts = new ArrayList<>();
         if( CurVee.IsOmni() ) {
-            ArrayList v = CurVee.GetLoadouts();
-            for( int i = 0; i < v.size(); i++ ) {
-                CurVee.SetCurLoadout( ((ifCVLoadout) v.get( i )).GetName() );
-                if( CurVee.GetCurrentTons() > CurVee.GetTonnage() ) {
-                    Media.Messager( this, ((ifCVLoadout) v.get( i )).GetName() +
-                        " loadout is overweight.  Reduce the weight\nto equal or below the Vehicle's tonnage." );
-                    //cmbOmniVariant.setSelectedItem( ((ifCVLoadout) v.get( i )).GetName() );
-                    //cmbOmniVariantActionPerformed( evt );
-                    tbpMainTabPane.setSelectedComponent( pnlBasicSetup );
-                    SetSource = true;
-                    return false;
-                }
-            }
+            loadouts.addAll( CurVee.GetLoadouts() );
         } else {
+            loadouts.add( null );
+        }
+        for( ifCVLoadout loadout : loadouts ) {
+            String name;
+            JPanel panel;
+            if( loadout == null ) {
+                name = "This Vehicle";
+                panel = pnlBasicSetup;
+            } else {
+                name = loadout.GetName() + " loadout";
+                CurVee.SetCurLoadout( loadout.GetName() );
+                panel = pnlEquipment;
+            }
             if( CurVee.GetCurrentTons() > CurVee.GetTonnage() ) {
-                Media.Messager( this, "This Vehicle is overweight.  Reduce the weight to\nequal or below the Vehicle's tonnage." );
-                tbpMainTabPane.setSelectedComponent( pnlBasicSetup );
+                Media.Messager( this, name + " is overweight.\n" +
+                        "Reduce the weight to equal or below the Vehicle's tonnage." );
+                tbpMainTabPane.setSelectedComponent( panel );
+                SetSource = true;
+                return false;
+            }
+            Turret turret = CurVee.GetLoadout().GetTurret();
+            if( turret.isTonnageSet() && turret.GetTonnageFromItems() > turret.GetMaxTonnage() ) {
+                Media.Messager( this, name + "'s turret is overweight.\n" +
+                        "Reduce the turret's weight to equal or below its max tonnage." );
+                tbpMainTabPane.setSelectedComponent( panel );
+                SetSource = true;
+                return false;
+            }
+            turret = CurVee.GetLoadout().GetRearTurret();
+            if( turret.isTonnageSet() && turret.GetTonnageFromItems() > turret.GetMaxTonnage() ) {
+                Media.Messager( this, name + "'s rear turret is overweight.\n" +
+                        "Reduce the rear turret's weight to equal or below its max tonnage." );
+                tbpMainTabPane.setSelectedComponent( panel );
                 SetSource = true;
                 return false;
             }

--- a/saw/src/main/java/saw/gui/frmVee.java
+++ b/saw/src/main/java/saw/gui/frmVee.java
@@ -1758,6 +1758,8 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         spnTurretTonnage.setEnabled(false);
         spnTurretTonnage.addChangeListener(this::spnTurretTonnageStateChanged);
 
+        // TODO: copy spnRearTurretTonnage code from frmVeeWide
+
         javax.swing.GroupLayout pnlChassisLayout = new javax.swing.GroupLayout(pnlChassis);
         pnlChassis.setLayout(pnlChassisLayout);
         pnlChassisLayout.setHorizontalGroup(
@@ -6967,17 +6969,18 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
         String Turret = cmbTurret.getSelectedItem().toString();
         if ( Turret.equals("Single Turret") || Turret.equals("Chin Turret")) {
             CurVee.setHasTurret1(true);
-            if (chkOmniVee.isSelected() && !isLocked )
-                spnTurretTonnage.setEnabled(true);
+            spnTurretTonnage.setEnabled(chkOmniVee.isSelected() && !isLocked);
         } else if(Turret.equals("Dual Turret")) {
             CurVee.setHasTurret1(true);
             CurVee.setHasTurret2(true);
-            if (chkOmniVee.isSelected() && !isLocked )
-                spnTurretTonnage.setEnabled(true);
+            spnTurretTonnage.setEnabled(chkOmniVee.isSelected() && !isLocked);
         } else {
             CurVee.setHasTurret1(false);
             CurVee.setHasTurret2(false);
             spnTurretTonnage.setEnabled(false);
+        }
+        if( ! spnTurretTonnage.isEnabled() ) {
+            spnTurretTonnage.setValue(0);
         }
 
         BuildLocationSelector();
@@ -8666,11 +8669,13 @@ public final class frmVee extends javax.swing.JFrame implements java.awt.datatra
     }
 
     private void spnTurretTonnageStateChanged(javax.swing.event.ChangeEvent evt) {
-        double Tons = 0;
-        try
-        {
-           Tons = Double.parseDouble(spnTurretTonnage.getValue().toString());
-           CurVee.GetLoadout().GetTurret().SetTonnage(Tons);
+        try {
+            if( spnTurretTonnage.isEnabled() ) {
+                double Tons = Double.parseDouble(spnTurretTonnage.getValue().toString());
+                CurVee.GetLoadout().GetTurret().SetTonnage(Tons);
+            } else {
+                CurVee.GetLoadout().GetTurret().UnsetTonnage();
+            }
         } catch ( Exception e ) {
             Media.Messager(e.getMessage());
             return;

--- a/saw/src/main/java/saw/gui/frmVeeWide.form
+++ b/saw/src/main/java/saw/gui/frmVeeWide.form
@@ -413,7 +413,23 @@
           <Properties>
             <Property name="editable" type="boolean" value="false"/>
             <Property name="horizontalAlignment" type="int" value="0"/>
-            <Property name="text" type="java.lang.String" value="Turret: 000.00"/>
+            <Property name="text" type="java.lang.String" value="Turret: 00.0/00.0"/>
+            <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[100, 20]"/>
+            </Property>
+            <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[100, 20]"/>
+            </Property>
+            <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[100, 20]"/>
+            </Property>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JTextField" name="txtRearTurretInfo">
+          <Properties>
+            <Property name="editable" type="boolean" value="false"/>
+            <Property name="horizontalAlignment" type="int" value="0"/>
+            <Property name="text" type="java.lang.String" value="Rear Turret: 00.0/00.0"/>
             <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
               <Dimension value="[120, 20]"/>
             </Property>
@@ -421,7 +437,7 @@
               <Dimension value="[120, 20]"/>
             </Property>
             <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[100, 20]"/>
+              <Dimension value="[120, 20]"/>
             </Property>
           </Properties>
         </Component>
@@ -445,15 +461,15 @@
           <Properties>
             <Property name="editable" type="boolean" value="false"/>
             <Property name="horizontalAlignment" type="int" value="0"/>
-            <Property name="text" type="java.lang.String" value="Cost: 000,000,000,000.00"/>
+            <Property name="text" type="java.lang.String" value="Cost: 000,000,000"/>
             <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[165, 20]"/>
+              <Dimension value="[120, 20]"/>
             </Property>
             <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[165, 20]"/>
+              <Dimension value="[120, 20]"/>
             </Property>
             <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[165, 20]"/>
+              <Dimension value="[120, 20]"/>
             </Property>
           </Properties>
         </Component>

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -633,10 +633,6 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         boolean caseless = LegalCaseless( CurItem ) && CommonTools.IsAllowed( CaselessAmmoAC, CurVee );
         boolean lotchange = LegalLotChange( CurItem );
         boolean dumper = LegalDumper( CurItem );
-        mnuAddCapacitor.setEnabled( cap );
-        mnuAddInsulator.setEnabled( insul );
-        mnuAddPulseModule.setEnabled(pulseModule);
-        mnuCaseless.setEnabled( caseless );
         mnuAddCapacitor.setVisible( cap );
         mnuAddInsulator.setVisible( insul );
         mnuAddPulseModule.setVisible(pulseModule);

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -2886,8 +2886,6 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
     }
 
     private void BuildLocationSelector() {
-        int curSelection = Math.max(cmbLocation.getSelectedIndex(), 0);
-
         ArrayList locs = new ArrayList();
         locs.add("Front");
         locs.add("Left");
@@ -2904,6 +2902,10 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             locs.add("Rear Turret");
 
         cmbLocation.setModel(new DefaultComboBoxModel(locs.toArray()));
+        int curSelection = cmbLocation.getSelectedIndex();
+        if ( curSelection < 0 || curSelection >= locs.size()) {
+            curSelection = 0; // reset to Front
+        }
         cmbLocation.setSelectedIndex(curSelection);
     }
 

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -4551,21 +4551,25 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             RefreshOmniChoices();
         }
 
-        spnTurretTonnage.setValue(0);
-        spnRearTurretTonnage.setValue(0);
-        if ( CurVee.isHasTurret1() ) {
+        if( CurVee.isHasTurret1() ) {
             cmbTurret.setSelectedItem("Single Turret");
             if (chkOmniVee.isSelected()) {
                 spnTurretTonnage.setEnabled(!isLocked);
                 spnTurretTonnage.setValue(CurVee.GetLoadout().GetTurret().GetTonnage());
             }
         }
-        if ( CurVee.isHasTurret2() ) {
+        if( ! spnTurretTonnage.isEnabled() ) {
+            spnTurretTonnage.setValue(0);
+        }
+        if( CurVee.isHasTurret2() ) {
             cmbTurret.setSelectedItem("Dual Turret");
             if (chkOmniVee.isSelected()) {
                 spnRearTurretTonnage.setEnabled(!isLocked);
                 spnRearTurretTonnage.setValue(CurVee.GetLoadout().GetRearTurret().GetTonnage());
             }
+        }
+        if( ! spnRearTurretTonnage.isEnabled() ) {
+            spnRearTurretTonnage.setValue(0);
         }
 
         FixTonnageSpinner( CurVee.GetMinTonnage(), CurVee.GetMaxTonnage() );
@@ -6519,10 +6523,13 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
     }
 
     private void spnTurretTonnageStateChanged(javax.swing.event.ChangeEvent evt) {
-        double Tons = 0;
         try {
-            Tons = Double.parseDouble(spnTurretTonnage.getValue().toString());
-            CurVee.GetLoadout().GetTurret().SetTonnage(Tons);
+            if( spnTurretTonnage.isEnabled() ) {
+                double Tons = Double.parseDouble(spnTurretTonnage.getValue().toString());
+                CurVee.GetLoadout().GetTurret().SetTonnage(Tons);
+            } else {
+                CurVee.GetLoadout().GetTurret().UnsetTonnage();
+            }
         } catch (Exception e) {
             Media.Messager(e.getMessage());
             return;
@@ -6533,10 +6540,13 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
     }
 
     private void spnRearTurretTonnageStateChanged(javax.swing.event.ChangeEvent evt) {
-        double Tons = 0;
         try {
-            Tons = Double.parseDouble(spnRearTurretTonnage.getValue().toString());
-            CurVee.GetLoadout().GetRearTurret().SetTonnage(Tons);
+            if( spnRearTurretTonnage.isEnabled() ) {
+                double Tons = Double.parseDouble(spnRearTurretTonnage.getValue().toString());
+                CurVee.GetLoadout().GetRearTurret().SetTonnage(Tons);
+            } else {
+                CurVee.GetLoadout().GetRearTurret().UnsetTonnage();
+            }
         } catch (Exception e) {
             Media.Messager(e.getMessage());
             return;
@@ -6601,7 +6611,6 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             CurVee.setHasTurret1(true);
             spnTurretTonnage.setEnabled(chkOmniVee.isSelected() && !isLocked);
             spnRearTurretTonnage.setEnabled(false);
-            spnRearTurretTonnage.setValue(0);
         } else if (Turret.equals("Dual Turret")) {
             CurVee.setHasTurret1(true);
             CurVee.setHasTurret2(true);
@@ -6611,8 +6620,12 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             CurVee.setHasTurret1(false);
             CurVee.setHasTurret2(false);
             spnTurretTonnage.setEnabled(false);
-            spnTurretTonnage.setValue(0);
             spnRearTurretTonnage.setEnabled(false);
+        }
+        if( ! spnTurretTonnage.isEnabled() ) {
+            spnTurretTonnage.setValue(0);
+        }
+        if( ! spnRearTurretTonnage.isEnabled() ) {
             spnRearTurretTonnage.setValue(0);
         }
 

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -3687,24 +3687,43 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         //}
 
         // ensure we're not overweight
+        ArrayList<ifCVLoadout> loadouts = new ArrayList<>();
         if( CurVee.IsOmni() ) {
-            ArrayList v = CurVee.GetLoadouts();
-            for (Object o : v) {
-                CurVee.SetCurLoadout(((ifCVLoadout) o).GetName());
-                if (CurVee.GetCurrentTons() > CurVee.GetTonnage()) {
-                    Media.Messager(this, ((ifCVLoadout) o).GetName() +
-                            " loadout is overweight.  Reduce the weight\nto equal or below the Vehicle's tonnage.");
-                    //cmbOmniVariant.setSelectedItem( ((ifCVLoadout) v.get( i )).GetName() );
-                    //cmbOmniVariantActionPerformed( evt );
-                    tbpMainTabPane.setSelectedComponent(pnlBasicSetup);
-                    SetSource = true;
-                    return false;
-                }
-            }
+            loadouts.addAll( CurVee.GetLoadouts() );
         } else {
+            loadouts.add( null );
+        }
+        for( ifCVLoadout loadout : loadouts ) {
+            String name;
+            JPanel panel;
+            if( loadout == null ) {
+                name = "This Vehicle";
+                panel = pnlBasicSetup;
+            } else {
+                name = loadout.GetName() + " loadout";
+                CurVee.SetCurLoadout( loadout.GetName() );
+                panel = pnlEquipment;
+            }
             if( CurVee.GetCurrentTons() > CurVee.GetTonnage() ) {
-                Media.Messager( this, "This Vehicle is overweight.  Reduce the weight to\nequal or below the Vehicle's tonnage." );
-                tbpMainTabPane.setSelectedComponent( pnlBasicSetup );
+                Media.Messager( this, name + " is overweight.\n" +
+                        "Reduce the weight to equal or below the Vehicle's tonnage." );
+                tbpMainTabPane.setSelectedComponent( panel );
+                SetSource = true;
+                return false;
+            }
+            Turret turret = CurVee.GetLoadout().GetTurret();
+            if( turret.isTonnageSet() && turret.GetTonnageFromItems() > turret.GetMaxTonnage() ) {
+                Media.Messager( this, name + "'s turret is overweight.\n" +
+                        "Reduce the turret's weight to equal or below its max tonnage." );
+                tbpMainTabPane.setSelectedComponent( panel );
+                SetSource = true;
+                return false;
+            }
+            turret = CurVee.GetLoadout().GetRearTurret();
+            if( turret.isTonnageSet() && turret.GetTonnageFromItems() > turret.GetMaxTonnage() ) {
+                Media.Messager( this, name + "'s rear turret is overweight.\n" +
+                        "Reduce the rear turret's weight to equal or below its max tonnage." );
+                tbpMainTabPane.setSelectedComponent( panel );
                 SetSource = true;
                 return false;
             }

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -4552,7 +4552,6 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         }
 
         if( CurVee.isHasTurret1() ) {
-            cmbTurret.setSelectedItem("Single Turret");
             if (chkOmniVee.isSelected()) {
                 spnTurretTonnage.setEnabled(!isLocked);
                 spnTurretTonnage.setValue(CurVee.GetLoadout().GetTurret().GetTonnage());
@@ -4562,7 +4561,6 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             spnTurretTonnage.setValue(0);
         }
         if( CurVee.isHasTurret2() ) {
-            cmbTurret.setSelectedItem("Dual Turret");
             if (chkOmniVee.isSelected()) {
                 spnRearTurretTonnage.setEnabled(!isLocked);
                 spnRearTurretTonnage.setValue(CurVee.GetLoadout().GetRearTurret().GetTonnage());

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -3911,15 +3911,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
 
         // now let's ensure that all the omni controls are enabled or disabled
         // as appropriate
-        if( chkOmniVee.isEnabled() ) {
-            if( chkOmniVee.isSelected() ) {
-                //btnLockChassis.setEnabled( true );
-            } else {
-                //btnLockChassis.setEnabled( false );
-            }
-        } else {
-            //btnLockChassis.setEnabled( false );
-        }
+        btnLockChassis.setEnabled( chkOmniVee.isEnabled() && chkOmniVee.isSelected() );
     }
 
     private void RefreshEquipment() {
@@ -4031,7 +4023,6 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         // an Omni.
         isLocked = false;
 
-        chkOmniVee.setSelected( false );
         chkOmniVee.setEnabled( true );
         mnuUnlock.setEnabled( false );
         cmbMotiveType.setEnabled( true );
@@ -4057,7 +4048,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         chkFCSAIV.setEnabled( true );
         chkFCSAV.setEnabled( true );
         chkFCSApollo.setEnabled( true );
-        btnLockChassis.setEnabled( true );
+        btnLockChassis.setEnabled( chkOmniVee.isSelected() );
         spnCruiseMP.setEnabled( true );
         chkYearRestrict.setEnabled( true );
         chkSupercharger.setEnabled( true );
@@ -4308,7 +4299,6 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         // this locks most of the GUI controls.  Used mainly by OmniVehichles.
         isLocked = true;
 
-        chkOmniVee.setSelected( true );
         chkOmniVee.setEnabled( false );
         mnuUnlock.setEnabled( true );
         spnTonnage.setEnabled( false );
@@ -4548,6 +4538,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         Load = false;
 
         if( CurVee.IsOmni() ) {
+            chkOmniVee.setSelected( true );
             LockGUIForOmni();
             RefreshOmniVariants();
             RefreshOmniChoices();
@@ -6351,7 +6342,6 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
 
         // make it an omni
         CurVee.SetOmni(VariantName);
-        chkOmniVee.setEnabled(false);
         FixJJSpinnerModel();
         FixHeatSinkSpinnerModel();
         LockGUIForOmni();
@@ -6816,7 +6806,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
     }
 
     private void chkOmniVeeActionPerformed(java.awt.event.ActionEvent evt) {
-        btnLockChassis.setEnabled(chkOmniVee.isSelected());
+        btnLockChassis.setEnabled( chkOmniVee.isSelected() );
         cmbTurretActionPerformed(evt);
     }
 

--- a/saw/src/main/java/saw/gui/frmVeeWide.java
+++ b/saw/src/main/java/saw/gui/frmVeeWide.java
@@ -762,6 +762,33 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
             txtInfoFreeCrits.setForeground(Color.black);
         }
 
+        if( CurVee.isHasTurret1() ) {
+            txtTurretInfo.setVisible( true );
+            Turret turret = CurVee.GetLoadout().GetTurret();
+            if( turret.isTonnageSet() ) {
+                if( turret.GetTonnageFromItems() > turret.GetMaxTonnage() ) {
+                    txtTurretInfo.setForeground( Color.red );
+                } else {
+                    txtTurretInfo.setForeground( Color.black );
+                }
+            }
+        } else {
+            txtTurretInfo.setVisible( false );
+        }
+        if( CurVee.isHasTurret2() ) {
+            txtRearTurretInfo.setVisible( true );
+            Turret turret = CurVee.GetLoadout().GetRearTurret();
+            if( turret.isTonnageSet() ) {
+                if( turret.GetTonnageFromItems() > turret.GetMaxTonnage() ) {
+                    txtRearTurretInfo.setForeground( Color.red );
+                } else {
+                    txtRearTurretInfo.setForeground( Color.black );
+                }
+            }
+        } else {
+            txtRearTurretInfo.setVisible( false );
+        }
+
         // fill in the movement summary
         String temp = "Max C/F: ";
         temp += CurVee.GetAdjustedCruiseMP( false, true ) + "/";
@@ -923,6 +950,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         txtInfoFreeTons = new javax.swing.JTextField();
         txtInfoFreeCrits = new javax.swing.JTextField();
         txtTurretInfo = new javax.swing.JTextField();
+        txtRearTurretInfo = new javax.swing.JTextField();
         txtInfoBattleValue = new javax.swing.JTextField();
         txtInfoCost = new javax.swing.JTextField();
         tlbIconBar = new javax.swing.JToolBar();
@@ -1072,7 +1100,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         txtArmorSpace = new javax.swing.JTextField("00");
         lblArmorTonsWasted = new javax.swing.JLabel("0.00 Tons Wasted");
         lblArmorLeftInLot = new javax.swing.JLabel("99 Points Left In This 1/2 Ton Lot");
-        JPanel pnlEquipment = new JPanel();
+        pnlEquipment = new JPanel();
         pnlEquipInfo = new javax.swing.JPanel();
         lblInfoAVSL = new javax.swing.JLabel();
         lblInfoAVSW = new javax.swing.JLabel();
@@ -1229,11 +1257,19 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
 
         txtTurretInfo.setEditable(false);
         txtTurretInfo.setHorizontalAlignment(javax.swing.JTextField.CENTER);
-        txtTurretInfo.setText("Turret: 000.00");
-        txtTurretInfo.setMaximumSize(new Dimension(120, 20));
-        txtTurretInfo.setMinimumSize(new Dimension(120, 20));
+        txtTurretInfo.setText("Turret: 00.0/0.00");
+        txtTurretInfo.setMaximumSize(new Dimension(100, 20));
+        txtTurretInfo.setMinimumSize(new Dimension(100, 20));
         txtTurretInfo.setPreferredSize(new Dimension(100, 20));
         pnlInfoPane.add(txtTurretInfo);
+
+        txtRearTurretInfo.setEditable(false);
+        txtRearTurretInfo.setHorizontalAlignment(javax.swing.JTextField.CENTER);
+        txtRearTurretInfo.setText("Rear Turret: 00.0/0.00");
+        txtRearTurretInfo.setMaximumSize(new Dimension(120, 20));
+        txtRearTurretInfo.setMinimumSize(new Dimension(120, 20));
+        txtRearTurretInfo.setPreferredSize(new Dimension(120, 20));
+        pnlInfoPane.add(txtRearTurretInfo);
 
         txtInfoBattleValue.setEditable(false);
         txtInfoBattleValue.setHorizontalAlignment(javax.swing.JTextField.CENTER);
@@ -1245,10 +1281,10 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
 
         txtInfoCost.setEditable(false);
         txtInfoCost.setHorizontalAlignment(javax.swing.JTextField.CENTER);
-        txtInfoCost.setText("Cost: 000,000,000,000.00");
-        txtInfoCost.setMaximumSize(new Dimension(165, 20));
-        txtInfoCost.setMinimumSize(new Dimension(165, 20));
-        txtInfoCost.setPreferredSize(new Dimension(165, 20));
+        txtInfoCost.setText("Cost: 000,000,000");
+        txtInfoCost.setMaximumSize(new Dimension(120, 20));
+        txtInfoCost.setMinimumSize(new Dimension(120, 20));
+        txtInfoCost.setPreferredSize(new Dimension(120, 20));
         pnlInfoPane.add(txtInfoCost);
         //endregion
 
@@ -2722,7 +2758,8 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
         txtSumConTons.setText("" + CurVee.GetControls() );
         txtSumTurTons.setText("" + CurVee.GetLoadout().GetTurret().GetTonnage() );
         txtSumTurAV.setText( CurVee.GetLoadout().GetTurret().GetAvailability().GetBestCombinedCode() );
-        txtTurretInfo.setText("Turret: " + CurVee.GetLoadout().GetTurret().GetTonnage() );
+        txtTurretInfo.setText( "Turret: " + CurVee.GetLoadout().GetTurret().GetTonnageText() );
+        txtRearTurretInfo.setText( "Rear Turret: " + CurVee.GetLoadout().GetRearTurret().GetTonnageText() );
         txtSumRTuTons.setText("" + CurVee.GetLoadout().GetRearTurret().GetTonnage() );
         txtSumRTuAV.setText( CurVee.GetLoadout().GetRearTurret().GetAvailability().GetBestCombinedCode() );
         txtSumSpnTons.setText("" + CurVee.GetLoadout().GetSponsonTurretTonnage() );
@@ -7485,6 +7522,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
     private javax.swing.JPanel pnlBasicSetup;
     private javax.swing.JPanel pnlCapabilities;
     private javax.swing.JPanel pnlDeployment;
+    private javax.swing.JPanel pnlEquipment;
     private javax.swing.JPanel pnlEquipInfo;
     private javax.swing.JPanel pnlHistory;
     private javax.swing.JPanel pnlNotables;
@@ -7527,6 +7565,7 @@ public final class frmVeeWide extends javax.swing.JFrame implements java.awt.dat
     private javax.swing.JTextField txtManufacturerLocation;
     private javax.swing.JTextField txtModel;
     private javax.swing.JTextField txtProdYear;
+    private javax.swing.JTextField txtRearTurretInfo;
     private javax.swing.JTextField txtSource;
     private javax.swing.JTextField txtSumArmAV;
     private javax.swing.JTextField txtSumArmSpace;

--- a/ssw/src/main/java/ssw/gui/frmMain.java
+++ b/ssw/src/main/java/ssw/gui/frmMain.java
@@ -3542,6 +3542,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
 
     private void ConfigureUtilsMenu( java.awt.Component c ) {
         // configures the utilities popup menu
+        boolean rear = LegalRearMount( CurItem );
         boolean armor = LegalArmoring( CurItem ) && CommonTools.IsAllowed( abPlaceable.ArmoredAC, CurMech );
         boolean cap = LegalCapacitor( CurItem ) && CommonTools.IsAllowed( PPCCapAC, CurMech );
         boolean insul = LegalInsulator( CurItem ) && CommonTools.IsAllowed( LIAC, CurMech );
@@ -3550,11 +3551,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         boolean lotchange = LegalLotChange( CurItem );
         boolean turreted = LegalTurretMount( CurItem );
         boolean dumper = LegalDumper( CurItem );
-        mnuArmorComponent.setEnabled( armor );
-        mnuAddCapacitor.setEnabled( cap );
-        mnuAddInsulator.setEnabled( insul );
-        mnuAddPulseModule.setEnabled(pulseModule);
-        mnuCaseless.setEnabled( caseless );
+        mnuMountRear.setVisible( rear );
         mnuArmorComponent.setVisible( armor );
         mnuAddCapacitor.setVisible( cap );
         mnuAddInsulator.setVisible( insul );
@@ -4012,6 +4009,23 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
                 }
                 RefreshInfoPane();
             }
+        }
+    }
+
+    public boolean LegalRearMount( abPlaceable p ) {
+        switch( CurMech.GetLoadout().Find( p ) ) {
+            case LocationIndex.MECH_LOC_HD:
+            case LocationIndex.MECH_LOC_CT:
+            case LocationIndex.MECH_LOC_LT:
+            case LocationIndex.MECH_LOC_RT:
+            case LocationIndex.MECH_LOC_LL:
+            case LocationIndex.MECH_LOC_RL:
+                return CurItem.CanMountRear();
+            case LocationIndex.MECH_LOC_LA:
+            case LocationIndex.MECH_LOC_RA:
+                return CurMech.IsQuad() && CurItem.CanMountRear();
+            default:
+                return false;
         }
     }
 

--- a/ssw/src/main/java/ssw/gui/frmMain.java
+++ b/ssw/src/main/java/ssw/gui/frmMain.java
@@ -3570,8 +3570,8 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
                 mnuArmorComponent.setText( "Armor Component" );
             }
         }
-        if( turreted && ( CurItem instanceof RangedWeapon ) ) {
-            if( ((RangedWeapon) CurItem).IsTurreted() ) {
+        if( turreted ) {
+            if( CurItem.IsTurreted() ) {
                 mnuTurret.setText( "Remove from Turret" );
             } else {
                 mnuTurret.setText( "Add to Turret");
@@ -3867,57 +3867,19 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
     }
 
     private void TurretMount() {
-        if( CurItem instanceof RangedWeapon ) {
-            RangedWeapon w = (RangedWeapon) CurItem;
+        if( CurItem.IsTurreted() ) {
+            CurItem.MountTurret( null );
+        } else {
             int location = CurMech.GetLoadout().Find( CurItem );
-            if( w.IsTurreted() ) {
-                if( location == LocationIndex.MECH_LOC_HD ) {
-                    w.RemoveFromTurret( CurMech.GetLoadout().GetHDTurret() );
-                } else if( location == LocationIndex.MECH_LOC_LT ) {
-                    w.RemoveFromTurret( CurMech.GetLoadout().GetLTTurret() );
-                } else if( location == LocationIndex.MECH_LOC_RT ) {
-                    w.RemoveFromTurret( CurMech.GetLoadout().GetRTTurret() );
-                } else {
-                    Media.Messager( this, "Cannot remove from turret!" );
-                    return;
-                }
+            if( location == LocationIndex.MECH_LOC_HD ) {
+                CurItem.MountTurret( CurMech.GetLoadout().GetHDTurret() );
+            } else if( location == LocationIndex.MECH_LOC_LT ) {
+                CurItem.MountTurret( CurMech.GetLoadout().GetLTTurret() );
+            } else if( location == LocationIndex.MECH_LOC_RT ) {
+                CurItem.MountTurret( CurMech.GetLoadout().GetRTTurret() );
             } else {
-                if( location == LocationIndex.MECH_LOC_HD ) {
-                    w.AddToTurret( CurMech.GetLoadout().GetHDTurret() );
-                } else if( location == LocationIndex.MECH_LOC_LT ) {
-                    w.AddToTurret( CurMech.GetLoadout().GetLTTurret() );
-                } else if( location == LocationIndex.MECH_LOC_RT ) {
-                    w.AddToTurret( CurMech.GetLoadout().GetRTTurret() );
-                } else {
-                    Media.Messager( this, "Cannot add to turret!" );
-                    return;
-                }
-            }
-        } else if( CurItem instanceof MGArray ) {
-            MGArray w = (MGArray) CurItem;
-            int location = CurMech.GetLoadout().Find( CurItem );
-            if( w.IsTurreted() ) {
-                if( location == LocationIndex.MECH_LOC_HD ) {
-                    w.RemoveFromTurret( CurMech.GetLoadout().GetHDTurret() );
-                } else if( location == LocationIndex.MECH_LOC_LT ) {
-                    w.RemoveFromTurret( CurMech.GetLoadout().GetLTTurret() );
-                } else if( location == LocationIndex.MECH_LOC_RT ) {
-                    w.RemoveFromTurret( CurMech.GetLoadout().GetRTTurret() );
-                } else {
-                    Media.Messager( this, "Cannot remove from turret!" );
-                    return;
-                }
-            } else {
-                if( location == LocationIndex.MECH_LOC_HD ) {
-                    w.AddToTurret( CurMech.GetLoadout().GetHDTurret() );
-                } else if( location == LocationIndex.MECH_LOC_LT ) {
-                    w.AddToTurret( CurMech.GetLoadout().GetLTTurret() );
-                } else if( location == LocationIndex.MECH_LOC_RT ) {
-                    w.AddToTurret( CurMech.GetLoadout().GetRTTurret() );
-                } else {
-                    Media.Messager( this, "Cannot add to turret!" );
-                    return;
-                }
+                Media.Messager( this, "Invalid turret location!" );
+                return;
             }
         }
         RefreshInfoPane();
@@ -4108,7 +4070,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
     }
 
     public boolean LegalTurretMount( abPlaceable p ) {
-        if( ! (( p instanceof RangedWeapon ) || ( p instanceof MGArray )) ) { return false; }
+        if( ! p.CanMountTurret() ) { return false; }
         int location = CurMech.GetLoadout().Find( p );
         if( location == LocationIndex.MECH_LOC_HD ) {
             if( CurMech.IsOmnimech() ) {

--- a/ssw/src/main/java/ssw/gui/frmMain.java
+++ b/ssw/src/main/java/ssw/gui/frmMain.java
@@ -3560,6 +3560,13 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         mnuSetLotSize.setVisible( lotchange );
         mnuTurret.setVisible( turreted );
         mnuDumper.setVisible( dumper );
+        if( rear ) {
+            if( CurItem.IsMountedRear() ) {
+                mnuMountRear.setText( "Unmount Rear " );
+            } else {
+                mnuMountRear.setText( "Mount Rear " );
+            }
+        }
         if( armor ) {
             if( CurItem.IsArmored() ) {
                 mnuArmorComponent.setText( "Unarmor Component" );
@@ -3676,22 +3683,6 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
             } else {
                 mnuUnallocateAll.setText( "Unallocate All" );
                 mnuUnallocateAll.setEnabled( false );
-            }
-            if( c == lstHDCrits || c == lstCTCrits || c == lstLTCrits || c == lstRTCrits || c == lstLLCrits || c == lstRLCrits || ( CurMech.IsQuad() && (c == lstRACrits || c == lstLACrits))) {
-                if( CurItem.CanMountRear() ) {
-                    mnuMountRear.setEnabled( true );
-                    if( CurItem.IsMountedRear() ) {
-                        mnuMountRear.setText( "Unmount Rear " );
-                    } else {
-                        mnuMountRear.setText( "Mount Rear " );
-                    }
-                } else {
-                    mnuMountRear.setEnabled( false );
-                    mnuMountRear.setText( "Mount Rear " );
-                }
-            } else {
-                mnuMountRear.setEnabled( false );
-                mnuMountRear.setText( "Mount Rear " );
             }
             if( CurItem.Contiguous() ) {
                 EquipmentCollection C = CurMech.GetLoadout().GetCollection( CurItem );

--- a/ssw/src/main/java/ssw/gui/frmMain.java
+++ b/ssw/src/main/java/ssw/gui/frmMain.java
@@ -2018,15 +2018,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
 
         // now let's ensure that all the omni controls are enabled or disabled
         // as appropriate
-        if( chkOmnimech.isEnabled() ) {
-            if( chkOmnimech.isSelected() ) {
-                btnLockChassis.setEnabled( true );
-            } else {
-                btnLockChassis.setEnabled( false );
-            }
-        } else {
-            btnLockChassis.setEnabled( false );
-        }
+        btnLockChassis.setEnabled( chkOmnimech.isEnabled() && chkOmnimech.isSelected() );
     }
 
     private void SaveOmniFluffInfo() {
@@ -3249,7 +3241,6 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
 
     private void LockGUIForOmni() {
         // this locks most of the BFB.GUI controls.  Used mainly by Omnimechs.
-        chkOmnimech.setSelected( true );
         chkOmnimech.setEnabled( false );
         mnuUnlock.setEnabled( true );
         cmbTonnage.setEnabled( false );
@@ -3365,7 +3356,6 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
     private void UnlockGUIFromOmni() {
         // this should be used anytime a new mech is made or when unlocking
         // an omnimech.
-        chkOmnimech.setSelected( false );
         chkOmnimech.setEnabled( true );
         mnuUnlock.setEnabled( false );
         cmbTonnage.setEnabled( true );
@@ -3395,7 +3385,6 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         btnEfficientArmor.setEnabled( true );
         btnBalanceArmor.setEnabled( true );
         cmbJumpJetType.setEnabled( true );
-        btnLockChassis.setEnabled( true );
         chkFCSAIV.setEnabled( true );
         chkFCSAV.setEnabled( true );
         chkFCSApollo.setEnabled( true );
@@ -3413,7 +3402,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
         chkHDTurret.setEnabled( true );
         chkLTTurret.setEnabled( true );
         chkRTTurret.setEnabled( true );
-        btnLockChassis.setEnabled( false );
+        btnLockChassis.setEnabled( chkOmnimech.isSelected() );
         spnWalkMP.setEnabled( true );
         chkYearRestrict.setEnabled( true );
         chkNullSig.setEnabled( true );
@@ -12560,7 +12549,6 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
 
         // make it an omni
         CurMech.SetOmnimech( VariantName );
-        chkOmnimech.setEnabled( false );
         FixTransferHandlers();
         SetLoadoutArrays();
         FixJJSpinnerModel();
@@ -12574,11 +12562,7 @@ public class frmMain extends javax.swing.JFrame implements java.awt.datatransfer
     }//GEN-LAST:event_btnLockChassisActionPerformed
 
     private void chkOmnimechActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_chkOmnimechActionPerformed
-        if( chkOmnimech.isSelected() ) {
-            btnLockChassis.setEnabled( true );
-        } else {
-            btnLockChassis.setEnabled( false );
-        }
+        btnLockChassis.setEnabled( chkOmnimech.isSelected() );
     }//GEN-LAST:event_chkOmnimechActionPerformed
 
     private void btnAddVariantActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnAddVariantActionPerformed
@@ -13280,6 +13264,7 @@ public void LoadMechIntoGUI() {
     txtMechModel.setText( CurMech.GetModel() );
 
     if( CurMech.IsOmnimech() ) {
+        chkOmnimech.setSelected( true );
         LockGUIForOmni();
         RefreshOmniVariants();
         RefreshOmniChoices();

--- a/ssw/src/main/java/ssw/gui/frmMainWide.java
+++ b/ssw/src/main/java/ssw/gui/frmMainWide.java
@@ -3491,6 +3491,7 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
 
     private void ConfigureUtilsMenu( java.awt.Component c ) {
         // configures the utilities popup menu
+        boolean rear = LegalRearMount( CurItem );
         boolean armor = LegalArmoring( CurItem ) && CommonTools.IsAllowed( abPlaceable.ArmoredAC, CurMech );
         boolean cap = LegalCapacitor( CurItem ) && CommonTools.IsAllowed( PPCCapAC, CurMech );
         boolean insul = LegalInsulator( CurItem ) && CommonTools.IsAllowed( LIAC, CurMech );
@@ -3498,11 +3499,7 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
         boolean caseless = LegalCaseless( CurItem ) && CommonTools.IsAllowed( CaselessAmmoAC, CurMech );
         boolean lotchange = LegalLotChange( CurItem );
         boolean turreted = LegalTurretMount( CurItem );
-        mnuArmorComponent.setEnabled( armor );
-        mnuAddCapacitor.setEnabled( cap );
-        mnuAddInsulator.setEnabled( insul );
-        mnuAddPulseModule.setEnabled(pulseModule);
-        mnuCaseless.setEnabled( caseless );
+        mnuMountRear.setVisible( rear );
         mnuArmorComponent.setVisible( armor );
         mnuAddCapacitor.setVisible( cap );
         mnuAddInsulator.setVisible( insul );
@@ -3510,6 +3507,13 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
         mnuCaseless.setVisible( caseless );
         mnuSetLotSize.setVisible( lotchange );
         mnuTurret.setVisible( turreted );
+        if( rear ) {
+            if( CurItem.IsMountedRear() ) {
+                mnuMountRear.setText( "Unmount Rear " );
+            } else {
+                mnuMountRear.setText( "Mount Rear " );
+            }
+        }
         if( armor ) {
             if( CurItem.IsArmored() ) {
                 mnuArmorComponent.setText( "Unarmor Component" );
@@ -3626,22 +3630,6 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
             } else {
                 mnuUnallocateAll.setText( "Unallocate All" );
                 mnuUnallocateAll.setEnabled( false );
-            }
-            if( c == lstHDCrits || c == lstCTCrits || c == lstLTCrits || c == lstRTCrits || c == lstLLCrits || c == lstRLCrits  || ( CurMech.IsQuad() && (c == lstRACrits || c == lstLACrits))) {
-                if( CurItem.CanMountRear() ) {
-                    mnuMountRear.setEnabled( true );
-                    if( CurItem.IsMountedRear() ) {
-                        mnuMountRear.setText( "Unmount Rear " );
-                    } else {
-                        mnuMountRear.setText( "Mount Rear " );
-                    }
-                } else {
-                    mnuMountRear.setEnabled( false );
-                    mnuMountRear.setText( "Mount Rear " );
-                }
-            } else {
-                mnuMountRear.setEnabled( false );
-                mnuMountRear.setText( "Mount Rear " );
             }
             if( CurItem.Contiguous() ) {
                 EquipmentCollection C = CurMech.GetLoadout().GetCollection( CurItem );
@@ -3953,6 +3941,23 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
                 }
                 RefreshInfoPane();
             }
+        }
+    }
+
+    public boolean LegalRearMount( abPlaceable p ) {
+        switch( CurMech.GetLoadout().Find( p ) ) {
+            case LocationIndex.MECH_LOC_HD:
+            case LocationIndex.MECH_LOC_CT:
+            case LocationIndex.MECH_LOC_LT:
+            case LocationIndex.MECH_LOC_RT:
+            case LocationIndex.MECH_LOC_LL:
+            case LocationIndex.MECH_LOC_RL:
+                return CurItem.CanMountRear();
+            case LocationIndex.MECH_LOC_LA:
+            case LocationIndex.MECH_LOC_RA:
+                return CurMech.IsQuad() && CurItem.CanMountRear();
+            default:
+                return false;
         }
     }
 

--- a/ssw/src/main/java/ssw/gui/frmMainWide.java
+++ b/ssw/src/main/java/ssw/gui/frmMainWide.java
@@ -3517,8 +3517,8 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
                 mnuArmorComponent.setText( "Armor Component" );
             }
         }
-        if( turreted && ( CurItem instanceof RangedWeapon ) ) {
-            if( ((RangedWeapon) CurItem).IsTurreted() ) {
+        if( turreted ) {
+            if( CurItem.IsTurreted() ) {
                 mnuTurret.setText( "Remove from Turret" );
             } else {
                 mnuTurret.setText( "Add to Turret");
@@ -3814,57 +3814,19 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
     }
 
     private void TurretMount() {
-        if( CurItem instanceof RangedWeapon ) {
-            RangedWeapon w = (RangedWeapon) CurItem;
+        if( CurItem.IsTurreted() ) {
+            CurItem.MountTurret( null );
+        } else {
             int location = CurMech.GetLoadout().Find( CurItem );
-            if( w.IsTurreted() ) {
-                if( location == LocationIndex.MECH_LOC_HD ) {
-                    w.RemoveFromTurret( CurMech.GetLoadout().GetHDTurret() );
-                } else if( location == LocationIndex.MECH_LOC_LT ) {
-                    w.RemoveFromTurret( CurMech.GetLoadout().GetLTTurret() );
-                } else if( location == LocationIndex.MECH_LOC_RT ) {
-                    w.RemoveFromTurret( CurMech.GetLoadout().GetRTTurret() );
-                } else {
-                    Media.Messager( this, "Cannot remove from turret!" );
-                    return;
-                }
+            if( location == LocationIndex.MECH_LOC_HD ) {
+                CurItem.MountTurret( CurMech.GetLoadout().GetHDTurret() );
+            } else if( location == LocationIndex.MECH_LOC_LT ) {
+                CurItem.MountTurret( CurMech.GetLoadout().GetLTTurret() );
+            } else if( location == LocationIndex.MECH_LOC_RT ) {
+                CurItem.MountTurret( CurMech.GetLoadout().GetRTTurret() );
             } else {
-                if( location == LocationIndex.MECH_LOC_HD ) {
-                    w.AddToTurret( CurMech.GetLoadout().GetHDTurret() );
-                } else if( location == LocationIndex.MECH_LOC_LT ) {
-                    w.AddToTurret( CurMech.GetLoadout().GetLTTurret() );
-                } else if( location == LocationIndex.MECH_LOC_RT ) {
-                    w.AddToTurret( CurMech.GetLoadout().GetRTTurret() );
-                } else {
-                    Media.Messager( this, "Cannot add to turret!" );
-                    return;
-                }
-            }
-        } else if( CurItem instanceof MGArray ) {
-            MGArray w = (MGArray) CurItem;
-            int location = CurMech.GetLoadout().Find( CurItem );
-            if( w.IsTurreted() ) {
-                if( location == LocationIndex.MECH_LOC_HD ) {
-                    w.RemoveFromTurret( CurMech.GetLoadout().GetHDTurret() );
-                } else if( location == LocationIndex.MECH_LOC_LT ) {
-                    w.RemoveFromTurret( CurMech.GetLoadout().GetLTTurret() );
-                } else if( location == LocationIndex.MECH_LOC_RT ) {
-                    w.RemoveFromTurret( CurMech.GetLoadout().GetRTTurret() );
-                } else {
-                    Media.Messager( this, "Cannot remove from turret!" );
-                    return;
-                }
-            } else {
-                if( location == LocationIndex.MECH_LOC_HD ) {
-                    w.AddToTurret( CurMech.GetLoadout().GetHDTurret() );
-                } else if( location == LocationIndex.MECH_LOC_LT ) {
-                    w.AddToTurret( CurMech.GetLoadout().GetLTTurret() );
-                } else if( location == LocationIndex.MECH_LOC_RT ) {
-                    w.AddToTurret( CurMech.GetLoadout().GetRTTurret() );
-                } else {
-                    Media.Messager( this, "Cannot add to turret!" );
-                    return;
-                }
+                Media.Messager( this, "Invalid turret location!" );
+                return;
             }
         }
         RefreshInfoPane();
@@ -4049,7 +4011,7 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
     }
 
     public boolean LegalTurretMount( abPlaceable p ) {
-        if( ! (( p instanceof RangedWeapon ) || ( p instanceof MGArray )) ) { return false; }
+        if( ! p.CanMountTurret() ) { return false; }
         int location = CurMech.GetLoadout().Find( p );
         if( location == LocationIndex.MECH_LOC_HD ) {
             if( CurMech.IsOmnimech() ) {

--- a/ssw/src/main/java/ssw/gui/frmMainWide.java
+++ b/ssw/src/main/java/ssw/gui/frmMainWide.java
@@ -2012,15 +2012,7 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
 
         // now let's ensure that all the omni controls are enabled or disabled
         // as appropriate
-        if( chkOmnimech.isEnabled() ) {
-            if( chkOmnimech.isSelected() ) {
-                btnLockChassis.setEnabled( true );
-            } else {
-                btnLockChassis.setEnabled( false );
-            }
-        } else {
-            btnLockChassis.setEnabled( false );
-        }
+        btnLockChassis.setEnabled( chkOmnimech.isEnabled() && chkOmnimech.isSelected() );
     }
 
     private void SaveOmniFluffInfo() {
@@ -3314,7 +3306,6 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
     private void UnlockGUIFromOmni() {
         // this should be used anytime a new mech is made or when unlocking
         // an omnimech.
-        chkOmnimech.setSelected( false );
         chkOmnimech.setEnabled( true );
         mnuUnlock.setEnabled( false );
         cmbTonnage.setEnabled( true );
@@ -3344,7 +3335,6 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
         btnEfficientArmor.setEnabled( true );
         btnBalanceArmor.setEnabled( true );
         cmbJumpJetType.setEnabled( true );
-        btnLockChassis.setEnabled( true );
         chkFCSAIV.setEnabled( true );
         chkFCSAV.setEnabled( true );
         chkFCSApollo.setEnabled( true );
@@ -3362,7 +3352,7 @@ public class frmMainWide extends javax.swing.JFrame implements java.awt.datatran
         chkHDTurret.setEnabled( true );
         chkLTTurret.setEnabled( true );
         chkRTTurret.setEnabled( true );
-        btnLockChassis.setEnabled( false );
+        btnLockChassis.setEnabled( chkOmnimech.isSelected() );
         spnWalkMP.setEnabled( true );
         chkYearRestrict.setEnabled( true );
         chkNullSig.setEnabled( true );
@@ -10602,6 +10592,7 @@ public void LoadMechIntoGUI() {
     txtMechModel.setText( CurMech.GetModel() );
 
     if( CurMech.IsOmnimech() ) {
+        chkOmnimech.setSelected( true );
         LockGUIForOmni();
         RefreshOmniVariants();
         RefreshOmniChoices();
@@ -13405,7 +13396,6 @@ private void btnLockChassisActionPerformed(java.awt.event.ActionEvent evt) {//GE
 
     // make it an omni
     CurMech.SetOmnimech( VariantName );
-    chkOmnimech.setEnabled( false );
     FixTransferHandlers();
     SetLoadoutArrays();
     FixJJSpinnerModel();
@@ -13702,11 +13692,7 @@ private void cmbMechTypeActionPerformed(java.awt.event.ActionEvent evt) {//GEN-F
 }//GEN-LAST:event_cmbMechTypeActionPerformed
 
 private void chkOmnimechActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_chkOmnimechActionPerformed
-    if( chkOmnimech.isSelected() ) {
-        btnLockChassis.setEnabled( true );
-    } else {
-        btnLockChassis.setEnabled( false );
-    }
+    btnLockChassis.setEnabled( chkOmnimech.isSelected() );
 }//GEN-LAST:event_chkOmnimechActionPerformed
 
 private void cmbPhysEnhanceActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cmbPhysEnhanceActionPerformed

--- a/ssw/src/main/java/ssw/gui/thHDTransferHandler.java
+++ b/ssw/src/main/java/ssw/gui/thHDTransferHandler.java
@@ -129,6 +129,7 @@ public class thHDTransferHandler extends TransferHandler {
 
         LocationDragDatagram DropItem = null;
         boolean rear = false;
+        boolean turreted = false;
         // get the item data
         try {
             DropItem = (LocationDragDatagram) info.getTransferable().getTransferData( new DataFlavor( LocationDragDatagram.class, "Location Drag Datagram" ) );
@@ -149,6 +150,7 @@ public class thHDTransferHandler extends TransferHandler {
             // from another location
             a = CurMech.GetLoadout().GetCrits( DropItem.Location )[DropItem.SourceIndex];
             rear = a.IsMountedRear();
+            turreted = a.IsTurreted();
             if( a.CanSplit() && a.Contiguous() ) {
                 CurMech.GetLoadout().UnallocateAll( a, false );
             } else {
@@ -170,6 +172,9 @@ public class thHDTransferHandler extends TransferHandler {
             CurMech.GetLoadout().RemoveFromQueue( a );
         }
         a.MountRear( rear );
+        if( turreted ) {
+            a.MountTurret( CurMech.GetLoadout().GetHDTurret() );
+        }
         Parent.RefreshSummary();
         Parent.RefreshInfoPane();
         return true;

--- a/ssw/src/main/java/ssw/gui/thLTTransferHandler.java
+++ b/ssw/src/main/java/ssw/gui/thLTTransferHandler.java
@@ -183,6 +183,7 @@ public class thLTTransferHandler extends TransferHandler {
 
         LocationDragDatagram DropItem = null;
         boolean rear = false;
+        boolean turreted = false;
         // get the item data
         try {
             DropItem = (LocationDragDatagram) info.getTransferable().getTransferData( new DataFlavor( LocationDragDatagram.class, "Location Drag Datagram" ) );
@@ -204,6 +205,7 @@ public class thLTTransferHandler extends TransferHandler {
             // from another location
             a = CurMech.GetLoadout().GetCrits( DropItem.Location )[DropItem.SourceIndex];
             rear = a.IsMountedRear();
+            turreted = a.IsTurreted();
             if( a.CanSplit() && a.Contiguous() ) {
                 // find all locations before unallocating
                 v = CurMech.GetLoadout().FindSplitIndex( a );
@@ -269,6 +271,9 @@ public class thLTTransferHandler extends TransferHandler {
             CurMech.GetLoadout().RemoveFromQueue( a );
         }
         a.MountRear( rear );
+        if( turreted ) {
+            a.MountTurret( CurMech.GetLoadout().GetLTTurret() );
+        }
         if( a instanceof VehicularGrenadeLauncher ) {
             // reset the arc as it may not be appropriate
             ((VehicularGrenadeLauncher ) a).SetArcFore();

--- a/ssw/src/main/java/ssw/gui/thRTTransferHandler.java
+++ b/ssw/src/main/java/ssw/gui/thRTTransferHandler.java
@@ -183,6 +183,7 @@ public class thRTTransferHandler extends TransferHandler {
 
         LocationDragDatagram DropItem = null;
         boolean rear = false;
+        boolean turreted = false;
         // get the item data
         try {
             DropItem = (LocationDragDatagram) info.getTransferable().getTransferData( new DataFlavor( LocationDragDatagram.class, "Location Drag Datagram" ) );
@@ -204,6 +205,7 @@ public class thRTTransferHandler extends TransferHandler {
             // from another location
             a = CurMech.GetLoadout().GetCrits( DropItem.Location )[DropItem.SourceIndex];
             rear = a.IsMountedRear();
+            turreted = a.IsTurreted();
             if( a.CanSplit() && a.Contiguous() ) {
                 // find all locations before unallocating
                 v = CurMech.GetLoadout().FindSplitIndex( a );
@@ -269,6 +271,9 @@ public class thRTTransferHandler extends TransferHandler {
             CurMech.GetLoadout().RemoveFromQueue( a );
         }
         a.MountRear( rear );
+        if( turreted ) {
+            a.MountTurret( CurMech.GetLoadout().GetRTTurret() );
+        }
         if( a instanceof VehicularGrenadeLauncher ) {
             // reset the arc as it may not be appropriate
             ((VehicularGrenadeLauncher ) a).SetArcFore();

--- a/sswlib/src/main/java/components/Ammunition.java
+++ b/sswlib/src/main/java/components/Ammunition.java
@@ -325,6 +325,12 @@ public class Ammunition extends abPlaceable {
         return false;
     }
 
+    @Override
+    public boolean CanMountTurret() {
+        // Ammunition can never be mounted in a turret
+        return false;
+    }
+
     public Ammunition Clone() {
         return new Ammunition( this );
     }

--- a/sswlib/src/main/java/components/BipedLoadout.java
+++ b/sswlib/src/main/java/components/BipedLoadout.java
@@ -2221,17 +2221,6 @@ public boolean IsTripod(){
             if( ((RangedWeapon) p).IsUsingPulseModule() ) {
                 UnallocateAll( ((RangedWeapon) p).GetPulseModule(), true );
             }
-            if( ((RangedWeapon) p).IsTurreted() ) {
-                if( ((RangedWeapon) p).GetTurret() == HDTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( HDTurret );
-                }
-                if( ((RangedWeapon) p).GetTurret() == LTTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( LTTurret );
-                }
-                if( ((RangedWeapon) p).GetTurret() == RTTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( RTTurret );
-                }
-            }
         }
 
         // if the item is an MG Array, check for it's MGs and unallocate
@@ -2239,6 +2228,10 @@ public boolean IsTripod(){
             for( int i = 0; i < ((MGArray) p).GetMGs().length; i++ ) {
                 UnallocateAll( ((MGArray) p).GetMGs()[i], true );
             }
+        }
+
+        if( p.IsTurreted() ) {
+            p.MountTurret( null );
         }
 
         Owner.SetChanged( true );
@@ -2339,17 +2332,6 @@ public boolean IsTripod(){
             if( ((RangedWeapon) p).IsUsingPulseModule() ) {
                 UnallocateAll( ((RangedWeapon) p).GetPulseModule(), true );
             }
-            if( ((RangedWeapon) p).IsTurreted() ) {
-                if( ((RangedWeapon) p).GetTurret() == HDTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( HDTurret );
-                }
-                if( ((RangedWeapon) p).GetTurret() == LTTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( LTTurret );
-                }
-                if( ((RangedWeapon) p).GetTurret() == RTTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( RTTurret );
-                }
-            }
         }
 
         // if the item is an MG Array, check for it's MGs and unallocate
@@ -2357,6 +2339,10 @@ public boolean IsTripod(){
             for( int i = 0; i < ((MGArray) p).GetMGs().length; i++ ) {
                 UnallocateAll( ((MGArray) p).GetMGs()[i], true );
             }
+        }
+
+        if( p.IsTurreted() ) {
+            p.MountTurret( null );
         }
 
         Owner.SetChanged( true );
@@ -4922,13 +4908,9 @@ public boolean IsTripod(){
 
     private void ClearTurretWeapons( MechTurret t ) {
         for( int i = 0; i < NonCore.size(); i++ ) {
-            if( NonCore.get( i ) instanceof RangedWeapon ) {
-                RangedWeapon w = (RangedWeapon) NonCore.get( i );
-                if( w.IsTurreted() ) {
-                    if( w.GetTurret() == t ) {
-                        w.RemoveFromTurret( t );
-                    }
-                }
+            abPlaceable p = (abPlaceable) NonCore.get( i );
+            if( p.GetTurret() == t ) {
+                p.MountTurret( null );
             }
         }
     }

--- a/sswlib/src/main/java/components/BipedLoadout.java
+++ b/sswlib/src/main/java/components/BipedLoadout.java
@@ -3163,6 +3163,25 @@ public boolean IsTripod(){
 
     // Private Methods
     private void Allocate( abPlaceable p, int SIndex, abPlaceable[] Loc ) throws Exception {
+        class RemoveEntry {
+            abPlaceable p;
+            boolean rear;
+            ifTurret turret;
+
+            RemoveEntry( int AddInLoc, int i ) {
+                // we've already ensured that it is not location locked
+                // above, so put the item back into the queue.
+                p = Loc[i];
+                rear = p.IsMountedRear();
+                turret = p.GetTurret();
+                if( p.CanSplit() && p.Contiguous() ) {
+                    UnallocateAll( Loc[i], false );
+                } else {
+                    UnallocateByIndex( AddInLoc, Loc  );
+                }
+            }
+        }
+
         // Adds the specified placeable to the given location at the specified
         // stating index.  Throws Exceptions with error messages if things went
         // wrong.
@@ -3170,14 +3189,16 @@ public boolean IsTripod(){
         if (p instanceof Equipment) {
             ((Equipment) p).ValidateMaxPerLocation(Loc);
         }
+
+        // TODO: this snapshot thing doesn't work (see its usage below), commented out for now
         // Let's get a snapshot of the location so we can reset it if we have to.
-        abPlaceable SnapShot[] = Loc.clone();
+        //abPlaceable SnapShot[] = Loc.clone();
 
         // we have to accomodate for Artemis IV systems
         boolean AddIn = false;
         boolean ArrayGood = false;
         int AddInSize = 1;
-        ArrayList removed = new ArrayList(), rears = new ArrayList();
+        ArrayList<RemoveEntry> removed = new ArrayList<>();
 
         // check for generic placement
         if( SIndex == -1 ) {
@@ -3290,17 +3311,7 @@ public boolean IsTripod(){
                 for( i = SIndex; i < ( p.NumCrits() + SIndex ); i++ ) {
                     // is there a non-location locked item there?
                     if( Loc[i] != NoItem ) {
-                        // we've already ensured that it is not location locked
-                        // above, so put the item back into the queue.
-                        if( Loc[i].CanSplit() && Loc[i].Contiguous() ) {
-                            removed.add( Loc[i] );
-                            rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                            UnallocateAll( Loc[i], false );
-                        } else {
-                            removed.add( Loc[i] );
-                            rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                            UnallocateByIndex( i, Loc );
-                        }
+                        removed.add( new RemoveEntry( i, i ) );
                     }
                     // finally, allocate the item slot
                     Loc[i] = p;
@@ -3311,17 +3322,7 @@ public boolean IsTripod(){
                 if( p instanceof RangedWeapon ) {
                     if( ((RangedWeapon) p).IsUsingFCS() ) {
                         if( Loc[AddInLoc] != NoItem ) {
-                            // we've already ensured that it is not location locked
-                            // above, so put the item back into the queue.
-                            if( Loc[i].CanSplit() && Loc[i].Contiguous() ) {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateAll( Loc[i], false );
-                            } else {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateByIndex( AddInLoc, Loc  );
-                            }
+                            removed.add( new RemoveEntry( AddInLoc, i ) );
                         }
                         for( int j = AddInLoc; j < AddInSize + AddInLoc; j++ ) {
                             Loc[j] = (abPlaceable) ((RangedWeapon) p).GetFCS();
@@ -3329,49 +3330,19 @@ public boolean IsTripod(){
                     }
                     if( ((RangedWeapon) p).IsUsingCapacitor() ) {
                         if( Loc[AddInLoc] != NoItem ) {
-                            // we've already ensured that it is not location locked
-                            // above, so put the item back into the queue.
-                            if( Loc[i].CanSplit() && Loc[i].Contiguous() ) {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateAll( Loc[i], false );
-                            } else {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateByIndex( AddInLoc, Loc  );
-                            }
+                            removed.add( new RemoveEntry( AddInLoc, i ) );
                         }
                         Loc[AddInLoc] = ((RangedWeapon) p).GetCapacitor();
                     }
                     if( ((RangedWeapon) p).IsUsingInsulator() ) {
                         if( Loc[AddInLoc] != NoItem ) {
-                            // we've already ensured that it is not location locked
-                            // above, so put the item back into the queue.
-                            if( Loc[i].CanSplit() && Loc[i].Contiguous() ) {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateAll( Loc[i], false );
-                            } else {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateByIndex( AddInLoc, Loc  );
-                            }
+                            removed.add( new RemoveEntry( AddInLoc, i ) );
                         }
                         Loc[AddInLoc] = ((RangedWeapon) p).GetInsulator();
                     }
                     if( ((RangedWeapon) p).IsUsingPulseModule() ) {
                         if( Loc[AddInLoc] != NoItem ) {
-                            // we've already ensured that it is not location locked
-                            // above, so put the item back into the queue.
-                            if( Loc[i].CanSplit() && Loc[i].Contiguous() ) {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateAll( Loc[i], false );
-                            } else {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateByIndex( AddInLoc, Loc  );
-                            }
+                            removed.add( new RemoveEntry( AddInLoc, i ) );
                         }
                         Loc[AddInLoc] = ((RangedWeapon) p).GetPulseModule();
                     }
@@ -3381,16 +3352,7 @@ public boolean IsTripod(){
                 if( p instanceof MGArray ) {
                     for( i = 0; i < ((MGArray) p).GetNumMGs(); i++ ) {
                         if( Loc[MGLocs[i]] != NoItem ) {
-                            // we know it's not location locked, so kick it out
-                            if( Loc[MGLocs[i]].CanSplit() && Loc[MGLocs[i]].Contiguous() ) {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateAll( Loc[MGLocs[i]], false );
-                            } else {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateByIndex( MGLocs[i], Loc );
-                            }
+                            removed.add( new RemoveEntry( MGLocs[i], i ) );
                         }
                         Loc[MGLocs[i]] = ((MGArray) p).GetMGs()[i];
                     }
@@ -3408,16 +3370,7 @@ public boolean IsTripod(){
 
                     // if there is an item there, put it back in the queue
                     if( Loc[SIndex] != NoItem ) {
-                        // put the item back into the queue
-                        if( Loc[SIndex].CanSplit() && Loc[SIndex].Contiguous() ) {
-                            removed.add( Loc[SIndex] );
-                            rears.add( new Boolean( Loc[SIndex].IsMountedRear() ) );
-                            UnallocateAll( Loc[SIndex], false );
-                        } else {
-                            removed.add( Loc[SIndex] );
-                            rears.add( new Boolean( Loc[SIndex].IsMountedRear() ) );
-                            UnallocateByIndex( SIndex, Loc );
-                        }
+                        removed.add( new RemoveEntry( SIndex, SIndex ) );
                     }
 
                     // now allocate the item.
@@ -3432,16 +3385,18 @@ public boolean IsTripod(){
             }
 
             // now that allocation is finished, add in the removed items if possible
-            for( int i = 0; i < removed.size(); i++ ) {
+            for( RemoveEntry remove : removed ) {
                 // no error handling here since the items are already in the queue
                 try {
-                    Allocate( (abPlaceable) removed.get( i ), -1, Loc );
-                    ((abPlaceable) removed.get( i )).MountRear( ((Boolean) rears.get( i )));
+                    Allocate( remove.p, -1, Loc );
+                    remove.p.MountRear( remove.rear );
+                    remove.p.MountTurret( remove.turret );
                 } catch( Exception e1 ) { }
             }
         } catch ( ArrayIndexOutOfBoundsException e ) {
+            // TODO: Following snapshot thing actually does nothing
             // reset the location
-            Loc = SnapShot;
+            //Loc = SnapShot;
 
             // tell the user what happened.
             if( p instanceof RangedWeapon ) {

--- a/sswlib/src/main/java/components/CVLoadout.java
+++ b/sswlib/src/main/java/components/CVLoadout.java
@@ -364,32 +364,16 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
                     throw new Exception(p.ActualName() + " cannot be allocated to the Side.");
                 break;
             case LocationIndex.CV_LOC_TURRET1:
-                if ( p.CanAllocCVTurret() ) {
+                if ( p.CanAllocCVTurret() )
                     Turret1Items.add(p);
-                    if ( Turret1.isTonnageSet() ) {
-                        double tons = Turret1.GetTonnageFromItems();
-                        if ( tons > Turret1.GetMaxTonnage() ) {
-                            Turret1Items.remove(p);
-                            throw new Exception( String.format( "Turret is out of space: %.1f/%.1f",
-                                    tons, Turret1.GetMaxTonnage()) );
-                        }
-                    }
-                } else
+                else
                     throw new Exception(p.ActualName() + " cannot be allocated to the Turret.");
                 
                 break;
             case LocationIndex.CV_LOC_TURRET2:
-                if ( p.CanAllocCVTurret() ) {
+                if ( p.CanAllocCVTurret() )
                     Turret2Items.add(p);
-                    if ( Turret2.isTonnageSet() ) {
-                        double tons = Turret2.GetTonnageFromItems();
-                        if ( tons > Turret2.GetMaxTonnage() ) {
-                            Turret2Items.remove(p);
-                            throw new Exception( String.format( "Turret is out of space: %.1f/%.1f",
-                                    tons, Turret2.GetMaxTonnage()) );
-                        }
-                    }
-                } else
+                else
                     throw new Exception(p.ActualName() + " cannot be allocated to the Rear Turret.");
                 break;
             case LocationIndex.CV_LOC_SPONSON_LEFT:

--- a/sswlib/src/main/java/components/CVLoadout.java
+++ b/sswlib/src/main/java/components/CVLoadout.java
@@ -793,8 +793,8 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
         clone.SetRightItems( (ArrayList<abPlaceable>)RightItems.clone() );
         clone.SetBodyItems( (ArrayList<abPlaceable>)BodyItems.clone() );
         clone.SetRearItems( (ArrayList<abPlaceable>)RearItems.clone() );
-        clone.SetTurret1( (ArrayList<abPlaceable>)Turret1Items.clone() );
-        clone.SetTurret2( (ArrayList<abPlaceable>)Turret2Items.clone() );
+        clone.SetTurret1Items( (ArrayList<abPlaceable>)Turret1Items.clone() );
+        clone.SetTurret2Items( (ArrayList<abPlaceable>)Turret2Items.clone() );
         clone.SetSponsonTurretLeftItems((ArrayList<abPlaceable>) SponsonTurretLeftItems.clone());
         clone.SetSponsonTurretRightItems((ArrayList<abPlaceable>) SponsonTurretRightItems.clone());
 
@@ -822,6 +822,7 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
         clone.SetTurret(Turret1);
         clone.SetRearTurret(Turret2);
         clone.SetSponsonTurretLeft(SponsonTurretLeft);
+        clone.SetSponsonTurretRight(SponsonTurretRight);
 
         return clone;
     }
@@ -855,11 +856,11 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
         BodyItems = c;
     }
 
-    public void SetTurret1(ArrayList<abPlaceable> c) {
+    public void SetTurret1Items(ArrayList<abPlaceable> c) {
         Turret1Items = c;
     }
 
-    public void SetTurret2(ArrayList<abPlaceable> c) {
+    public void SetTurret2Items(ArrayList<abPlaceable> c) {
         Turret2Items =  c;
     }
 

--- a/sswlib/src/main/java/components/CVLoadout.java
+++ b/sswlib/src/main/java/components/CVLoadout.java
@@ -366,10 +366,12 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
             case LocationIndex.CV_LOC_TURRET1:
                 if ( p.CanAllocCVTurret() ) {
                     Turret1Items.add(p);
-                    if ( Owner.IsOmni() ) {
-                        if ( Turret1.GetTonnage() > Turret1.GetMaxTonnage()  ) {
+                    if ( Turret1.isTonnageSet() ) {
+                        double tons = Turret1.GetTonnageFromItems();
+                        if ( tons > Turret1.GetMaxTonnage() ) {
                             Turret1Items.remove(p);
-                            throw new Exception("Turret is out of space");
+                            throw new Exception( String.format( "Turret is out of space: %.1f/%.1f",
+                                    tons, Turret1.GetMaxTonnage()) );
                         }
                     }
                 } else
@@ -377,9 +379,17 @@ public class CVLoadout implements ifCVLoadout, ifLoadout {
                 
                 break;
             case LocationIndex.CV_LOC_TURRET2:
-                if ( p.CanAllocCVTurret() )
+                if ( p.CanAllocCVTurret() ) {
                     Turret2Items.add(p);
-                else
+                    if ( Turret2.isTonnageSet() ) {
+                        double tons = Turret2.GetTonnageFromItems();
+                        if ( tons > Turret2.GetMaxTonnage() ) {
+                            Turret2Items.remove(p);
+                            throw new Exception( String.format( "Turret is out of space: %.1f/%.1f",
+                                    tons, Turret2.GetMaxTonnage()) );
+                        }
+                    }
+                } else
                     throw new Exception(p.ActualName() + " cannot be allocated to the Rear Turret.");
                 break;
             case LocationIndex.CV_LOC_SPONSON_LEFT:

--- a/sswlib/src/main/java/components/CombatVehicle.java
+++ b/sswlib/src/main/java/components/CombatVehicle.java
@@ -175,6 +175,7 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
         CurLoadout = new CVLoadout(this);
         CurLoadout.GetHeatSinks().SetSingle();
         MainLoadout = CurLoadout;
+        CurLoadout.SetBaseLoadout( MainLoadout );
 
         Quirks = new ArrayList<Quirk>();
 
@@ -1401,7 +1402,7 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
         this.HasTurret1 = HasTurret1;
         //Move any weapons/equipment that was in the turret to another location
         if (!HasTurret1) {
-            GetLoadout().SetTurret1(new ArrayList<abPlaceable>());
+            GetLoadout().SetTurret1Items(new ArrayList<abPlaceable>());
             GetLoadout().RefreshHeatSinks();
             CurArmor.SetArmor(LocationIndex.CV_LOC_TURRET1, 0);
         }
@@ -1415,7 +1416,7 @@ public class CombatVehicle implements ifUnit, ifBattleforce {
         this.HasTurret2 = HasTurret2;
         //Move any weapons/equipment that was in the turret to another location
         if (!HasTurret2) {
-            GetLoadout().SetTurret2(new ArrayList<abPlaceable>());
+            GetLoadout().SetTurret2Items(new ArrayList<abPlaceable>());
             GetLoadout().RefreshHeatSinks();
             CurArmor.SetArmor(LocationIndex.CV_LOC_TURRET2, 0);
         }

--- a/sswlib/src/main/java/components/Equipment.java
+++ b/sswlib/src/main/java/components/Equipment.java
@@ -81,6 +81,7 @@ public class Equipment extends abPlaceable implements ifEquipment {
                     RequiresNuclear = false,
                     RequiresPowerAmps = false;
     private transient boolean Rear = false;
+    private transient ifTurret Turret = null;
     @SerializedName("Availability") private AvailableCode AC;
 
     public Equipment() {
@@ -234,14 +235,12 @@ public class Equipment extends abPlaceable implements ifEquipment {
         return ActualName;
     }
 
-    private  String RearName() { return Rear ? "(R) " : ""; }
-
     public String CritName() {
         String retval = CritName;
         if( VariableSize ) {
             retval += " (" + Tonnage + " tons)";
         }
-        return RearName() + retval;
+        return NameModifier() + retval;
     }
 
     @Override
@@ -254,7 +253,7 @@ public class Equipment extends abPlaceable implements ifEquipment {
     }
     
     public String LookupName() {
-        return RearName() + LookupName;
+        return NameModifier() + LookupName;
     }
 
     public String ChatName() {
@@ -262,7 +261,7 @@ public class Equipment extends abPlaceable implements ifEquipment {
     }
 
     public String MegaMekName( boolean UseRear ) {
-        return (MegaMekName + " " + RearName()).trim();
+        return (MegaMekName + " " + NameModifier()).trim();
     }
 
     public String BookReference() {
@@ -434,7 +433,7 @@ public class Equipment extends abPlaceable implements ifEquipment {
 
     @Override
     public boolean CanMountRear() {
-        return CanMountRear;
+        return CanMountRear && ! IsTurreted();
     }
 
     @Override
@@ -445,6 +444,28 @@ public class Equipment extends abPlaceable implements ifEquipment {
     @Override
     public boolean IsMountedRear() {
         return Rear;
+    }
+
+    @Override
+    public boolean CanMountTurret() {
+        return CanAllocCVTurret() && ! IsMountedRear();
+    }
+
+    @Override
+    public void MountTurret( ifTurret t ) {
+        if( Turret == t ) return;
+        if( Turret != null ) {
+            Turret.RemoveItem( this );
+        }
+        if( t != null ) {
+            t.AddItem( this );
+        }
+        Turret = t;
+    }
+
+    @Override
+    public ifTurret GetTurret() {
+        return Turret;
     }
 
     @Override

--- a/sswlib/src/main/java/components/LiftHoist.java
+++ b/sswlib/src/main/java/components/LiftHoist.java
@@ -34,7 +34,6 @@ package components;
  */
 public class LiftHoist extends Equipment implements ifEquipment {
     private final ifUnit Owner;
-    private transient boolean Rear = false;
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
     public LiftHoist(ifUnit l)
     {
@@ -55,14 +54,12 @@ public class LiftHoist extends Equipment implements ifEquipment {
         SetMountableRear(true);
     }
 
-    public String RearName() { return Rear ? "(R) " : ""; }
-
     public String ActualName() {
         return "Lift Hoist";
     }
 
     public String CritName() {
-        return RearName() + "Lift Hoist";
+        return NameModifier() + "Lift Hoist";
     }
 
     @Override
@@ -198,19 +195,5 @@ public class LiftHoist extends Equipment implements ifEquipment {
             return ((CombatVehicle) Owner).IsVTOL();
         }
         return false;
-    }
-
-    @Override
-    public String GetEquipmentType() {
-        return "equipment";
-    }
-
-    @Override
-    public void MountRear( boolean rear ) {
-        Rear = rear;
-    }
-    @Override
-    public boolean IsMountedRear() {
-        return Rear;
     }
 }

--- a/sswlib/src/main/java/components/MGArray.java
+++ b/sswlib/src/main/java/components/MGArray.java
@@ -89,35 +89,17 @@ public class MGArray extends abPlaceable implements ifWeapon {
     // the lookup name is used when we are trying to find the piece of equipment.
     public String LookupName() {
         String retval = GetName();
-        if( Rear ) {
-            if( Clan ) {
-                retval = "(R) (CL) " + retval;
-            } else {
-                retval = "(R) (IS) " + retval;
-            }
+        if( Clan ) {
+            retval = "(CL) " + retval;
         } else {
-            if( Clan ) {
-                retval = "(CL) " + retval;
-            } else {
-                retval = "(IS) " + retval;
-            }
+            retval = "(IS) " + retval;
         }
-        if( IsTurreted() ) {
-            retval = "(T) " + retval;
-        }
-        return retval;
+        return NameModifier() + retval;
     }
 
     // the crit name is how the item appears in the loadout when allocated.
     public String CritName() {
-        String retval = GetShortName();
-        if( Rear ) {
-            retval = "(R) " + retval;
-        }
-        if( IsTurreted() ) {
-            retval = "(T) " + retval;
-        }
-        return retval;
+        return NameModifier() + GetShortName();
     }
 
     // the name to be used when expoerting this equipment to a chat line.
@@ -140,10 +122,7 @@ public class MGArray extends abPlaceable implements ifWeapon {
         } else {
             retval = "IS" + retval;
         }
-        if( Rear ) {
-            retval += " (R)";
-        }
-        return retval;
+        return NameModifier() + retval;
     }
 
     // reference for the book that the equipment comes from
@@ -449,16 +428,12 @@ public class MGArray extends abPlaceable implements ifWeapon {
 
     @Override
     public boolean CanMountRear() {
-        return true;
+        return ! IsTurreted();
     }
 
     @Override
     public void MountRear( boolean rear ) {
         Rear = rear;
-        if( MGs[0] != null ) { MGs[0].MountRear( rear ); }
-        if( MGs[1] != null ) { MGs[1].MountRear( rear ); }
-        if( MGs[2] != null ) { MGs[2].MountRear( rear ); }
-        if( MGs[3] != null ) { MGs[3].MountRear( rear ); }
     }
 
     @Override
@@ -476,26 +451,24 @@ public class MGArray extends abPlaceable implements ifWeapon {
         return Manufacturer;
     }
 
-    public boolean AddToTurret( ifTurret t ) {
-        if( t.AddWeapon( this ) ) {
-            Turret = t;
-            return true;
-        } else {
-            Turret = null;
-            return false;
+    @Override
+    public boolean CanMountTurret() {
+        return CanAllocCVTurret() && ! IsMountedRear();
+    }
+
+    @Override
+    public void MountTurret( ifTurret t ) {
+        if( Turret == t ) return;
+        if( Turret != null ) {
+            Turret.RemoveItem( this );
         }
+        if( t != null ) {
+            t.AddItem( this );
+        }
+        Turret = t;
     }
 
-    public void RemoveFromTurret( ifTurret t ) {
-        t.RemoveWeapon( this );
-        Turret = null;
-    }
-
-    public boolean IsTurreted() {
-        if( Turret != null ) { return true; }
-        return false;
-    }
-
+    @Override
     public ifTurret GetTurret() {
         return Turret;
     }

--- a/sswlib/src/main/java/components/MechTurret.java
+++ b/sswlib/src/main/java/components/MechTurret.java
@@ -36,7 +36,7 @@ public class MechTurret extends abPlaceable implements ifTurret {
 
     private ifMechLoadout Owner;
     private AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
-    private Vector<ifWeapon> weapons = new Vector<ifWeapon>();
+    private Vector<abPlaceable> items = new Vector<abPlaceable>();
 
     public MechTurret( ifMechLoadout l ) {
         Owner = l;
@@ -49,43 +49,41 @@ public class MechTurret extends abPlaceable implements ifTurret {
         AC.SetCLFactions( "", "", "PS", "" );
     }
 
-    public boolean AddWeapon( ifWeapon w ) {
-        if( ! (( w instanceof RangedWeapon ) || ( w instanceof MGArray )) ) {
-            return false;
-        }
-        if( w instanceof RangedWeapon ) {
-            //If it can't go in a Vehicle Turret then it can't go in a Mech one.
-            if( !((RangedWeapon) w).CanAllocCVTurret() ) return false;
-            //Make sure if they can split, that they haven't been.
-            if( ((RangedWeapon) w).CanSplit() ) {
-                //Gets all crit slots
-                ArrayList locations = Owner.FindIndexes( (abPlaceable) w );
-                //first one
-                LocationIndex firstSlot = (LocationIndex) locations.get(0);
-                //check all of them
-                for (int i = 0; i < locations.size(); i++) {
-                    //compare to the first. If they are different, it's been split.
-                    LocationIndex currentSlot = ((LocationIndex) locations.get(i));
-                    if (currentSlot.Location != firstSlot.Location)
-                        return false;
-                }
+    @Override
+    public boolean AddItem( abPlaceable p ) {
+        if( ! items.contains( p )) return false;
+        //Make sure if they can split, that they haven't been.
+        if( p.CanSplit() ) {
+            //Gets all crit slots
+            ArrayList locations = Owner.FindIndexes( (abPlaceable) p );
+            //first one
+            LocationIndex firstSlot = (LocationIndex) locations.get(0);
+            //check all of them
+            for (int i = 0; i < locations.size(); i++) {
+                //compare to the first. If they are different, it's been split.
+                LocationIndex currentSlot = ((LocationIndex) locations.get(i));
+                if (currentSlot.Location != firstSlot.Location)
+                    return false;
             }
         }
-        weapons.add( w );
+        items.add( p );
         return true;
     }
 
-    public void RemoveWeapon( ifWeapon w ) {
+    @Override
+    public void RemoveItem( abPlaceable p ) {
         // extra code here!
-        weapons.remove( w );
+        items.remove( p );
     }
 
-    public Vector<ifWeapon> GetWeapons() {
-        return weapons;
+    @Override
+    public Vector<abPlaceable> GetItems() {
+        return items;
     }
 
-    public boolean IsInstalled( ifWeapon w ) {
-        return weapons.contains( w );
+    @Override
+    public boolean IsInstalled( abPlaceable p ) {
+        return items.contains( p );
     }
 
     @Override
@@ -170,8 +168,8 @@ public class MechTurret extends abPlaceable implements ifTurret {
 
     private double GetSize() {
         double retval = 0.0;
-        for( int i = 0; i < weapons.size(); i++ ) {
-            retval += ((abPlaceable) weapons.get( i )).GetTonnage();
+        for( int i = 0; i < items.size(); i++ ) {
+            retval += ((abPlaceable) items.get( i )).GetTonnage();
         }
         if( Owner.GetMech().UsingFractionalAccounting() ) {
             return CommonTools.RoundFractionalTons( retval * 0.1 );

--- a/sswlib/src/main/java/components/MechTurret.java
+++ b/sswlib/src/main/java/components/MechTurret.java
@@ -51,7 +51,7 @@ public class MechTurret extends abPlaceable implements ifTurret {
 
     @Override
     public boolean AddItem( abPlaceable p ) {
-        if( ! items.contains( p )) return false;
+        if( items.contains( p )) return false;
         //Make sure if they can split, that they haven't been.
         if( p.CanSplit() ) {
             //Gets all crit slots

--- a/sswlib/src/main/java/components/QuadLoadout.java
+++ b/sswlib/src/main/java/components/QuadLoadout.java
@@ -1973,17 +1973,6 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
             if( ((RangedWeapon) p).IsUsingPulseModule() ) {
                 UnallocateAll( ((RangedWeapon) p).GetPulseModule(), true );
             }
-            if( ((RangedWeapon) p).IsTurreted() ) {
-                if( ((RangedWeapon) p).GetTurret() == HDTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( HDTurret );
-                }
-                if( ((RangedWeapon) p).GetTurret() == LTTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( LTTurret );
-                }
-                if( ((RangedWeapon) p).GetTurret() == RTTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( RTTurret );
-                }
-            }
         }
 
         // if the item is an MG Array, check for it's MGs and unallocate
@@ -1991,6 +1980,10 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
             for( int i = 0; i < ((MGArray) p).GetMGs().length; i++ ) {
                 UnallocateAll( ((MGArray) p).GetMGs()[i], true );
             }
+        }
+
+        if( p.IsTurreted() ) {
+            p.MountTurret( null );
         }
 
         Owner.SetChanged( true );
@@ -2091,17 +2084,6 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
             if( ((RangedWeapon) p).IsUsingPulseModule() ) {
                 UnallocateAll( ((RangedWeapon) p).GetPulseModule(), true );
             }
-            if( ((RangedWeapon) p).IsTurreted() ) {
-                if( ((RangedWeapon) p).GetTurret() == HDTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( HDTurret );
-                }
-                if( ((RangedWeapon) p).GetTurret() == LTTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( LTTurret );
-                }
-                if( ((RangedWeapon) p).GetTurret() == RTTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( RTTurret );
-                }
-            }
         }
 
         // if the item is an MG Array, check for it's MGs and unallocate
@@ -2109,6 +2091,10 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
             for( int i = 0; i < ((MGArray) p).GetMGs().length; i++ ) {
                 UnallocateAll( ((MGArray) p).GetMGs()[i], true );
             }
+        }
+
+        if( p.IsTurreted() ) {
+            p.MountTurret( null );
         }
 
         Owner.SetChanged( true );
@@ -4635,13 +4621,9 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
 
     private void ClearTurretWeapons( MechTurret t ) {
         for( int i = 0; i < NonCore.size(); i++ ) {
-            if( NonCore.get( i ) instanceof RangedWeapon ) {
-                RangedWeapon w = (RangedWeapon) NonCore.get( i );
-                if( w.IsTurreted() ) {
-                    if( w.GetTurret() == t ) {
-                        w.RemoveFromTurret( t );
-                    }
-                }
+            abPlaceable p = (abPlaceable) NonCore.get( i );
+            if( p.GetTurret() == t ) {
+                p.MountTurret( null );
             }
         }
     }

--- a/sswlib/src/main/java/components/QuadLoadout.java
+++ b/sswlib/src/main/java/components/QuadLoadout.java
@@ -4522,10 +4522,7 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
     }
 
     public boolean CanUseHDTurret() {
-        if( Owner.GetCockpit().IsTorsoMounted() && !HasLTTurret() && !HasRTTurret() ) {
-            return true;
-        }
-        return false;
+        return Owner.GetCockpit().IsTorsoMounted();
     }
 
     public MechTurret GetLTTurret() {
@@ -4579,8 +4576,7 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
     }
 
     public boolean CanUseLTTurret() {
-        if( HasRTTurret() || HasHDTurret() ) { return false; }
-        return true;
+        return ! HasRTTurret();
     }
 
     public MechTurret GetRTTurret() {
@@ -4634,8 +4630,7 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
     }
 
     public boolean CanUseRTTurret() {
-        if( HasLTTurret() || HasHDTurret() ) { return false; }
-        return true;
+        return ! HasLTTurret();
     }
 
     private void ClearTurretWeapons( MechTurret t ) {

--- a/sswlib/src/main/java/components/QuadLoadout.java
+++ b/sswlib/src/main/java/components/QuadLoadout.java
@@ -2907,6 +2907,25 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
 
     // Private Methods
     private void Allocate( abPlaceable p, int SIndex, abPlaceable[] Loc ) throws Exception {
+        class RemoveEntry {
+            abPlaceable p;
+            boolean rear;
+            ifTurret turret;
+
+            RemoveEntry( int AddInLoc, int i ) {
+                // we've already ensured that it is not location locked
+                // above, so put the item back into the queue.
+                p = Loc[i];
+                rear = p.IsMountedRear();
+                turret = p.GetTurret();
+                if( p.CanSplit() && p.Contiguous() ) {
+                    UnallocateAll( Loc[i], false );
+                } else {
+                    UnallocateByIndex( AddInLoc, Loc  );
+                }
+            }
+        }
+
         // Adds the specified placeable to the given location at the specified
         // stating index.  Throws Exceptions with error messages if things went
         // wrong.
@@ -2915,14 +2934,15 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
             ((Equipment) p).ValidateMaxPerLocation(Loc);
         }
 
+        // TODO: this snapshot thing doesn't work (see its usage below), commented out for now
         // Let's get a snapshot of the location so we can reset it if we have to.
-        abPlaceable SnapShot[] = Loc.clone();
+        //abPlaceable SnapShot[] = Loc.clone();
 
         // we have to accomodate for Artemis IV systems
         boolean AddIn = false;
         boolean ArrayGood = false;
         int AddInSize = 1;
-        ArrayList removed = new ArrayList(), rears = new ArrayList();
+        ArrayList<RemoveEntry> removed = new ArrayList<>();
 
         // check for generic placement
         if( SIndex == -1 ) {
@@ -3035,17 +3055,7 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
                 for( i = SIndex; i < ( p.NumCrits() + SIndex ); i++ ) {
                     // is there a non-location locked item there?
                     if( Loc[i] != NoItem ) {
-                        // we've already ensured that it is not location locked
-                        // above, so put the item back into the queue.
-                        if( Loc[i].CanSplit() && Loc[i].Contiguous() ) {
-                            removed.add( Loc[i] );
-                            rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                            UnallocateAll( Loc[i], false );
-                        } else {
-                            removed.add( Loc[i] );
-                            rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                            UnallocateByIndex( i, Loc );
-                        }
+                        removed.add( new RemoveEntry( i, i ) );
                     }
                     // finally, allocate the item slot
                     Loc[i] = p;
@@ -3056,17 +3066,7 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
                 if( p instanceof RangedWeapon ) {
                     if( ((RangedWeapon) p).IsUsingFCS() ) {
                         if( Loc[AddInLoc] != NoItem ) {
-                            // we've already ensured that it is not location locked
-                            // above, so put the item back into the queue.
-                            if( Loc[i].CanSplit() && Loc[i].Contiguous() ) {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateAll( Loc[i], false );
-                            } else {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateByIndex( AddInLoc, Loc  );
-                            }
+                            removed.add( new RemoveEntry( AddInLoc, i ) );
                         }
                         for( int j = AddInLoc; j < AddInSize + AddInLoc; j++ ) {
                             Loc[j] = (abPlaceable) ((RangedWeapon) p).GetFCS();
@@ -3074,49 +3074,19 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
                     }
                     if( ((RangedWeapon) p).IsUsingCapacitor() ) {
                         if( Loc[AddInLoc] != NoItem ) {
-                            // we've already ensured that it is not location locked
-                            // above, so put the item back into the queue.
-                            if( Loc[i].CanSplit() && Loc[i].Contiguous() ) {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateAll( Loc[i], false );
-                            } else {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateByIndex( AddInLoc, Loc  );
-                            }
+                            removed.add( new RemoveEntry( AddInLoc, i ) );
                         }
                         Loc[AddInLoc] = ((RangedWeapon) p).GetCapacitor();
                     }
                     if( ((RangedWeapon) p).IsUsingInsulator() ) {
                         if( Loc[AddInLoc] != NoItem ) {
-                            // we've already ensured that it is not location locked
-                            // above, so put the item back into the queue.
-                            if( Loc[i].CanSplit() && Loc[i].Contiguous() ) {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateAll( Loc[i], false );
-                            } else {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateByIndex( AddInLoc, Loc  );
-                            }
+                            removed.add( new RemoveEntry( AddInLoc, i ) );
                         }
                         Loc[AddInLoc] = ((RangedWeapon) p).GetInsulator();
                     }
                     if( ((RangedWeapon) p).IsUsingPulseModule() ) {
                         if( Loc[AddInLoc] != NoItem ) {
-                            // we've already ensured that it is not location locked
-                            // above, so put the item back into the queue.
-                            if( Loc[i].CanSplit() && Loc[i].Contiguous() ) {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateAll( Loc[i], false );
-                            } else {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateByIndex( AddInLoc, Loc  );
-                            }
+                            removed.add( new RemoveEntry( AddInLoc, i ) );
                         }
                         Loc[AddInLoc] = ((RangedWeapon) p).GetPulseModule();
                     }
@@ -3126,16 +3096,7 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
                 if( p instanceof MGArray ) {
                     for( i = 0; i < ((MGArray) p).GetNumMGs(); i++ ) {
                         if( Loc[MGLocs[i]] != NoItem ) {
-                            // we know it's not location locked, so kick it out
-                            if( Loc[MGLocs[i]].CanSplit() && Loc[MGLocs[i]].Contiguous() ) {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateAll( Loc[MGLocs[i]], false );
-                            } else {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateByIndex( MGLocs[i], Loc );
-                            }
+                            removed.add( new RemoveEntry( MGLocs[i], i ) );
                         }
                         Loc[MGLocs[i]] = ((MGArray) p).GetMGs()[i];
                     }
@@ -3153,16 +3114,7 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
 
                     // if there is an item there, put it back in the queue
                     if( Loc[SIndex] != NoItem ) {
-                        // put the item back into the queue
-                        if( Loc[SIndex].CanSplit() && Loc[SIndex].Contiguous() ) {
-                            removed.add( Loc[SIndex] );
-                            rears.add( new Boolean( Loc[SIndex].IsMountedRear() ) );
-                            UnallocateAll( Loc[SIndex], false );
-                        } else {
-                            removed.add( Loc[SIndex] );
-                            rears.add( new Boolean( Loc[SIndex].IsMountedRear() ) );
-                            UnallocateByIndex( SIndex, Loc );
-                        }
+                        removed.add( new RemoveEntry( SIndex, SIndex ) );
                     }
 
                     // now allocate the item.
@@ -3177,16 +3129,18 @@ public class QuadLoadout implements ifMechLoadout, ifLoadout {
             }
 
             // now that allocation is finished, add in the removed items if possible
-            for( int i = 0; i < removed.size(); i++ ) {
+            for( RemoveEntry remove : removed ) {
                 // no error handling here since the items are already in the queue
                 try {
-                    Allocate( (abPlaceable) removed.get( i ), -1, Loc );
-                    ((abPlaceable) removed.get( i )).MountRear( ((Boolean) rears.get( i )));
+                    Allocate( remove.p, -1, Loc );
+                    remove.p.MountRear( remove.rear );
+                    remove.p.MountTurret( remove.turret );
                 } catch( Exception e1 ) { }
             }
         } catch ( ArrayIndexOutOfBoundsException e ) {
+            // TODO: Following snapshot thing actually does nothing
             // reset the location
-            Loc = SnapShot;
+            //Loc = SnapShot;
 
             // tell the user what happened.
             if( p instanceof RangedWeapon ) {

--- a/sswlib/src/main/java/components/SponsonTurret.java
+++ b/sswlib/src/main/java/components/SponsonTurret.java
@@ -28,16 +28,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package components;
 
-import common.CommonTools;
 import java.util.ArrayList;
 
 public class SponsonTurret extends abPlaceable {
     private ifCVLoadout Owner;
     private final static AvailableCode AC = new AvailableCode( AvailableCode.TECH_BOTH );
-    private boolean Clan,
-            isTonnageSet;
+    private boolean Clan;
     private ArrayList Items = new ArrayList();
-    private double MaxTonnage = 0;
 
     public SponsonTurret( ifCVLoadout l, boolean clan) {
         AC.SetISCodes( 'B', 'F', 'F', 'F', 'D' );
@@ -96,10 +93,7 @@ public class SponsonTurret extends abPlaceable {
 
     @Override
     public double GetTonnage() {
-        if ( isTonnageSet )
-            return MaxTonnage;
-        else
-            return GetSize();
+        return GetSize();
     }
 
     @Override
@@ -145,9 +139,6 @@ public class SponsonTurret extends abPlaceable {
     private double GetSize() {
         double Build = 0.0;
 
-        if ( isTonnageSet )
-            return MaxTonnage;
-
         if( Items.isEmpty() ) {
             return 0;
         }
@@ -191,22 +182,5 @@ public class SponsonTurret extends abPlaceable {
 
     public ArrayList GetItems() {
         return Items;
-    }
-
-    public void TonnageSet( boolean i ) {
-        isTonnageSet = i;
-        if (!i)
-            MaxTonnage = 0;
-    }
-    public void SetTonnage( double t ) {
-        MaxTonnage = t;
-        isTonnageSet = true;
-    }
-    public boolean isTonnageSet() {
-        return isTonnageSet;
-    }
-
-    public double GetMaxTonnage() {
-        return MaxTonnage;
     }
 }

--- a/sswlib/src/main/java/components/TripodLoadout.java
+++ b/sswlib/src/main/java/components/TripodLoadout.java
@@ -2349,17 +2349,6 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
             if( ((RangedWeapon) p).IsUsingPulseModule() ) {
                 UnallocateAll( ((RangedWeapon) p).GetPulseModule(), true );
             }
-            if( ((RangedWeapon) p).IsTurreted() ) {
-                if( ((RangedWeapon) p).GetTurret() == HDTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( HDTurret );
-                }
-                if( ((RangedWeapon) p).GetTurret() == LTTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( LTTurret );
-                }
-                if( ((RangedWeapon) p).GetTurret() == RTTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( RTTurret );
-                }
-            }
         }
 
         // if the item is an MG Array, check for it's MGs and unallocate
@@ -2367,6 +2356,10 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
             for( int i = 0; i < ((MGArray) p).GetMGs().length; i++ ) {
                 UnallocateAll( ((MGArray) p).GetMGs()[i], true );
             }
+        }
+
+        if( p.IsTurreted() ) {
+            p.MountTurret( null );
         }
 
         Owner.SetChanged( true );
@@ -2467,17 +2460,6 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
             if( ((RangedWeapon) p).IsUsingPulseModule() ) {
                 UnallocateAll( ((RangedWeapon) p).GetPulseModule(), true );
             }
-            if( ((RangedWeapon) p).IsTurreted() ) {
-                if( ((RangedWeapon) p).GetTurret() == HDTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( HDTurret );
-                }
-                if( ((RangedWeapon) p).GetTurret() == LTTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( LTTurret );
-                }
-                if( ((RangedWeapon) p).GetTurret() == RTTurret ) {
-                    ((RangedWeapon) p).RemoveFromTurret( RTTurret );
-                }
-            }
         }
 
         // if the item is an MG Array, check for it's MGs and unallocate
@@ -2485,6 +2467,10 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
             for( int i = 0; i < ((MGArray) p).GetMGs().length; i++ ) {
                 UnallocateAll( ((MGArray) p).GetMGs()[i], true );
             }
+        }
+
+        if( p.IsTurreted() ) {
+            p.MountTurret( null );
         }
 
         Owner.SetChanged( true );
@@ -5125,13 +5111,9 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
 
     private void ClearTurretWeapons( MechTurret t ) {
         for( int i = 0; i < NonCore.size(); i++ ) {
-            if( NonCore.get( i ) instanceof RangedWeapon ) {
-                RangedWeapon w = (RangedWeapon) NonCore.get( i );
-                if( w.IsTurreted() ) {
-                    if( w.GetTurret() == t ) {
-                        w.RemoveFromTurret( t );
-                    }
-                }
+            abPlaceable p = (abPlaceable) NonCore.get( i );
+            if( p.GetTurret() == t ) {
+                p.MountTurret( null );
             }
         }
     }

--- a/sswlib/src/main/java/components/TripodLoadout.java
+++ b/sswlib/src/main/java/components/TripodLoadout.java
@@ -3343,6 +3343,25 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
 
     // Private Methods
     private void Allocate( abPlaceable p, int SIndex, abPlaceable[] Loc ) throws Exception {
+        class RemoveEntry {
+            abPlaceable p;
+            boolean rear;
+            ifTurret turret;
+
+            RemoveEntry( int AddInLoc, int i ) {
+                // we've already ensured that it is not location locked
+                // above, so put the item back into the queue.
+                p = Loc[i];
+                rear = p.IsMountedRear();
+                turret = p.GetTurret();
+                if( p.CanSplit() && p.Contiguous() ) {
+                    UnallocateAll( Loc[i], false );
+                } else {
+                    UnallocateByIndex( AddInLoc, Loc  );
+                }
+            }
+        }
+
         // Adds the specified placeable to the given location at the specified
         // stating index.  Throws Exceptions with error messages if things went
         // wrong.
@@ -3351,14 +3370,15 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
             ((Equipment) p).ValidateMaxPerLocation(Loc);
         }
 
+        // TODO: this snapshot thing doesn't work (see its usage below), commented out for now
         // Let's get a snapshot of the location so we can reset it if we have to.
-        abPlaceable SnapShot[] = Loc.clone();
+        //abPlaceable SnapShot[] = Loc.clone();
 
         // we have to accomodate for Artemis IV systems
         boolean AddIn = false;
         boolean ArrayGood = false;
         int AddInSize = 1;
-        ArrayList removed = new ArrayList(), rears = new ArrayList();
+        ArrayList<RemoveEntry> removed = new ArrayList<>();
 
         // check for generic placement
         if( SIndex == -1 ) {
@@ -3471,17 +3491,7 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
                 for( i = SIndex; i < ( p.NumCrits() + SIndex ); i++ ) {
                     // is there a non-location locked item there?
                     if( Loc[i] != NoItem ) {
-                        // we've already ensured that it is not location locked
-                        // above, so put the item back into the queue.
-                        if( Loc[i].CanSplit() && Loc[i].Contiguous() ) {
-                            removed.add( Loc[i] );
-                            rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                            UnallocateAll( Loc[i], false );
-                        } else {
-                            removed.add( Loc[i] );
-                            rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                            UnallocateByIndex( i, Loc );
-                        }
+                        removed.add( new RemoveEntry( i, i ) );
                     }
                     // finally, allocate the item slot
                     Loc[i] = p;
@@ -3492,17 +3502,7 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
                 if( p instanceof RangedWeapon ) {
                     if( ((RangedWeapon) p).IsUsingFCS() ) {
                         if( Loc[AddInLoc] != NoItem ) {
-                            // we've already ensured that it is not location locked
-                            // above, so put the item back into the queue.
-                            if( Loc[i].CanSplit() && Loc[i].Contiguous() ) {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateAll( Loc[i], false );
-                            } else {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateByIndex( AddInLoc, Loc  );
-                            }
+                            removed.add( new RemoveEntry( AddInLoc, i ) );
                         }
                         for( int j = AddInLoc; j < AddInSize + AddInLoc; j++ ) {
                             Loc[j] = (abPlaceable) ((RangedWeapon) p).GetFCS();
@@ -3510,49 +3510,19 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
                     }
                     if( ((RangedWeapon) p).IsUsingCapacitor() ) {
                         if( Loc[AddInLoc] != NoItem ) {
-                            // we've already ensured that it is not location locked
-                            // above, so put the item back into the queue.
-                            if( Loc[i].CanSplit() && Loc[i].Contiguous() ) {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateAll( Loc[i], false );
-                            } else {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateByIndex( AddInLoc, Loc  );
-                            }
+                            removed.add( new RemoveEntry( AddInLoc, i ) );
                         }
                         Loc[AddInLoc] = ((RangedWeapon) p).GetCapacitor();
                     }
                     if( ((RangedWeapon) p).IsUsingInsulator() ) {
                         if( Loc[AddInLoc] != NoItem ) {
-                            // we've already ensured that it is not location locked
-                            // above, so put the item back into the queue.
-                            if( Loc[i].CanSplit() && Loc[i].Contiguous() ) {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateAll( Loc[i], false );
-                            } else {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateByIndex( AddInLoc, Loc  );
-                            }
+                            removed.add( new RemoveEntry( AddInLoc, i ) );
                         }
                         Loc[AddInLoc] = ((RangedWeapon) p).GetInsulator();
                     }
                     if( ((RangedWeapon) p).IsUsingPulseModule() ) {
                         if( Loc[AddInLoc] != NoItem ) {
-                            // we've already ensured that it is not location locked
-                            // above, so put the item back into the queue.
-                            if( Loc[i].CanSplit() && Loc[i].Contiguous() ) {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateAll( Loc[i], false );
-                            } else {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateByIndex( AddInLoc, Loc  );
-                            }
+                            removed.add( new RemoveEntry( AddInLoc, i ) );
                         }
                         Loc[AddInLoc] = ((RangedWeapon) p).GetPulseModule();
                     }
@@ -3562,16 +3532,7 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
                 if( p instanceof MGArray ) {
                     for( i = 0; i < ((MGArray) p).GetNumMGs(); i++ ) {
                         if( Loc[MGLocs[i]] != NoItem ) {
-                            // we know it's not location locked, so kick it out
-                            if( Loc[MGLocs[i]].CanSplit() && Loc[MGLocs[i]].Contiguous() ) {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateAll( Loc[MGLocs[i]], false );
-                            } else {
-                                removed.add( Loc[i] );
-                                rears.add( new Boolean( Loc[i].IsMountedRear() ) );
-                                UnallocateByIndex( MGLocs[i], Loc );
-                            }
+                            removed.add( new RemoveEntry( MGLocs[i], i ) );
                         }
                         Loc[MGLocs[i]] = ((MGArray) p).GetMGs()[i];
                     }
@@ -3589,16 +3550,7 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
 
                     // if there is an item there, put it back in the queue
                     if( Loc[SIndex] != NoItem ) {
-                        // put the item back into the queue
-                        if( Loc[SIndex].CanSplit() && Loc[SIndex].Contiguous() ) {
-                            removed.add( Loc[SIndex] );
-                            rears.add( new Boolean( Loc[SIndex].IsMountedRear() ) );
-                            UnallocateAll( Loc[SIndex], false );
-                        } else {
-                            removed.add( Loc[SIndex] );
-                            rears.add( new Boolean( Loc[SIndex].IsMountedRear() ) );
-                            UnallocateByIndex( SIndex, Loc );
-                        }
+                        removed.add( new RemoveEntry( SIndex, SIndex ) );
                     }
 
                     // now allocate the item.
@@ -3613,16 +3565,18 @@ public class TripodLoadout implements ifMechLoadout, ifLoadout {
             }
 
             // now that allocation is finished, add in the removed items if possible
-            for( int i = 0; i < removed.size(); i++ ) {
+            for( RemoveEntry remove : removed ) {
                 // no error handling here since the items are already in the queue
                 try {
-                    Allocate( (abPlaceable) removed.get( i ), -1, Loc );
-                    ((abPlaceable) removed.get( i )).MountRear( ((Boolean) rears.get( i )));
+                    Allocate( remove.p, -1, Loc );
+                    remove.p.MountRear( remove.rear );
+                    remove.p.MountTurret( remove.turret );
                 } catch( Exception e1 ) { }
             }
         } catch ( ArrayIndexOutOfBoundsException e ) {
+            // TODO: Following snapshot thing actually does nothing
             // reset the location
-            Loc = SnapShot;
+            //Loc = SnapShot;
 
             // tell the user what happened.
             if( p instanceof RangedWeapon ) {

--- a/sswlib/src/main/java/components/Turret.java
+++ b/sswlib/src/main/java/components/Turret.java
@@ -184,28 +184,29 @@ public class Turret extends abPlaceable {
     public String toString() {
         return CritName();
     }
-    
+
     public void SetItems( ArrayList a ) {
         Items = a;
     }
-    
+
     public ArrayList GetItems() {
         return Items;
     }
-    
-    public void TonnageSet( boolean i ) {
-        isTonnageSet = i;
-        if (!i)
-            MaxTonnage = 0;
+
+    public void UnsetTonnage() {
+        MaxTonnage = 0;
+        isTonnageSet = false;
     }
+
     public void SetTonnage( double t ) {
         MaxTonnage = t;
         isTonnageSet = true;
     }
+
     public boolean isTonnageSet() {
         return isTonnageSet;
     }
-    
+
     public double GetMaxTonnage() {
         return MaxTonnage;
     }

--- a/sswlib/src/main/java/components/Turret.java
+++ b/sswlib/src/main/java/components/Turret.java
@@ -99,12 +99,12 @@ public class Turret extends abPlaceable {
         if ( isTonnageSet )
             return MaxTonnage;
         else 
-            return GetSize();
+            return GetTonnageFromItems();
     }
 
     @Override
     public double GetCost() {
-        return GetSize() * 5000.0;
+        return GetTonnage() * 5000.0;
     }
 
     public double GetOffensiveBV() {
@@ -142,15 +142,12 @@ public class Turret extends abPlaceable {
         return retval;
     }
 
-    private double GetSize() {
-        double Build = 0.0;
-
-        if ( isTonnageSet ) 
-            return MaxTonnage;
-        
+    public double GetTonnageFromItems() {
         if( Items.isEmpty() ) {
             return 0;
         }
+
+        double Build = 0.0;
 
         for( int i = 0; i < Items.size(); i++ ) {
             abPlaceable a = (abPlaceable)Items.get(i);

--- a/sswlib/src/main/java/components/Turret.java
+++ b/sswlib/src/main/java/components/Turret.java
@@ -172,6 +172,14 @@ public class Turret extends abPlaceable {
         return CommonTools.RoundHalfUp( Build * 0.10 );
     }
 
+    public String GetTonnageText() {
+        if( isTonnageSet ) {
+            return String.format( "%.1f/%.1f", GetTonnageFromItems(), GetMaxTonnage() );
+        } else {
+            return String.format( "%.1f", GetTonnage() );
+        }
+    }
+
     @Override
     public boolean CoreComponent() {
         return true;

--- a/sswlib/src/main/java/components/abPlaceable.java
+++ b/sswlib/src/main/java/components/abPlaceable.java
@@ -312,6 +312,17 @@ public abstract class abPlaceable implements Comparable<abPlaceable> {
     // we use other names elsewhere because this can get extremely long.
     public abstract String ActualName();
 
+    // intended for usage within LookupName and CritName
+    protected String NameModifier() {
+        if( IsMountedRear() ) {
+            return "(R) ";
+        } else if( IsTurreted() ) {
+            return "(T) ";
+        } else {
+            return "";
+        }
+    }
+
     // the lookup name is used when we are trying to find the piece of equipment.
     public abstract String LookupName();
 
@@ -327,11 +338,12 @@ public abstract class abPlaceable implements Comparable<abPlaceable> {
     public String PrintName() {
         return CritName();
     }
-    
+
     // the name to be used when expoerting this equipment to a chat line.
     public abstract String ChatName();
 
     // the name to be used when exporting to MegaMek
+    // TODO: UseRear is legacy and unused
     public abstract String MegaMekName( boolean UseRear );
 
     // reference for the book that the equipment comes from 
@@ -382,19 +394,42 @@ public abstract class abPlaceable implements Comparable<abPlaceable> {
     public void ResetPlaced() {
     }
 
-    // tells us whether the item can be mounted to the rear.  Most items cannot,
-    // so this automatically returns false
+    // Tells us whether the item can be mounted to the rear on a mech location.
+    // Most items cannot, so this automatically returns false
+    // (Not used for vehicles, which have their own dedicated rear location.)
     public boolean CanMountRear() {
         return false;
     }
 
-    // This next two methods should be overridden by any component that can be
-    // mounted to the rear.
+    // The next two methods should be overridden by any component that can be
+    // mounted to the rear on a mech location.
+    // (Not used for vehicles, which have their own dedicated rear location.)
     public void MountRear(boolean rear) {
     }
 
     public boolean IsMountedRear() {
         return false;
+    }
+
+    // Tells us whether the item can be mounted to a mech turret.
+    // Defaults to delegating to CanAllocCVTurret.
+    // (Not used for vehicles, which have their own dedicated turret locations.)
+    public boolean CanMountTurret() {
+        return CanAllocCVTurret();
+    }
+
+    // The next two methods should be overridden by any component that can be
+    // mounted to a mech turret.
+    // (Not used for vehicles, which have their own dedicated turret locations.)
+    public void MountTurret(ifTurret turret) {
+    }
+
+    public ifTurret GetTurret() {
+        return null;
+    }
+
+    public boolean IsTurreted() {
+        return GetTurret() != null;
     }
 
     // tells us if this is a core component.  A special list is kept in the

--- a/sswlib/src/main/java/components/ifCVLoadout.java
+++ b/sswlib/src/main/java/components/ifCVLoadout.java
@@ -116,8 +116,8 @@ public interface ifCVLoadout {
     public void SetRightItems( ArrayList<abPlaceable> c );
     public void SetRearItems( ArrayList<abPlaceable> c );
     public void SetBodyItems( ArrayList<abPlaceable> c );
-    public void SetTurret1( ArrayList<abPlaceable> c );
-    public void SetTurret2( ArrayList<abPlaceable> c );
+    public void SetTurret1Items( ArrayList<abPlaceable> c );
+    public void SetTurret2Items( ArrayList<abPlaceable> c );
     public void SetSponsonTurretLeftItems(ArrayList<abPlaceable> c);
     public void SetSponsonTurretRightItems(ArrayList<abPlaceable> c);
     public void SetNonCore( ArrayList v );

--- a/sswlib/src/main/java/components/ifTurret.java
+++ b/sswlib/src/main/java/components/ifTurret.java
@@ -31,10 +31,10 @@ package components;
 import java.util.Vector;
 
 public interface ifTurret {
-    public boolean AddWeapon( ifWeapon w );
-    public void RemoveWeapon( ifWeapon w );
-    public Vector<ifWeapon> GetWeapons();
-    public boolean IsInstalled( ifWeapon w );
+    public boolean AddItem( abPlaceable p );
+    public void RemoveItem( abPlaceable p );
+    public Vector<abPlaceable> GetItems();
+    public boolean IsInstalled( abPlaceable p );
     public double GetTonnage();
     public double GetCost();
 }

--- a/sswlib/src/main/java/filehandlers/CVReader.java
+++ b/sswlib/src/main/java/filehandlers/CVReader.java
@@ -1207,7 +1207,8 @@ public class CVReader {
                 name = FileCommon.LookupStripArc( name );
                 rear = true;
             } else if( name.substring( 0, 4 ).equals( "(T) " ) ) {
-                // turreted items are handled elsewhere, unfortunately.
+                // this is for mech turrets so shouldn't even exist,
+                // but handle it just in case
                 name = FileCommon.LookupStripArc( name );
             }
         }
@@ -1338,6 +1339,7 @@ public class CVReader {
                 retval.MountRear( true );
             }
         } catch( Exception e ) {
+            Messages += e.toString();
             return null;
         }
         return retval;

--- a/sswlib/src/main/java/filehandlers/CVReader.java
+++ b/sswlib/src/main/java/filehandlers/CVReader.java
@@ -416,6 +416,9 @@ public class CVReader {
         if ( omniCombatVehicle && map.getNamedItem("turretlimit") != null ) {
             m.GetLoadout().GetTurret().SetTonnage( Double.parseDouble(map.getNamedItem("turretlimit").getTextContent() ) );
         }
+        if ( omniCombatVehicle && map.getNamedItem("rearturretlimit") != null ) {
+            m.GetLoadout().GetRearTurret().SetTonnage( Double.parseDouble(map.getNamedItem("rearturretlimit").getTextContent() ) );
+        }
         n = n.item( 0 ).getChildNodes();
         LocationIndex ltc = new LocationIndex();
         for( int i = 0; i < n.getLength(); i++ ) {

--- a/sswlib/src/main/java/filehandlers/CVWriter.java
+++ b/sswlib/src/main/java/filehandlers/CVWriter.java
@@ -174,7 +174,14 @@ public class CVWriter {
         if( CurUnit.IsOmni() ) {
             CurUnit.SetCurLoadout( common.Constants.BASELOADOUT_NAME );
         }
-        FR.write( tab + "<baseloadout fcsa4=\"" + FileCommon.GetBoolean( CurUnit.UsingArtemisIV() ) + "\" fcsa5=\"" + FileCommon.GetBoolean( CurUnit.UsingArtemisV() ) + "\" fcsapollo=\"" + FileCommon.GetBoolean( CurUnit.UsingApollo() ) + "\" turretlimit=\"" + CurUnit.GetBaseLoadout().GetTurret().GetMaxTonnage() + "\" >" );
+        FR.write( tab + "<baseloadout fcsa4=\"" + FileCommon.GetBoolean( CurUnit.UsingArtemisIV() ) + "\" fcsa5=\"" + FileCommon.GetBoolean( CurUnit.UsingArtemisV() ) + "\" fcsapollo=\"" + FileCommon.GetBoolean( CurUnit.UsingApollo() ) + "\"");
+        if( CurUnit.GetLoadout().GetTurret().isTonnageSet() ) {
+            FR.write( " turretlimit=\"" + CurUnit.GetLoadout().GetTurret().GetMaxTonnage() + "\"");
+        }
+        if( CurUnit.GetLoadout().GetRearTurret().isTonnageSet() ) {
+            FR.write( " rearturretlimit=\"" + CurUnit.GetLoadout().GetRearTurret().GetMaxTonnage() + "\"" );
+        }
+        FR.write( ">" );
         FR.newLine();
 
         FR.write( tab + tab + "<source>" + FileCommon.EncodeFluff( CurUnit.getSource() ) + "</source>" );

--- a/sswlib/src/main/java/filehandlers/MechReader.java
+++ b/sswlib/src/main/java/filehandlers/MechReader.java
@@ -856,46 +856,34 @@ public class MechReader {
                             }
                             if( turreted ) {
                                 if( l.Location == LocationIndex.MECH_LOC_HD ) {
-                                    if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
+                                    if( p.CanMountTurret() ) {
                                         if( ! m.GetLoadout().HasHDTurret() ) {
-                                            throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
+                                            throw new Exception( "An item was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
                                         }
-                                        if( p instanceof MGArray ) {
-                                            ((MGArray) p).AddToTurret( m.GetLoadout().GetHDTurret() );
-                                        } else {
-                                            ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetHDTurret() );
-                                        }
+                                        p.MountTurret( m.GetLoadout().GetHDTurret() );
                                     } else {
-                                        throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
+                                        throw new Exception( "A non-turret-mountable item was specified as turreted.\nThe 'Mech cannot be loaded." );
                                     }
                                 } else if( l.Location == LocationIndex.MECH_LOC_LT ) {
-                                    if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
+                                    if( p.CanMountTurret() ) {
                                         if( ! m.GetLoadout().HasLTTurret() ) {
-                                            throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
+                                            throw new Exception( "An item was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
                                         }
-                                        if( p instanceof MGArray ) {
-                                            ((MGArray) p).AddToTurret( m.GetLoadout().GetLTTurret() );
-                                        } else {
-                                            ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetLTTurret() );
-                                        }
+                                        p.MountTurret( m.GetLoadout().GetLTTurret() );
                                     } else {
-                                        throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
+                                        throw new Exception( "A non-turret-mountable item was specified as turreted.\nThe 'Mech cannot be loaded." );
                                     }
                                 } else if( l.Location == LocationIndex.MECH_LOC_RT ) {
-                                    if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
+                                    if( p.CanMountTurret() ) {
                                         if( ! m.GetLoadout().HasRTTurret() ) {
-                                            throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
+                                            throw new Exception( "An item was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
                                         }
-                                        if( p instanceof MGArray ) {
-                                            ((MGArray) p).AddToTurret( m.GetLoadout().GetRTTurret() );
-                                        } else {
-                                            ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetRTTurret() );
-                                        }
+                                        p.MountTurret( m.GetLoadout().GetRTTurret() );
                                     } else {
-                                        throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
+                                        throw new Exception( "A non-turret-mountable item was specified as turreted.\nThe 'Mech cannot be loaded." );
                                     }
                                 } else {
-                                    throw new Exception( "A weapon was specified as turreted, but it is\nnot in a location that can have a turret.\nThe 'Mech cannot be loaded." );
+                                    throw new Exception( "A item was specified as turreted, but it is\nnot in a location that can have a turret.\nThe 'Mech cannot be loaded." );
                                 }
                             }
                         }
@@ -1629,43 +1617,31 @@ public class MechReader {
                                     }
                                     if( turreted ) {
                                         if( l.Location == LocationIndex.MECH_LOC_HD ) {
-                                            if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
+                                            if( p.CanMountTurret() ) {
                                                 if( ! m.GetLoadout().HasHDTurret() ) {
-                                                    throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
+                                                    throw new Exception( "An item was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
                                                 }
-                                                if( p instanceof MGArray ) {
-                                                    ((MGArray) p).AddToTurret( m.GetLoadout().GetHDTurret() );
-                                                } else {
-                                                    ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetHDTurret() );
-                                                }
+                                                p.MountTurret( m.GetLoadout().GetHDTurret() );
                                             } else {
-                                                throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
+                                                throw new Exception( "A non-turret-mountable item was specified as turreted.\nThe 'Mech cannot be loaded." );
                                             }
                                         } else if( l.Location == LocationIndex.MECH_LOC_LT ) {
-                                            if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
+                                            if( p.CanMountTurret() ) {
                                                 if( ! m.GetLoadout().HasLTTurret() ) {
-                                                    throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
+                                                    throw new Exception( "An item was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
                                                 }
-                                                if( p instanceof MGArray ) {
-                                                    ((MGArray) p).AddToTurret( m.GetLoadout().GetLTTurret() );
-                                                } else {
-                                                    ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetLTTurret() );
-                                                }
+                                                p.MountTurret( m.GetLoadout().GetLTTurret() );
                                             } else {
-                                                throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
+                                                throw new Exception( "A non-turret-mountable item was specified as turreted.\nThe 'Mech cannot be loaded." );
                                             }
                                         } else if( l.Location == LocationIndex.MECH_LOC_RT ) {
-                                            if( ( p instanceof RangedWeapon ) || ( p instanceof MGArray ) ) {
+                                            if( p.CanMountTurret() ) {
                                                 if( ! m.GetLoadout().HasRTTurret() ) {
-                                                    throw new Exception( "A weapon was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
+                                                    throw new Exception( "An item was specified as turreted but there is no\nturret that it can legally be added to.\nThe 'Mech cannot be loaded." );
                                                 }
-                                                if( p instanceof MGArray ) {
-                                                    ((MGArray) p).AddToTurret( m.GetLoadout().GetRTTurret() );
-                                                } else {
-                                                    ((RangedWeapon) p).AddToTurret( m.GetLoadout().GetRTTurret() );
-                                                }
+                                                p.MountTurret( m.GetLoadout().GetRTTurret() );
                                             } else {
-                                                throw new Exception( "An item that is not a weapon was specified as turreted\nbut only weapons can be turreted.\nThe 'Mech cannot be loaded." );
+                                                throw new Exception( "A non-turret-mountable item was specified as turreted.\nThe 'Mech cannot be loaded." );
                                             }
                                         }
                                     }
@@ -1852,7 +1828,8 @@ public class MechReader {
                 name = FileCommon.LookupStripArc( name );
                 rear = true;
             } else if( name.substring( 0, 4 ).equals( "(T) " ) ) {
-                // turreted items are handled elsewhere, unfortunately.
+                // turreted items are handled elsewhere due to dependency on
+                // separate equipment (the mech turret itself)
                 name = FileCommon.LookupStripArc( name );
             }
         }
@@ -1983,6 +1960,7 @@ public class MechReader {
                 retval.MountRear( true );
             }
         } catch( Exception e ) {
+            Messages += e.toString();
             return null;
         }
         return retval;


### PR DESCRIPTION
Mech turrets:
* Fix quad mechs to allow both torso and head turrets (they're considered different types of mech turrets).
* Revamp mech turret code to fix edge cases and allow equipment.
* Align mech turret/rear-mounting code, both in lib and GUI logic.
* Drag&drop weapon/equipment retains mech turreted status.
* Displaced weapon/equipment (when dragging another equipment onto it, requiring reallocation) also retains mech turreted status.
* Disallow mounting ammo in mech turret. (Technically, I think ammo can be allocated to the turret but shouldn't count for turret tonnage, which functionally should be the same as disallowing turreted ammo.)

Vehicle turrets:
* Add rear turret tonnage to info bar. To help make it fit in the info bar, turret tonnages are hidden if corresponding turret doesn't exist, and reduce width of some boxes there.
* Fix error if removing CV turret and adding item without selecting location.
* Fix regression from b46d085 that inadvertently unset rear turret armor.
* Fix changing from dual turrets to single turret not removing rear turret location.
* Fix regression from 2415ab5 and related omnivehicle code that broke turrets on non-omnivehicles on wide CV GUI. Specifically, omnivehicle code didn't properly unset turret max tonnage when disabled, and the wide CV GUI specifically resets them to 0 even for non-omnivehicles.

Omnivehicle turrets:
* Add turret tonnage limits to info bar, color-coded in same way as total tonnage. 
* Turret tonnage from items now checked against max turret tonnage as part of pre-save/export validation. Also improve this validation error behavior a bit.
* Avoid unsetting turret tonnage for locked chassis (omni variants).
* Fix some weird edge cases by ensuring turret tonnage is kept in sync b/w UI and model.
* Fix omnivehicle rear turret tonnage limit not being saved/loaded.
* Unlocking omni chassis no longer unchecks omni checkbox and zeros out turret tonnages.

Misc omni stuff:
* Fix wide CV UI not resetting omni variant combobox when loading new vehicle.
* Fix lock chassis button getting out of sync with omni checkbox (applies for both omnimechs and omnivees).
* Fix right sponson turret not being propagated to omni variants.
* Remove omnivehicle max tonnage code from sponson turrets since they're unrelated to omnivehicles, and some other internal changes.
