### PR TITLE
Bug Fix: Medium Shield on an omni mech modifies the reported speed for every variant. #322

### DIFF
--- a/Data/Equipment/physicals.json
+++ b/Data/Equipment/physicals.json
@@ -1281,7 +1281,8 @@
       "IntMult": 0,
       "CanJump": true,
       "BVMovement": true,
-      "BVHeatMod": false
+      "BVHeatMod": false,
+	  "ConfigOnly": true
     }
   },
   "Large Shield": {


### PR DESCRIPTION
Updated the Medium Shield JSON to include ConfigOnly field for the Modifiers. This should probably be done with all the equipment to allow them to behave correctly for Omni Mechs.